### PR TITLE
Re-enable Betamax CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,35 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
 
+  betamax:
+    name: Betamax tapes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+      - name: Install just
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: just
+      - name: Install Betamax
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: betamax@0.1.12
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Run Betamax tapes
+        env:
+          BETAMAX_JOBS: 1
+        run: just betamax
+
   required:
     name: Required
     runs-on: ubuntu-latest
@@ -182,6 +211,7 @@ jobs:
       - package
       - dependencies
       - zizmor
+      - betamax
     if: ${{ always() }}
     steps:
       - name: Check required jobs

--- a/justfile
+++ b/justfile
@@ -55,7 +55,9 @@ betamax tape="":
     mkdir -p target/betamax/renderers
     betamax="${BETAMAX_BIN:-}"; \
     if [ -z "$betamax" ]; then \
-        if [ -x ../../betamax/target/debug/betamax ]; then \
+        if command -v betamax >/dev/null 2>&1; then \
+            betamax="betamax"; \
+        elif [ -x ../../betamax/target/debug/betamax ]; then \
             betamax="../../betamax/target/debug/betamax"; \
         else \
             cargo build --manifest-path ../../betamax/Cargo.toml; \


### PR DESCRIPTION
## Summary

- re-enable the Betamax tape job in CI
- install `betamax@0.1.12` with `taiki-e/install-action`
- include Betamax in the aggregate `Required` check

## Validation

- `BETAMAX_BIN=/tmp/betamax-0.1.12/bin/betamax BETAMAX_JOBS=4 just betamax`
- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/release-plz.yml`
- `zizmor .github/workflows`
