### PR TITLE
Add production automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      rust:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,198 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions: {}
+
+jobs:
+  lint:
+    name: Lint, docs, and validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          components: clippy
+      - name: Install nightly rustfmt
+        run: rustup toolchain install nightly --component rustfmt
+      - name: Install beta clippy
+        run: rustup toolchain install beta --component clippy
+      - name: Install just
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: just
+      - name: Install typos
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: typos-cli@1.47.2
+      - name: Install markdownlint-cli2
+        run: npm install --global markdownlint-cli2@0.22.1
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Check formatting
+        run: just fmt-check
+      - name: Check clippy
+        run: just clippy
+      - name: Check beta clippy
+        run: just clippy-beta
+      - name: Check documentation builds
+        run: just doc
+      - name: Run doc tests
+        run: just doc-test
+      - name: Lint Markdown
+        run: just lint-md
+      - name: Check spelling
+        run: just typos
+
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - name: Install just
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: just
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Check workspace
+        run: just check
+      - name: Test workspace
+        run: just test
+
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - name: Install just
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: just
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Package crates
+        run: just package
+
+  dependencies:
+    name: Dependency check (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: policy
+            tools: cargo-deny
+            command: just dependency-policy
+          - name: features
+            tools: cargo-hack
+            command: just feature-check
+          - name: minimal versions
+            tools: cargo-minimal-versions,cargo-hack
+            command: just minimal-versions
+          - name: semver
+            tools: cargo-semver-checks
+            command: just semver-checks
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - name: Install just
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: just
+      - name: Install cargo maintenance tools
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: ${{ matrix.tools }}
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Run dependency check
+        run: ${{ matrix.command }}
+
+  zizmor:
+    name: GitHub Actions security
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+
+  required:
+    name: Required
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - test
+      - package
+      - dependencies
+      - zizmor
+    if: ${{ always() }}
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+          HAS_FAILED_JOB: >-
+            ${{
+              contains(needs.*.result, 'failure')
+              || contains(needs.*.result, 'cancelled')
+              || contains(needs.*.result, 'skipped')
+            }}
+        run: |
+          echo "$NEEDS_JSON"
+          test "$HAS_FAILED_JOB" = "false"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze Rust
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: rust
+          build-mode: none
+          queries: +security-extended
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,72 @@
+name: Release-plz
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    environment: release
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.repository_owner == 'ratatui' &&
+        (
+          github.event_name == 'workflow_dispatch' ||
+          startsWith(github.event.head_commit.message, 'chore: release') ||
+          contains(github.event.head_commit.message, '): release')
+        )
+      }}
+    permissions:
+      contents: write
+      pull-requests: read
+      id-token: write
+    steps:
+      - &checkout
+        name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - &install-rust
+        name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - name: Run release-plz
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.repository_owner == 'ratatui' &&
+        github.event_name == 'push' &&
+        !startsWith(github.event.head_commit.message, 'chore: release') &&
+        !contains(github.event.head_commit.message, '): release')
+      }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - *checkout
+      - *install-rust
+      - name: Run release-plz
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Release entries are managed by release-plz.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,11 +1060,11 @@ dependencies = [
 
 [[package]]
 name = "ratatui-action"
-version = "0.0.0"
+version = "0.1.0"
 
 [[package]]
 name = "ratatui-command-palette"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "crossterm",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-labs"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "ratatui-action",
  "ratatui-command-palette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,9 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-repository = "https://github.com/ratatui/ratatui"
+repository = "https://github.com/ratatui/ratatui-labs"
 homepage = "https://ratatui.rs"
+rust-version = "1.88.0"
 keywords = ["ratatui", "tui", "terminal", "ui"]
 categories = ["command-line-interface"]
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest released version of each crate is supported for security fixes.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities privately through GitHub Security Advisories for this
+repository. Do not open a public issue for a vulnerability that has not been disclosed.
+
+Include the affected crate, version, impact, reproduction steps, and any suggested fix. We will
+acknowledge reports as soon as practical and coordinate disclosure once a fix is available.

--- a/crates/ratatui-action/Cargo.toml
+++ b/crates/ratatui-action/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "ratatui-action"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "Experimental semantic action model for Ratatui applications."

--- a/crates/ratatui-command-palette/Cargo.toml
+++ b/crates/ratatui-command-palette/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "ratatui-command-palette"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "Experimental command palette state and rendering for Ratatui applications."
@@ -19,7 +20,7 @@ future_scope = "command palette state, filtering, preview, invocation, and rende
 [dependencies]
 crossterm = { version = "0.29.0", optional = true }
 ratatui = "0.30.2"
-ratatui-action = { path = "../ratatui-action", version = "0.0.0" }
+ratatui-action = { path = "../ratatui-action", version = "0.1.0" }
 
 [dev-dependencies]
 clap = { version = "4.5.47", features = ["derive"] }

--- a/crates/ratatui-labs/Cargo.toml
+++ b/crates/ratatui-labs/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "ratatui-labs"
-version = "0.0.0"
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "Reserved for Ratatui labs-style experiments and prototype Ratatui work."
@@ -17,8 +18,8 @@ area = "Experimental APIs"
 future_scope = "labs-style experiments and prototype Ratatui work"
 
 [dependencies]
-ratatui-action = { path = "../ratatui-action", version = "0.0.0" }
-ratatui-command-palette = { path = "../ratatui-command-palette", version = "0.0.0" }
+ratatui-action = { path = "../ratatui-action", version = "0.1.0" }
+ratatui-command-palette = { path = "../ratatui-command-palette", version = "0.1.0" }
 
 [lints]
 workspace = true

--- a/crates/ratatui-labs/README.md
+++ b/crates/ratatui-labs/README.md
@@ -56,7 +56,7 @@ just betamax
 The crate points at the main Ratatui project rather than a separate
 implementation repository:
 
-- <https://github.com/ratatui/ratatui>
+- <https://github.com/ratatui/ratatui-labs>
 - <https://docs.rs/ratatui/latest/ratatui/>
 
 Documentation for this reservation crate is published at:

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,21 @@
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "Unicode-3.0",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/justfile
+++ b/justfile
@@ -1,4 +1,7 @@
-set shell := ["sh", "-cu"]
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+default:
+    @just --list
 
 fmt:
     cargo +nightly fmt --all
@@ -7,28 +10,66 @@ fmt-check:
     cargo +nightly fmt --all -- --check
 
 check:
-    cargo check --workspace --all-targets
+    cargo check --workspace --all-targets --all-features
 
 clippy:
-    cargo clippy --workspace --all-targets -- -D warnings
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+clippy-beta:
+    cargo +beta clippy --workspace --all-targets --all-features -- -D warnings
 
 test:
-    cargo test --workspace
+    cargo test --workspace --all-targets --all-features
+
+doc:
+    cargo doc --workspace --all-features --no-deps
+
+doc-test:
+    cargo test --workspace --doc --all-features
+
+package:
+    cargo package --workspace --allow-dirty
+
+dependency-policy:
+    cargo deny check advisories licenses bans sources
+
+feature-check:
+    cargo hack check --workspace --lib --tests --feature-powerset
+
+minimal-versions:
+    cargo minimal-versions check --direct --workspace
+    cargo update --workspace
+
+semver-checks:
+    cargo semver-checks --workspace
+
+typos:
+    typos
 
 lint-md:
     markdownlint-cli2 README.md AGENTS.md 'docs/**/*.md' 'crates/**/*.md'
 
-validate: fmt-check check clippy test lint-md
+validate: fmt-check check clippy test doc doc-test lint-md
 
 betamax tape="":
     mkdir -p target/betamax/renderers
-    cargo build --manifest-path ../../betamax/Cargo.toml
+    betamax="${BETAMAX_BIN:-}"; \
+    if [ -z "$betamax" ]; then \
+        if [ -x ../../betamax/target/debug/betamax ]; then \
+            betamax="../../betamax/target/debug/betamax"; \
+        else \
+            cargo build --manifest-path ../../betamax/Cargo.toml; \
+            betamax="../../betamax/target/debug/betamax"; \
+        fi; \
+    fi; \
     tapes="{{tape}}"; \
     if [ -n "$tapes" ]; then \
         test -f "$tapes" || { echo "missing Betamax tape: $tapes" >&2; exit 1; }; \
-        ../../betamax/target/debug/betamax run "$tapes"; \
+        REPO_DIR="$PWD" "$betamax" run "$tapes"; \
     else \
         jobs="${BETAMAX_JOBS:-4}"; \
         find tapes -name '*.tape' | sort | xargs -P "$jobs" -I{} \
-            sh -c '../../betamax/target/debug/betamax run "$1"' sh {}; \
+            bash -euo pipefail -c 'REPO_DIR="$PWD" "$0" run "$1"' "$betamax" {}; \
     fi
+
+release-check: validate dependency-policy feature-check minimal-versions semver-checks package betamax

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,8 @@
+[workspace]
+changelog_path = "./CHANGELOG.md"
+release_always = false
+semver_check = true
+
+git_release_body = """
+{{ changelog | replace(from=" by @", to=" by ") }}
+"""

--- a/tapes/command-palette.tape
+++ b/tapes/command-palette.tape
@@ -5,7 +5,6 @@ Output target/betamax/command-palette.json
 Require cargo
 
 Set Shell "bash"
-Set Theme "GitHub Dark"
 Set Width 1200
 Set Height 620
 Set WindowBar Colorful
@@ -15,7 +14,7 @@ Set CursorBlink false
 Set WaitTimeout 30s
 
 Hide
-Type "cd /Users/joshka/local/ratatui-labs/default"
+Type "cd \"$REPO_DIR\""
 Enter
 Wait
 Type "cargo build --quiet -p ratatui-command-palette --example command-palette && printf 'built-command-palette\n'"

--- a/tapes/renderers/flat.tape
+++ b/tapes/renderers/flat.tape
@@ -5,7 +5,6 @@ Output target/betamax/renderers/flat.json
 Require cargo
 
 Set Shell "bash"
-Set Theme "GitHub Dark"
 Set Width 1200
 Set Height 620
 Set WindowBar Colorful
@@ -15,7 +14,7 @@ Set CursorBlink false
 Set WaitTimeout 30s
 
 Hide
-Type "cd /Users/joshka/local/ratatui-labs/default"
+Type "cd \"$REPO_DIR\""
 Enter
 Wait
 Type "cargo run --quiet -p ratatui-command-palette --example command-palette -- --renderer flat"

--- a/tapes/renderers/fullscreen.tape
+++ b/tapes/renderers/fullscreen.tape
@@ -5,7 +5,6 @@ Output target/betamax/renderers/fullscreen.json
 Require cargo
 
 Set Shell "bash"
-Set Theme "GitHub Dark"
 Set Width 1200
 Set Height 620
 Set WindowBar Colorful
@@ -15,7 +14,7 @@ Set CursorBlink false
 Set WaitTimeout 30s
 
 Hide
-Type "cd /Users/joshka/local/ratatui-labs/default"
+Type "cd \"$REPO_DIR\""
 Enter
 Wait
 Type "cargo run --quiet -p ratatui-command-palette --example command-palette -- --renderer fullscreen"

--- a/tapes/renderers/inline.tape
+++ b/tapes/renderers/inline.tape
@@ -5,7 +5,6 @@ Output target/betamax/renderers/inline.json
 Require cargo
 
 Set Shell "bash"
-Set Theme "GitHub Dark"
 Set Width 1200
 Set Height 620
 Set WindowBar Colorful
@@ -15,7 +14,7 @@ Set CursorBlink false
 Set WaitTimeout 30s
 
 Hide
-Type "cd /Users/joshka/local/ratatui-labs/default"
+Type "cd \"$REPO_DIR\""
 Enter
 Wait
 Type "cargo run --quiet -p ratatui-command-palette --example command-palette -- --renderer inline"

--- a/tapes/renderers/modal.tape
+++ b/tapes/renderers/modal.tape
@@ -5,7 +5,6 @@ Output target/betamax/renderers/modal.json
 Require cargo
 
 Set Shell "bash"
-Set Theme "GitHub Dark"
 Set Width 1200
 Set Height 620
 Set WindowBar Colorful
@@ -15,7 +14,7 @@ Set CursorBlink false
 Set WaitTimeout 30s
 
 Hide
-Type "cd /Users/joshka/local/ratatui-labs/default"
+Type "cd \"$REPO_DIR\""
 Enter
 Wait
 Type "cargo run --quiet -p ratatui-command-palette --example command-palette -- --renderer modal"

--- a/tapes/renderers/split.tape
+++ b/tapes/renderers/split.tape
@@ -5,7 +5,6 @@ Output target/betamax/renderers/split.json
 Require cargo
 
 Set Shell "bash"
-Set Theme "GitHub Dark"
 Set Width 1200
 Set Height 620
 Set WindowBar Colorful
@@ -15,7 +14,7 @@ Set CursorBlink false
 Set WaitTimeout 30s
 
 Hide
-Type "cd /Users/joshka/local/ratatui-labs/default"
+Type "cd \"$REPO_DIR\""
 Enter
 Wait
 Type "cargo run --quiet -p ratatui-command-palette --example command-palette -- --renderer split"

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,8 @@
+[files]
+extend-exclude = [
+    "**/CHANGELOG.md",
+    "target/**",
+]
+
+[default.extend-words]
+ratatui = "ratatui"


### PR DESCRIPTION
## Summary

- add production CI around `just` tasks, including formatting, clippy, docs, tests, packaging, Betamax tapes, dependency policy, feature checks, minimal versions, semver checks, typos, and zizmor
- add CodeQL, Dependabot, cargo-deny, release-plz, changelog, typo config, and security policy files
- prepare publishable crate metadata for the initial `0.1.0` labs crate releases

## Validation

- `just release-check`
- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/release-plz.yml`
- `zizmor .github/workflows`
- temp Git clone: `GIT_TOKEN=$(gh auth token) release-plz release --dry-run --allow-dirty --config release-plz.toml -o json`
