### PR TITLE
Import ratatui-layout crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +113,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +159,9 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -219,6 +252,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +295,7 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "serde",
  "static_assertions",
 ]
 
@@ -378,6 +439,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +492,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -536,6 +613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +657,12 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indoc"
@@ -747,6 +836,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +915,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +943,12 @@ checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "palette"
@@ -998,6 +1111,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1235,21 @@ version = "0.1.0"
 dependencies = [
  "ratatui-action",
  "ratatui-command-palette",
+ "ratatui-core",
+ "ratatui-layout",
+]
+
+[[package]]
+name = "ratatui-layout"
+version = "0.0.1-alpha.0"
+dependencies = [
+ "color-eyre",
+ "crossterm",
+ "document-features",
+ "pretty_assertions",
+ "ratatui",
+ "ratatui-core",
+ "serde",
 ]
 
 [[package]]
@@ -1204,6 +1342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1432,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1511,6 +1664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,6 +1692,47 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
 
 [[package]]
 name = "typenum"
@@ -1589,6 +1792,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -1779,3 +1988,9 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ grow into real experiments when there is a concrete design to test.
   invocation requests.
 - `crates/ratatui-command-palette` - experimental command palette state, rendering, preview, and
   invocation behavior.
+- `crates/ratatui-layout` - experimental frame-local UI coordination primitives for visible
+  regions, focus targets, pointer targets, cursor requests, and scroll metadata.
 - `crates/ratatui-labs` - umbrella crate for labs-style experiments and prototype Ratatui work.
 
 ## Examples
@@ -20,6 +22,8 @@ grow into real experiments when there is a concrete design to test.
 cargo run -p ratatui-command-palette --example command-palette
 cargo run -p ratatui-command-palette --example command-palette -- --help
 cargo run -p ratatui-command-palette --example command-palette -- --renderer split
+cargo run -p ratatui-layout --example left_right_row
+cargo run -p ratatui-layout --example frame_snapshot
 ```
 
 ## Docs

--- a/crates/ratatui-labs/Cargo.toml
+++ b/crates/ratatui-labs/Cargo.toml
@@ -18,8 +18,10 @@ area = "Experimental APIs"
 future_scope = "labs-style experiments and prototype Ratatui work"
 
 [dependencies]
+ratatui-core = "0.1.2"
 ratatui-action = { path = "../ratatui-action", version = "0.1.0" }
 ratatui-command-palette = { path = "../ratatui-command-palette", version = "0.1.0" }
+ratatui-layout = { path = "../ratatui-layout", version = "0.0.1-alpha.0" }
 
 [lints]
 workspace = true

--- a/crates/ratatui-labs/README.md
+++ b/crates/ratatui-labs/README.md
@@ -53,6 +53,29 @@ Rendered validation for this example is captured by the repository Betamax tape:
 just betamax
 ```
 
+## Layout Experiment
+
+The frame-local layout coordination experiment lives in `ratatui-layout`.
+It records visible regions, focus targets, pointer targets, cursor requests,
+viewport metadata, and scroll metrics produced by a render pass so applications
+can route later input events without adopting a retained widget tree.
+
+Start with `ratatui_layout::docs` when exploring the coordination model, or use
+the umbrella re-export:
+
+```rust
+use ratatui_labs::layout::{
+    frame::FrameSnapshot,
+    pointer::{PointerTarget, PointerTargets},
+};
+use ratatui_core::layout::Rect;
+
+let frame = FrameSnapshot::new(Rect::new(0, 0, 20, 1))
+    .mouse(PointerTargets::new().target(PointerTarget::new("save", Rect::new(0, 0, 6, 1))));
+
+assert_eq!(frame.route_position((2, 0)).unwrap().id, "save");
+```
+
 The crate points at the main Ratatui project rather than a separate
 implementation repository:
 
@@ -69,6 +92,7 @@ This reservation may overlap with:
 
 - `ratatui-unstable`, `ratatui-experimental`, and future unstable API policy.
 - the experimental `ratatui-action` and `ratatui-command-palette` crates in this workspace.
+- the experimental `ratatui-layout` crate in this workspace.
 
 Any future implementation should coordinate with those crates or clearly explain
 the difference before publishing a non-reservation release.

--- a/crates/ratatui-labs/src/lib.rs
+++ b/crates/ratatui-labs/src/lib.rs
@@ -5,3 +5,5 @@
 pub use ratatui_action as action;
 /// Command palette state, view data, and rendering.
 pub use ratatui_command_palette as command_palette;
+/// Frame-local UI coordination primitives.
+pub use ratatui_layout as layout;

--- a/crates/ratatui-layout/Cargo.toml
+++ b/crates/ratatui-layout/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "ratatui-layout"
+version = "0.0.1-alpha.0"
+description = "Extremely experimental frame-local UI coordination primitives for Ratatui."
+documentation = "https://docs.rs/ratatui-layout"
+readme = "README.md"
+# Published once at 0.0.1-alpha.0 to reserve the crate name while this experiment incubates.
+publish = false
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+include = ["Cargo.toml", "README.md", "examples/**/*.rs", "src/**/*.rs", "use-cases/**/*.md"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = []
+
+## enables std
+std = ["ratatui-core/std", "serde?/std"]
+
+## enables serialization and deserialization for region set types.
+serde = ["dep:serde", "ratatui-core/serde"]
+
+[dependencies]
+document-features = { version = "0.2.11", optional = true }
+ratatui-core = "0.1.2"
+serde = { version = "1", default-features = false, features = ["derive"], optional = true }
+
+[dev-dependencies]
+color-eyre = "0.6"
+crossterm = "0.29.0"
+pretty_assertions = "1"
+ratatui = "0.30.2"
+
+[lints]
+workspace = true

--- a/crates/ratatui-layout/README.md
+++ b/crates/ratatui-layout/README.md
@@ -1,0 +1,67 @@
+# ratatui-layout
+
+`ratatui-layout` is a `0.0.1-alpha.0` experiment for frame-local UI coordination in Ratatui.
+
+This crate is extremely experimental. It exists to test ideas, examples, and API pressure around
+immediate-mode UI coordination. Expect names, module boundaries, responsibilities, and maybe the
+crate shape itself to change substantially; the properly baked version is likely to look different
+from this alpha.
+
+The crate keeps Ratatui immediate-mode: apps still render inside `Terminal::draw`, and ordinary
+widgets still draw into `Rect` and `Buffer`. The added layer is optional data produced by a render
+pass: visible regions, focus targets, pointer targets, selection state, cursor requests, viewport
+metadata, and scroll metrics.
+
+Rustdoc is the main guide. Start with `ratatui_layout::docs` for the coordination model, the normal
+Ratatui alternatives, and the current API boundaries.
+
+For product and API validation, see [`use-cases/`](use-cases/). Those notes describe the app shapes
+used to check whether a proposed helper removes real coordination work.
+
+## Examples
+
+Layout and composition:
+
+```bash
+cargo run -p ratatui-layout --example left_right_row
+cargo run -p ratatui-layout --example external_participants
+cargo run -p ratatui-layout --example modal_prompt
+cargo run -p ratatui-layout --example modal_shell
+cargo run -p ratatui-layout --example container_dialog
+cargo run -p ratatui-layout --example component_frames
+```
+
+Interaction coordination:
+
+```bash
+cargo run -p ratatui-layout --example pointer_targets
+cargo run -p ratatui-layout --example focus_traversal
+cargo run -p ratatui-layout --example selection_modes
+cargo run -p ratatui-layout --example pointer_only_scroll_region
+cargo run -p ratatui-layout --example scroll_regions
+cargo run -p ratatui-layout --example cursor_request
+cargo run -p ratatui-layout --example toolbar_targets
+cargo run -p ratatui-layout --example action_surface
+cargo run -p ratatui-layout --example form_dialog
+cargo run -p ratatui-layout --example profile_editor
+cargo run -p ratatui-layout --example text_input
+cargo run -p ratatui-layout --example grid_palette
+cargo run -p ratatui-layout --example frame_snapshot
+cargo run -p ratatui-layout --example visible_selection_filter
+```
+
+Virtualization and scroll metadata:
+
+```bash
+cargo run -p ratatui-layout --example viewport
+cargo run -p ratatui-layout --example scrollable_pane
+cargo run -p ratatui-layout --example virtual_list
+cargo run -p ratatui-layout --example visible_selection_virtual_list
+cargo run -p ratatui-layout --example virtual_record_list
+cargo run -p ratatui-layout --example table_inspector
+cargo run -p ratatui-layout --example tree_browser
+```
+
+Use normal Ratatui `Layout` directly when solved rectangles are consumed immediately. Use this crate
+when visible regions or interaction data need to be stored, inspected, merged, clipped, or used to
+route the next input event.

--- a/crates/ratatui-layout/examples/action_surface.rs
+++ b/crates/ratatui-layout/examples/action_surface.rs
@@ -1,0 +1,198 @@
+//! Render a command row from one action description.
+//!
+//! A toolbar, button row, tab bar, and horizontal menu all need the same coordination: solve named
+//! action regions, draw labels into those regions, skip disabled actions for input, and route
+//! clicks back to command ids. `CommandRow` keeps the local left/right focus state while
+//! `ActionSurface` creates frame-local regions and targets.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::action::CommandRow;
+use ratatui_layout::frame::FrameSnapshot;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+fn run() -> Result<()> {
+    let mut app = App::new();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    dirty: bool,
+    selected: Command,
+    row: CommandRow<Command>,
+    previous_frame: FrameSnapshot<Command>,
+}
+
+impl App {
+    fn new() -> Self {
+        let row = CommandRow::new(Command::slots())
+            .spacing(1)
+            .flex(Flex::Center);
+        Self {
+            dirty: false,
+            selected: Command::Open,
+            row,
+            previous_frame: FrameSnapshot::new(Rect::default()),
+        }
+    }
+
+    fn render(&mut self, frame: &mut Frame) {
+        let area = centered(frame.area(), 42, 5);
+        let row_area = area.inner(ratatui::layout::Margin {
+            horizontal: 2,
+            vertical: 2,
+        });
+        let layout = self
+            .row
+            .layout_with(row_area, |command| !self.is_enabled(command));
+
+        frame.render_widget(
+            Block::new().borders(Borders::ALL).title("action surface"),
+            area,
+        );
+        for region in layout.regions().regions() {
+            self.render_command(frame, region.id, region.area);
+        }
+
+        self.previous_frame = layout.into_frame();
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Char('d') => self.dirty = !self.dirty,
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Tab => {
+                let dirty = self.dirty;
+                self.row
+                    .move_next_enabled(|command| !is_enabled(command, dirty));
+            }
+            KeyCode::Char('h') | KeyCode::Left | KeyCode::BackTab => {
+                let dirty = self.dirty;
+                self.row
+                    .move_previous_enabled(|command| !is_enabled(command, dirty));
+            }
+            KeyCode::Char(' ') | KeyCode::Enter => self.activate_focused(),
+            _ => {}
+        }
+        true
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        if !matches!(mouse.kind, MouseEventKind::Down(_)) {
+            return;
+        }
+        if let Some(hit) = self.previous_frame.route_click((mouse.column, mouse.row)) {
+            self.row.focus_id(hit.id);
+            self.activate(hit.id);
+        }
+    }
+
+    fn activate_focused(&mut self) {
+        if let Some(command) = self.row.focused_id() {
+            self.activate(command);
+        }
+    }
+
+    fn activate(&mut self, command: Command) {
+        if !self.is_enabled(command) {
+            return;
+        }
+        self.selected = command;
+        if command == Command::Open {
+            self.dirty = true;
+        }
+        if command == Command::Save {
+            self.dirty = false;
+        }
+    }
+
+    fn is_enabled(&self, command: Command) -> bool {
+        is_enabled(command, self.dirty)
+    }
+
+    fn render_command(&self, frame: &mut Frame, command: Command, area: Rect) {
+        let focused = self.row.focused_id() == Some(command);
+        let style = if !self.is_enabled(command) {
+            Style::new().fg(Color::DarkGray)
+        } else if focused {
+            Style::new()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else if self.selected == command {
+            Style::new().fg(Color::Black).bg(Color::Green)
+        } else {
+            Style::new().fg(Color::White).bg(Color::DarkGray)
+        };
+        frame.render_widget(
+            Paragraph::new(command.label()).centered().style(style),
+            area,
+        );
+    }
+}
+
+fn is_enabled(command: Command, dirty: bool) -> bool {
+    command != Command::Save || dirty
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Command {
+    Open,
+    Save,
+    Close,
+}
+
+impl Command {
+    const fn slots() -> [(Self, Constraint); 3] {
+        [
+            (Self::Open, Constraint::Length(10)),
+            (Self::Save, Constraint::Length(10)),
+            (Self::Close, Constraint::Length(10)),
+        ]
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Save => "save",
+            Self::Close => "close",
+        }
+    }
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/component_frames.rs
+++ b/crates/ratatui-layout/examples/component_frames.rs
@@ -1,0 +1,468 @@
+//! Compose child-local frame snapshots without introducing a component trait.
+//!
+//! This example sits between the tiny `frame_snapshot` example and the larger workspace inspector.
+//! Each pane renders ordinary Ratatui widgets, returns a `FrameSnapshot` with local ids and
+//! coordinates, and lets `App` map, translate, clip, and merge that data into one previous-frame
+//! snapshot.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Position, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+use ratatui_layout::focus::{FocusFallback, FocusState};
+use ratatui_layout::frame::{FrameSnapshot, FrameTargets};
+use ratatui_layout::regions::{Region, Regions};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+fn run() -> Result<()> {
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    previous_frame: FrameSnapshot<Target>,
+    focus: FocusState<Target>,
+    project: ProjectPane,
+    details: DetailsPane,
+    command: CommandInput,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            previous_frame: FrameSnapshot::new(Rect::default()),
+            focus: FocusState::default(),
+            project: ProjectPane::default(),
+            details: DetailsPane::default(),
+            command: CommandInput::default(),
+        }
+    }
+}
+
+impl App {
+    /// Renders each child in its screen area, then stores one merged frame snapshot for input
+    /// routing.
+    fn render(&mut self, frame: &mut Frame) {
+        let page = PageAreas::new(frame.area());
+        let project_focus = self.focus.focused().and_then(Target::project);
+        let details_focus = self.focus.focused().and_then(Target::details);
+        let command_focus = self.focus.focused().and_then(Target::command);
+
+        let project = self
+            .project
+            .render(frame, page.project, project_focus)
+            .map_id(Target::Project);
+        let details = self
+            .details
+            .render(
+                frame,
+                page.details,
+                self.project.selected_name(),
+                details_focus,
+            )
+            .map_id(Target::Details);
+        let command = self
+            .command
+            .render(frame, page.command, command_focus)
+            .map_id(Target::Command);
+
+        let frame_snapshot = FrameSnapshot::new(frame.area())
+            .place_child(project, page.project)
+            .place_child(details, page.details)
+            .place_child(command, page.command);
+
+        self.focus
+            .ensure_visible(&frame_snapshot.focus, FocusFallback::First);
+        if let Some(cursor) = frame_snapshot.cursor.final_cursor() {
+            frame.set_cursor_position(cursor.position);
+        }
+        self.previous_frame = frame_snapshot;
+    }
+
+    /// Routes keys through the currently focused app-level target.
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Char('j') | KeyCode::Down => self.move_focused(1),
+            KeyCode::Char('k') | KeyCode::Up => self.move_focused(-1),
+            KeyCode::Char('/') => self
+                .focus
+                .focus(Some(Target::Command(CommandTarget::Input))),
+            KeyCode::Tab => self.focus.next(&self.previous_frame.focus),
+            KeyCode::BackTab => self.focus.previous(&self.previous_frame.focus),
+            KeyCode::Char(ch) => self.handle_character(ch),
+            KeyCode::Backspace => self.handle_backspace(),
+            _ => {}
+        }
+        true
+    }
+
+    /// Routes pointer events through the frame-local data produced by the previous render.
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        let position = (mouse.column, mouse.row);
+        match mouse.kind {
+            MouseEventKind::Down(_) => self.click(position),
+            MouseEventKind::ScrollDown => self.scroll(position, 1),
+            MouseEventKind::ScrollUp => self.scroll(position, -1),
+            _ => {}
+        }
+    }
+
+    fn click(&mut self, position: (u16, u16)) {
+        let Some(hit) = self.previous_frame.route_click(position) else {
+            return;
+        };
+        self.focus.focus(Some(hit.id));
+        if let Target::Project(ProjectTarget::Row(index)) = hit.id {
+            self.project.select(index);
+            self.details.reset();
+        }
+    }
+
+    fn scroll(&mut self, position: (u16, u16), delta: isize) {
+        if matches!(
+            self.previous_frame.route_scroll(position).map(|hit| hit.id),
+            Some(Target::Details(DetailsTarget::Pane))
+        ) {
+            self.details.scroll(self.project.selected_name(), delta);
+        }
+    }
+
+    fn handle_character(&mut self, ch: char) {
+        if self.focus.focused() == Some(Target::Command(CommandTarget::Input)) {
+            self.command.push(ch);
+        }
+    }
+
+    fn handle_backspace(&mut self) {
+        if self.focus.focused() == Some(Target::Command(CommandTarget::Input)) {
+            self.command.pop();
+        }
+    }
+
+    fn move_focused(&mut self, delta: isize) {
+        match self.focus.focused() {
+            Some(Target::Project(_)) => {
+                self.project.select_relative(delta);
+                self.details.reset();
+            }
+            Some(Target::Details(DetailsTarget::Pane)) => {
+                self.details.scroll(self.project.selected_name(), delta);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PageAreas {
+    project: Rect,
+    details: Rect,
+    command: Rect,
+}
+
+impl PageAreas {
+    fn new(area: Rect) -> Self {
+        let [body, command] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(area);
+        let [project, details] =
+            Layout::horizontal([Constraint::Length(24), Constraint::Fill(1)]).areas(body);
+        Self {
+            project,
+            details,
+            command,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Target {
+    Project(ProjectTarget),
+    Details(DetailsTarget),
+    Command(CommandTarget),
+}
+
+impl Target {
+    const fn project(self) -> Option<ProjectTarget> {
+        match self {
+            Self::Project(target) => Some(target),
+            Self::Details(_) | Self::Command(_) => None,
+        }
+    }
+
+    const fn details(self) -> Option<DetailsTarget> {
+        match self {
+            Self::Details(target) => Some(target),
+            Self::Project(_) | Self::Command(_) => None,
+        }
+    }
+
+    const fn command(self) -> Option<CommandTarget> {
+        match self {
+            Self::Command(target) => Some(target),
+            Self::Project(_) | Self::Details(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct ProjectPane {
+    selected: usize,
+}
+
+impl ProjectPane {
+    /// Renders project rows and returns focus/mouse/region data in project-local coordinates.
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        focused: Option<ProjectTarget>,
+    ) -> FrameSnapshot<ProjectTarget> {
+        let local = local_area(area);
+        let rows = Self::row_slots(local);
+
+        frame.render_widget(Block::new().borders(Borders::ALL).title("projects"), area);
+        for region in &rows {
+            let screen = to_screen(area, region.area);
+            let style = self.row_style(region.id, focused);
+            frame.render_widget(
+                Paragraph::new(PROJECTS[region.id.index()]).style(style),
+                screen,
+            );
+        }
+
+        FrameTargets::from_regions(Regions::from_regions(local, rows), 0).build()
+    }
+
+    fn row_slots(area: Rect) -> Vec<Region<ProjectTarget>> {
+        let inner = inner(area);
+        PROJECTS
+            .iter()
+            .enumerate()
+            .take(usize::from(inner.height))
+            .map(|(index, _)| {
+                let row = Rect::new(
+                    inner.x,
+                    inner.y.saturating_add(index as u16),
+                    inner.width,
+                    1,
+                );
+                Region::new(ProjectTarget::Row(index), row)
+            })
+            .collect()
+    }
+
+    fn row_style(&self, target: ProjectTarget, focused: Option<ProjectTarget>) -> Style {
+        let mut style = Style::new();
+        if self.selected == target.index() {
+            style = style.add_modifier(Modifier::REVERSED);
+        }
+        if focused == Some(target) {
+            style = style.add_modifier(Modifier::BOLD);
+        }
+        style
+    }
+
+    const fn selected_name(&self) -> &'static str {
+        PROJECTS[self.selected]
+    }
+
+    fn select(&mut self, index: usize) {
+        self.selected = index.min(PROJECTS.len().saturating_sub(1));
+    }
+
+    fn select_relative(&mut self, delta: isize) {
+        self.selected = offset_index(self.selected, delta, PROJECTS.len());
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum ProjectTarget {
+    Row(usize),
+}
+
+impl ProjectTarget {
+    const fn index(self) -> usize {
+        match self {
+            Self::Row(index) => index,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct DetailsPane {
+    scroll: usize,
+}
+
+impl DetailsPane {
+    /// Renders a scrollable pane and returns one local target for focus and wheel routing.
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        project: &str,
+        focused: Option<DetailsTarget>,
+    ) -> FrameSnapshot<DetailsTarget> {
+        let local = local_area(area);
+        let inner = inner(local);
+        let block_style = if focused == Some(DetailsTarget::Pane) {
+            Style::new().add_modifier(Modifier::BOLD)
+        } else {
+            Style::new()
+        };
+
+        frame.render_widget(
+            Block::new()
+                .borders(Borders::ALL)
+                .title("details")
+                .style(block_style),
+            area,
+        );
+        let text = details_text(project);
+        let visible = text
+            .lines()
+            .skip(self.scroll)
+            .take(usize::from(inner.height))
+            .collect::<Vec<_>>()
+            .join("\n");
+        frame.render_widget(Paragraph::new(visible), to_screen(area, inner));
+
+        FrameTargets::new(local, 50).region(DetailsTarget::Pane, inner)
+    }
+
+    fn scroll(&mut self, project: &str, delta: isize) {
+        self.scroll = offset_index(self.scroll, delta, details_text(project).lines().count());
+    }
+
+    const fn reset(&mut self) {
+        self.scroll = 0;
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum DetailsTarget {
+    Pane,
+}
+
+#[derive(Debug, Default)]
+struct CommandInput {
+    value: String,
+}
+
+impl CommandInput {
+    /// Renders an input row and returns a local cursor request when it owns focus.
+    fn render(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        focused: Option<CommandTarget>,
+    ) -> FrameSnapshot<CommandTarget> {
+        let local = local_area(area);
+        let input = inner(local);
+        let style = if focused == Some(CommandTarget::Input) {
+            Style::new().add_modifier(Modifier::BOLD)
+        } else {
+            Style::new()
+        };
+        let text = format!("> {}", self.value);
+
+        frame.render_widget(Block::new().borders(Borders::ALL).title("command"), area);
+        frame.render_widget(Paragraph::new(text).style(style), to_screen(area, input));
+
+        let mut plan = FrameTargets::new(local, 90).region(CommandTarget::Input, input);
+        if focused == Some(CommandTarget::Input) {
+            let x = input
+                .x
+                .saturating_add(2)
+                .saturating_add(self.value.chars().count() as u16)
+                .min(input.right().saturating_sub(1));
+            let cursor =
+                CursorRequests::new().request(CursorRequest::visible(Position::new(x, input.y)));
+            plan = plan.cursor(cursor);
+        }
+        plan
+    }
+
+    fn push(&mut self, ch: char) {
+        self.value.push(ch);
+    }
+
+    fn pop(&mut self) {
+        self.value.pop();
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum CommandTarget {
+    Input,
+}
+
+const fn local_area(area: Rect) -> Rect {
+    Rect::new(0, 0, area.width, area.height)
+}
+
+const fn inner(area: Rect) -> Rect {
+    Rect::new(
+        area.x.saturating_add(1),
+        area.y.saturating_add(1),
+        area.width.saturating_sub(2),
+        area.height.saturating_sub(2),
+    )
+}
+
+const fn to_screen(origin: Rect, local: Rect) -> Rect {
+    Rect::new(
+        origin.x.saturating_add(local.x),
+        origin.y.saturating_add(local.y),
+        local.width,
+        local.height,
+    )
+}
+
+fn offset_index(index: usize, delta: isize, len: usize) -> usize {
+    if len == 0 {
+        return 0;
+    }
+    if delta.is_negative() {
+        index.saturating_sub(delta.unsigned_abs())
+    } else {
+        index.saturating_add(delta as usize).min(len - 1)
+    }
+}
+
+fn details_text(project: &str) -> String {
+    format!(
+        "{project}\n\nEach pane in this example returns local frame-local data.\n\n\
+         The parent maps local ids into Target, translates local coordinates into screen \
+         coordinates, clips them to the pane, and merges them into one previous frame.\n\n\
+         Try tab, click, mouse wheel over this pane, / to focus the command input, and q to quit."
+    )
+}
+
+const PROJECTS: [&str; 5] = ["api", "worker", "docs", "release", "ops"];

--- a/crates/ratatui-layout/examples/container_dialog.rs
+++ b/crates/ratatui-layout/examples/container_dialog.rs
@@ -1,0 +1,183 @@
+//! Keep dialog geometry separate from ordinary Ratatui rendering.
+//!
+//! This example uses `Container` for padded dialog layout, `FocusTargets` for field traversal, and
+//! `CursorRequests` for terminal cursor placement. Blocks and paragraphs remain ordinary Ratatui
+//! widgets rendered into the planned areas.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Position, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui_layout::container::{Container, Padding};
+use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+use ratatui_layout::focus::{FocusFallback, FocusState, FocusTarget, FocusTargets};
+use ratatui_layout::linear::Column;
+use ratatui_layout::regions::Regions;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && !app.handle_key(key.code)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+#[derive(Debug, Default)]
+struct App {
+    focus: FocusState<Field>,
+    title: String,
+    owner: String,
+    notes: String,
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let outer = centered(frame.area(), 52, 9);
+        let container = Container::new()
+            .padding(Padding::new(2, 2, 2, 1))
+            .child("fields")
+            .layout(outer);
+        let field_rows = [
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ];
+        let fields = Column::new(field_rows)
+            .spacing(1)
+            .regions(container.inner)
+            .map_id(Field::from_index);
+        let focus_plan = FocusTargets::from_regions(fields.regions().iter().copied());
+
+        self.focus.ensure_visible(&focus_plan, FocusFallback::First);
+
+        frame.render_widget(Clear, container.outer);
+        frame.render_widget(
+            Block::new().borders(Borders::ALL).title("container dialog"),
+            container.outer,
+        );
+        for region in fields.regions() {
+            self.render_field(frame, region.id, region.area);
+        }
+        self.place_cursor(frame, &fields);
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        let plan = Self::static_focus_plan();
+        match key {
+            KeyCode::Esc | KeyCode::Char('q') => return false,
+            KeyCode::Tab | KeyCode::Down => self.focus.next(&plan),
+            KeyCode::BackTab | KeyCode::Up => self.focus.previous(&plan),
+            KeyCode::Backspace => {
+                self.value_mut().pop();
+            }
+            KeyCode::Char(ch) => self.value_mut().push(ch),
+            _ => {}
+        }
+        true
+    }
+
+    fn render_field(&self, frame: &mut Frame, field: Field, area: Rect) {
+        let style = if self.focus.focused() == Some(field) {
+            Style::new().add_modifier(Modifier::REVERSED)
+        } else {
+            Style::new()
+        };
+        frame.render_widget(
+            Paragraph::new(format!("{}: {}", field.label(), self.value(field))).style(style),
+            area,
+        );
+    }
+
+    fn place_cursor(&self, frame: &mut Frame, fields: &Regions<Field>) {
+        let Some(field) = self.focus.focused() else {
+            return;
+        };
+        let Some(region) = fields.regions().iter().find(|region| region.id == field) else {
+            return;
+        };
+        let x = region
+            .area
+            .x
+            .saturating_add(field.label_width())
+            .saturating_add(self.value(field).chars().count() as u16)
+            .min(region.area.right().saturating_sub(1));
+        let cursor =
+            CursorRequests::new().request(CursorRequest::visible(Position::new(x, region.area.y)));
+        if let Some(cursor) = cursor.final_cursor() {
+            frame.set_cursor_position(cursor.position);
+        }
+    }
+
+    fn static_focus_plan() -> FocusTargets<Field> {
+        FocusTargets::from_targets([
+            FocusTarget::new(Field::Title, Rect::default(), 0),
+            FocusTarget::new(Field::Owner, Rect::default(), 1),
+            FocusTarget::new(Field::Notes, Rect::default(), 2),
+        ])
+    }
+
+    fn value(&self, field: Field) -> &str {
+        match field {
+            Field::Title => &self.title,
+            Field::Owner => &self.owner,
+            Field::Notes => &self.notes,
+        }
+    }
+
+    fn value_mut(&mut self) -> &mut String {
+        match self.focus.focused().unwrap_or(Field::Title) {
+            Field::Title => &mut self.title,
+            Field::Owner => &mut self.owner,
+            Field::Notes => &mut self.notes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Field {
+    Title,
+    Owner,
+    Notes,
+}
+
+impl Field {
+    const fn from_index(index: usize) -> Self {
+        match index {
+            0 => Self::Title,
+            1 => Self::Owner,
+            _ => Self::Notes,
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Title => "title",
+            Self::Owner => "owner",
+            Self::Notes => "notes",
+        }
+    }
+
+    const fn label_width(self) -> u16 {
+        self.label().len() as u16 + 2
+    }
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/cursor_request.rs
+++ b/crates/ratatui-layout/examples/cursor_request.rs
@@ -1,0 +1,189 @@
+//! Request terminal cursor placement from whichever field has focus.
+//!
+//! The focused field computes a cursor position during rendering and records it in
+//! `CursorRequests`. The frame applies the final visible request after all fields have had a chance
+//! to contribute.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::cursor::CursorRequests;
+use ratatui_layout::focus::{FocusFallback, FocusState, FocusTarget, FocusTargets};
+use ratatui_layout::input::TextFieldState;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && !app.handle_key(key.code)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    title: String,
+    owner: String,
+    title_field: TextFieldState,
+    owner_field: TextFieldState,
+    focus: FocusState<Field>,
+    previous_focus: FocusTargets<Field>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            title: String::from("release train"),
+            owner: String::from("platform"),
+            title_field: TextFieldState::at_end("release train"),
+            owner_field: TextFieldState::at_end("platform"),
+            focus: FocusState::default(),
+            previous_focus: FocusTargets::new(),
+        }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let area = centered(frame.area(), 48, 6);
+        let [title_area, owner_area] =
+            Layout::vertical([Constraint::Length(1), Constraint::Length(1)])
+                .spacing(1)
+                .margin(2)
+                .areas(area);
+        self.previous_focus = FocusTargets::from_targets([
+            FocusTarget::new(Field::Title, title_area, 0),
+            FocusTarget::new(Field::Owner, owner_area, 1),
+        ]);
+        self.focus
+            .ensure_visible(&self.previous_focus, FocusFallback::First);
+
+        let mut cursor = CursorRequests::new();
+        frame.render_widget(Block::new().borders(Borders::ALL).title("cursor"), area);
+        cursor = cursor.merge(self.render_field(frame, Field::Title, title_area));
+        cursor = cursor.merge(self.render_field(frame, Field::Owner, owner_area));
+        if let Some(cursor) = cursor.final_cursor() {
+            frame.set_cursor_position(cursor.position);
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Tab | KeyCode::Down => self.focus.next(&self.previous_focus),
+            KeyCode::BackTab | KeyCode::Up => self.focus.previous(&self.previous_focus),
+            KeyCode::Left => self.field_state().move_left(),
+            KeyCode::Right => {
+                let value = self.field_value().to_string();
+                self.field_state().move_right(&value);
+            }
+            KeyCode::Backspace => self.backspace(),
+            KeyCode::Char(ch) => self.insert(ch),
+            _ => {}
+        }
+        true
+    }
+
+    fn insert(&mut self, ch: char) {
+        match self.focus.focused() {
+            Some(Field::Title) => self.title_field.insert_char(&mut self.title, ch),
+            Some(Field::Owner) => self.owner_field.insert_char(&mut self.owner, ch),
+            None => {}
+        }
+    }
+
+    fn backspace(&mut self) {
+        match self.focus.focused() {
+            Some(Field::Title) => self.title_field.backspace(&mut self.title),
+            Some(Field::Owner) => self.owner_field.backspace(&mut self.owner),
+            None => {}
+        }
+    }
+
+    fn render_field(&self, frame: &mut Frame, field: Field, area: Rect) -> CursorRequests {
+        let focused = self.focus.focused() == Some(field);
+        let style = if focused {
+            Style::new().fg(Color::Black).bg(Color::Green)
+        } else {
+            Style::new().fg(Color::White)
+        };
+        let text = format!("{}: {}", field.label(), self.value(field));
+        frame.render_widget(Paragraph::new(text).style(style), area);
+        if focused {
+            let field_state = self.text_field(field);
+            let request = field_state.cursor_request_after_prefix(area, field.label_width());
+            CursorRequests::new().request(request)
+        } else {
+            CursorRequests::new()
+        }
+    }
+
+    const fn field_state(&mut self) -> &mut TextFieldState {
+        match self.focus.focused() {
+            Some(Field::Owner) => &mut self.owner_field,
+            Some(Field::Title) | None => &mut self.title_field,
+        }
+    }
+
+    fn field_value(&self) -> &str {
+        match self.focus.focused() {
+            Some(Field::Owner) => &self.owner,
+            Some(Field::Title) | None => &self.title,
+        }
+    }
+
+    fn value(&self, field: Field) -> &str {
+        match field {
+            Field::Title => &self.title,
+            Field::Owner => &self.owner,
+        }
+    }
+
+    const fn text_field(&self, field: Field) -> TextFieldState {
+        match field {
+            Field::Title => self.title_field,
+            Field::Owner => self.owner_field,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Field {
+    Title,
+    Owner,
+}
+
+impl Field {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Title => "title",
+            Self::Owner => "owner",
+        }
+    }
+
+    const fn label_width(self) -> u16 {
+        match self {
+            Self::Title | Self::Owner => 7,
+        }
+    }
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/external_participants.rs
+++ b/crates/ratatui-layout/examples/external_participants.rs
@@ -1,0 +1,102 @@
+//! Render app-owned items from a plan without storing widgets in the container.
+//!
+//! A normal `Layout` call can produce the same rectangles. The extra piece here is that each region
+//! id is passed back to an app-owned participant, so the container never stores card widgets.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Rect, Size};
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Paragraph, Widget};
+use ratatui_layout::linear::Column;
+use ratatui_layout::measure::{MeasureConstraint, SizeHint};
+use ratatui_layout::participant::{LayoutParticipant, MeasureContext, RenderContext};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && !app.handle_key(key.code)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+const CARDS: [(&str, &str); 3] = [
+    ("Inbox", "14 unread"),
+    ("Builds", "2 running"),
+    ("Deploys", "production healthy"),
+];
+
+#[derive(Default)]
+struct App {
+    selected: usize,
+}
+
+impl App {
+    fn render(&self, frame: &mut Frame) {
+        let plan = Column::new([Constraint::Length(3); CARDS.len()]).regions(frame.area());
+        let mut cards = Cards;
+
+        for region in plan.regions() {
+            cards.render(
+                region.id,
+                region.area,
+                frame.buffer_mut(),
+                RenderContext::selected(region.id == self.selected),
+            );
+        }
+    }
+
+    const fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('j') | KeyCode::Down => self.select_next_card(),
+            KeyCode::Char('k') | KeyCode::Up => self.select_previous_card(),
+            KeyCode::Char('q') | KeyCode::Esc => return Self::quit(),
+            _ => {}
+        }
+        true
+    }
+
+    const fn select_next_card(&mut self) {
+        self.selected = (self.selected + 1) % CARDS.len();
+    }
+
+    const fn select_previous_card(&mut self) {
+        self.selected = (self.selected + CARDS.len() - 1) % CARDS.len();
+    }
+
+    const fn quit() -> bool {
+        false
+    }
+}
+
+struct Cards;
+
+impl LayoutParticipant for Cards {
+    fn measure(&self, id: usize, _: MeasureConstraint, _: MeasureContext) -> SizeHint {
+        let (title, detail) = CARDS[id];
+        SizeHint::exact(Size::new((title.len() + detail.len() + 3) as u16, 3))
+    }
+
+    fn render(&mut self, id: usize, area: Rect, buf: &mut Buffer, ctx: RenderContext) {
+        let (title, detail) = CARDS[id];
+        let style = if ctx.state.selected {
+            Style::new().add_modifier(Modifier::REVERSED)
+        } else {
+            Style::new()
+        };
+
+        Paragraph::new(format!("{title}\n  {detail}"))
+            .style(style)
+            .render(area, buf);
+    }
+}

--- a/crates/ratatui-layout/examples/focus_traversal.rs
+++ b/crates/ratatui-layout/examples/focus_traversal.rs
@@ -1,0 +1,146 @@
+//! Move focus through visible controls while skipping disabled controls.
+//!
+//! The render pass rebuilds the focus target collection from visible fields. Input handling then
+//! moves through that previous plan, so hidden or disabled controls do not need special cases in
+//! key handling.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::focus::{FocusFallback, FocusState, FocusTarget, FocusTargets};
+use ratatui_layout::linear::Row;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && !app.handle_key(key.code)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+#[derive(Debug, Default)]
+struct App {
+    show_advanced: bool,
+    save_enabled: bool,
+    focus: FocusState<Field>,
+    previous_focus: FocusTargets<Field>,
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let area = centered(frame.area(), 58, 5);
+        let fields = self.visible_fields();
+        let constraints = fields.iter().map(|_| Constraint::Length(12));
+        let plan = Row::new(constraints)
+            .spacing(1)
+            .flex(Flex::Center)
+            .regions(area);
+        self.previous_focus = FocusTargets::from_targets(
+            plan.zip_ids(&fields)
+                .enumerate()
+                .map(|(order, (region, field))| {
+                    FocusTarget::new(field, region.area, order as u16)
+                        .disabled(!self.is_enabled(field))
+                })
+                .collect::<Vec<_>>(),
+        );
+        self.focus
+            .ensure_visible(&self.previous_focus, FocusFallback::First);
+
+        frame.render_widget(Block::new().borders(Borders::ALL).title("focus"), area);
+        for (region, field) in plan.zip_ids(&fields) {
+            self.render_field(frame, field, region.area);
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Char('a') => self.show_advanced = !self.show_advanced,
+            KeyCode::Char('s') => self.save_enabled = !self.save_enabled,
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Tab => {
+                self.focus.next(&self.previous_focus);
+            }
+            KeyCode::Char('h') | KeyCode::Left | KeyCode::BackTab => {
+                self.focus.previous(&self.previous_focus);
+            }
+            _ => {}
+        }
+        true
+    }
+
+    fn visible_fields(&self) -> Vec<Field> {
+        let mut fields = vec![Field::Title, Field::Owner, Field::Save];
+        if self.show_advanced {
+            fields.insert(2, Field::Advanced);
+        }
+        fields
+    }
+
+    fn is_enabled(&self, field: Field) -> bool {
+        field != Field::Save || self.save_enabled
+    }
+
+    fn render_field(&self, frame: &mut Frame, field: Field, area: Rect) {
+        let disabled = !self.is_enabled(field);
+        let focused = self.focus.focused() == Some(field);
+        let style = if disabled {
+            Style::new().fg(Color::DarkGray)
+        } else if focused {
+            Style::new()
+                .fg(Color::Black)
+                .bg(Color::Green)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::new().fg(Color::White)
+        };
+        frame.render_widget(
+            Paragraph::new(field.label()).centered().style(style).block(
+                Block::new()
+                    .borders(Borders::ALL)
+                    .title(if disabled { "disabled" } else { "" }),
+            ),
+            area,
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Field {
+    Title,
+    Owner,
+    Advanced,
+    Save,
+}
+
+impl Field {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Title => "title",
+            Self::Owner => "owner",
+            Self::Advanced => "advanced",
+            Self::Save => "save",
+        }
+    }
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/form_dialog.rs
+++ b/crates/ratatui-layout/examples/form_dialog.rs
@@ -1,0 +1,235 @@
+//! Route focus and cursor placement through app-owned controls in an overlay dialog.
+//!
+//! The overlay only values regions. `App` owns focus state and field data, and the cursor request
+//! is produced from the focused field after layout.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui_layout::cursor::CursorRequests;
+use ratatui_layout::focus::{FocusFallback, FocusState, FocusTarget, FocusTargets};
+use ratatui_layout::input::TextFieldState;
+use ratatui_layout::overlay::Overlay;
+use ratatui_layout::regions::{Region, Regions};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && !app.handle_key(key.code)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+#[derive(Debug, Default)]
+struct App {
+    focus: FocusState<Field>,
+    title: String,
+    owner: String,
+    title_field: TextFieldState,
+    owner_field: TextFieldState,
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let dialog = centered(frame.area(), 48, 7);
+        let plan = Overlay::new()
+            .region(Region::new(
+                Field::Title,
+                Rect::new(dialog.x + 2, dialog.y + 2, dialog.width - 4, 1),
+            ))
+            .region(Region::new(
+                Field::Owner,
+                Rect::new(dialog.x + 2, dialog.y + 4, dialog.width - 4, 1),
+            ))
+            .regions(dialog);
+        let focus_plan = Self::focus_plan(&plan);
+        self.focus.ensure_visible(&focus_plan, FocusFallback::First);
+
+        frame.render_widget(Clear, dialog);
+        frame.render_widget(Block::new().borders(Borders::ALL).title("task"), dialog);
+        self.render_field(frame, &plan, Field::Title, "title");
+        self.render_field(frame, &plan, Field::Owner, "owner");
+        self.place_cursor(frame, &plan);
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Tab | KeyCode::Down => self.focus_next(),
+            KeyCode::BackTab | KeyCode::Up => self.focus_previous(),
+            KeyCode::Left => self.move_cursor_left(),
+            KeyCode::Right => self.move_cursor_right(),
+            KeyCode::Home => self.move_cursor_home(),
+            KeyCode::End => self.move_cursor_end(),
+            KeyCode::Backspace => self.backspace(),
+            KeyCode::Delete => self.delete(),
+            KeyCode::Char('q') | KeyCode::Esc => return Self::quit(),
+            KeyCode::Char(ch) => self.insert(ch),
+            _ => {}
+        }
+        true
+    }
+
+    fn focus_next(&mut self) {
+        let plan = Self::static_focus_plan();
+        self.focus.next(&plan);
+    }
+
+    fn focus_previous(&mut self) {
+        let plan = Self::static_focus_plan();
+        self.focus.previous(&plan);
+    }
+
+    fn insert(&mut self, ch: char) {
+        match self.focus.focused() {
+            Some(Field::Title) => self.title_field.insert_char(&mut self.title, ch),
+            Some(Field::Owner) => self.owner_field.insert_char(&mut self.owner, ch),
+            None => {}
+        }
+    }
+
+    fn backspace(&mut self) {
+        match self.focus.focused() {
+            Some(Field::Title) => self.title_field.backspace(&mut self.title),
+            Some(Field::Owner) => self.owner_field.backspace(&mut self.owner),
+            None => {}
+        }
+    }
+
+    fn delete(&mut self) {
+        match self.focus.focused() {
+            Some(Field::Title) => self.title_field.delete(&mut self.title),
+            Some(Field::Owner) => self.owner_field.delete(&mut self.owner),
+            None => {}
+        }
+    }
+
+    const fn move_cursor_left(&mut self) {
+        match self.focus.focused() {
+            Some(Field::Title) => self.title_field.move_left(),
+            Some(Field::Owner) => self.owner_field.move_left(),
+            None => {}
+        }
+    }
+
+    fn move_cursor_right(&mut self) {
+        match self.focus.focused() {
+            Some(Field::Title) => self.title_field.move_right(&self.title),
+            Some(Field::Owner) => self.owner_field.move_right(&self.owner),
+            None => {}
+        }
+    }
+
+    const fn move_cursor_home(&mut self) {
+        match self.focus.focused() {
+            Some(Field::Title) => self.title_field.move_home(),
+            Some(Field::Owner) => self.owner_field.move_home(),
+            None => {}
+        }
+    }
+
+    fn move_cursor_end(&mut self) {
+        match self.focus.focused() {
+            Some(Field::Title) => self.title_field.move_end(&self.title),
+            Some(Field::Owner) => self.owner_field.move_end(&self.owner),
+            None => {}
+        }
+    }
+
+    fn render_field(&self, frame: &mut Frame, plan: &Regions<Field>, field: Field, label: &str) {
+        let area = plan
+            .regions()
+            .iter()
+            .find(|region| region.id == field)
+            .unwrap()
+            .area;
+        let text = format!("{label}: {}", self.value(field));
+        let style = if self.focus.focused() == Some(field) {
+            Style::new().add_modifier(Modifier::REVERSED)
+        } else {
+            Style::new()
+        };
+        frame.render_widget(Paragraph::new(text).style(style), area);
+    }
+
+    fn place_cursor(&self, frame: &mut Frame, plan: &Regions<Field>) {
+        let Some(field) = self.focus.focused() else {
+            return;
+        };
+        let region = plan
+            .regions()
+            .iter()
+            .find(|region| region.id == field)
+            .unwrap();
+        let cursor = CursorRequests::new().request(
+            self.field_state(field)
+                .cursor_request_after_prefix(region.area, field.label_width()),
+        );
+        if let Some(cursor) = cursor.final_cursor() {
+            frame.set_cursor_position(cursor.position);
+        }
+    }
+
+    fn focus_plan(plan: &Regions<Field>) -> FocusTargets<Field> {
+        FocusTargets::from_regions(plan.regions().iter().copied())
+    }
+
+    fn static_focus_plan() -> FocusTargets<Field> {
+        FocusTargets::from_targets([
+            FocusTarget::new(Field::Title, Rect::default(), 0),
+            FocusTarget::new(Field::Owner, Rect::default(), 1),
+        ])
+    }
+
+    fn value(&self, field: Field) -> &str {
+        match field {
+            Field::Title => &self.title,
+            Field::Owner => &self.owner,
+        }
+    }
+
+    const fn field_state(&self, field: Field) -> TextFieldState {
+        match field {
+            Field::Title => self.title_field,
+            Field::Owner => self.owner_field,
+        }
+    }
+
+    const fn quit() -> bool {
+        false
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Field {
+    Title,
+    Owner,
+}
+
+impl Field {
+    const fn label_width(self) -> u16 {
+        match self {
+            Self::Title | Self::Owner => 7,
+        }
+    }
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(ratatui::layout::Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(ratatui::layout::Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/frame_snapshot.rs
+++ b/crates/ratatui-layout/examples/frame_snapshot.rs
@@ -1,0 +1,169 @@
+//! Store one frame's UI data and route the next input event through them.
+//!
+//! This example keeps the previous `FrameSnapshot` on `App`. Rendering rebuilds layout and pointer
+//! data; key and mouse events then use the stored plan instead of reconstructing geometry in
+//! handlers.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode, MouseEventKind};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::focus::{FocusFallback, FocusState, FocusTargets};
+use ratatui_layout::frame::FrameSnapshot;
+use ratatui_layout::linear::Row;
+use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+use ratatui_layout::selection::{SelectionMode, SelectionState};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    previous_frame: FrameSnapshot<Action>,
+    focus: FocusState<Action>,
+    selection: SelectionState<Action>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            previous_frame: FrameSnapshot::new(Rect::default()),
+            focus: FocusState::default(),
+            selection: SelectionState::new(SelectionMode::Single),
+        }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let area = centered(frame.area(), 48, 5);
+        let action_widths = [
+            Constraint::Length(14),
+            Constraint::Length(14),
+            Constraint::Length(14),
+        ];
+        let plan = Row::new(action_widths)
+            .spacing(1)
+            .flex(Flex::Center)
+            .regions(area)
+            .map_id(Action::from_index);
+        let focus = FocusTargets::from_regions(plan.regions().iter().copied());
+        let mouse = PointerTargets::from_targets(
+            plan.regions()
+                .iter()
+                .map(|region| PointerTarget::from_region(*region))
+                .collect::<Vec<_>>(),
+        );
+
+        self.focus.ensure_visible(&focus, FocusFallback::First);
+        if self.selection.primary().is_none() {
+            self.selection.select(Action::Open);
+        }
+
+        frame.render_widget(
+            Block::new().borders(Borders::ALL).title("frame snapshot"),
+            area,
+        );
+        for region in plan.regions() {
+            self.render_action(frame, region.id, region.area);
+        }
+
+        self.previous_frame = FrameSnapshot::from_layout(plan).focus(focus).mouse(mouse);
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Esc | KeyCode::Char('q') => return false,
+            KeyCode::Right | KeyCode::Tab => self.focus.next(&self.previous_frame.focus),
+            KeyCode::Left | KeyCode::BackTab => self.focus.previous(&self.previous_frame.focus),
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                if let Some(action) = self.focus.focused() {
+                    self.selection.select(action);
+                }
+            }
+            _ => {}
+        }
+        true
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        if matches!(mouse.kind, MouseEventKind::Down(_) | MouseEventKind::Up(_))
+            && let Some(hit) = self
+                .previous_frame
+                .route_position((mouse.column, mouse.row))
+        {
+            self.focus.focus(Some(hit.id));
+            self.selection.select(hit.id);
+        }
+    }
+
+    fn render_action(&self, frame: &mut Frame, action: Action, area: Rect) {
+        let mut style = Style::new();
+        if self.selection.is_selected(action) {
+            style = style.add_modifier(Modifier::REVERSED);
+        } else if self.focus.focused() == Some(action) {
+            style = style.add_modifier(Modifier::BOLD);
+        } else {
+            style = style.remove_modifier(Modifier::REVERSED);
+        }
+        frame.render_widget(
+            Paragraph::new(action.label())
+                .block(Block::new().borders(Borders::ALL))
+                .centered()
+                .style(style),
+            area,
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Action {
+    Open,
+    Save,
+    Close,
+}
+
+impl Action {
+    const fn from_index(index: usize) -> Self {
+        match index {
+            0 => Self::Open,
+            1 => Self::Save,
+            _ => Self::Close,
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Save => "save",
+            Self::Close => "close",
+        }
+    }
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/grid_palette.rs
+++ b/crates/ratatui-layout/examples/grid_palette.rs
@@ -1,0 +1,193 @@
+//! Route palette input through typed grid cells.
+//!
+//! This example uses `GridLayout` for `{ row, column }` cell ids, `PointerTargets` for pointer
+//! hits, `FocusTargets` for keyboard traversal, and `SelectionState` for app-owned selection.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode, MouseEventKind};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::focus::{FocusFallback, FocusState, FocusTargets};
+use ratatui_layout::grid::{Grid, GridPosition};
+use ratatui_layout::pointer::{PointerPhase, PointerState, PointerTarget, PointerTargets};
+use ratatui_layout::selection::{SelectionMode, SelectionState};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::new();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    focus: FocusState<GridPosition>,
+    mouse: PointerState<GridPosition>,
+    selection: SelectionState<GridPosition>,
+    previous_mouse_plan: PointerTargets<GridPosition>,
+    previous_focus_plan: FocusTargets<GridPosition>,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            focus: FocusState::default(),
+            mouse: PointerState::default(),
+            selection: SelectionState::new(SelectionMode::Single),
+            previous_mouse_plan: PointerTargets::new(),
+            previous_focus_plan: FocusTargets::new(),
+        }
+    }
+
+    fn render(&mut self, frame: &mut Frame) {
+        let area = centered(frame.area(), 42, 9);
+        let row_heights = [Constraint::Length(3), Constraint::Length(3)];
+        let column_widths = [
+            Constraint::Length(14),
+            Constraint::Length(14),
+            Constraint::Length(14),
+        ];
+        let grid = Grid::new(row_heights, column_widths).layout(area);
+        let focus_plan = FocusTargets::from_regions(grid.cells().regions().iter().copied());
+        let mouse_plan = PointerTargets::from_targets(
+            grid.cells()
+                .regions()
+                .iter()
+                .map(|region| PointerTarget::from_region(*region))
+                .collect::<Vec<_>>(),
+        );
+        let visible_ids = grid
+            .cells()
+            .regions()
+            .iter()
+            .map(|region| region.id)
+            .collect::<Vec<_>>();
+
+        self.focus.ensure_visible(&focus_plan, FocusFallback::First);
+        if self.selection.primary().is_none() {
+            self.selection.select(visible_ids[0]);
+        }
+
+        frame.render_widget(Block::new().borders(Borders::ALL).title("palette"), area);
+        for region in grid.cells().regions() {
+            self.render_cell(frame, region.id, region.area);
+        }
+
+        self.previous_focus_plan = focus_plan;
+        self.previous_mouse_plan = mouse_plan;
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Esc | KeyCode::Char('q') => return false,
+            KeyCode::Right | KeyCode::Tab => self.focus.next(&self.previous_focus_plan),
+            KeyCode::Left | KeyCode::BackTab => self.focus.previous(&self.previous_focus_plan),
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                if let Some(id) = self.focus.focused() {
+                    self.selection.select(id);
+                }
+            }
+            _ => {}
+        }
+        true
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        let position = (mouse.column, mouse.row);
+        let Some(phase) = pointer_phase(mouse.kind) else {
+            return;
+        };
+        let hit = self.mouse.route(&self.previous_mouse_plan, position, phase);
+        match (phase, hit) {
+            (PointerPhase::Press, Some(hit)) => {
+                self.focus.focus(Some(hit.id));
+            }
+            (PointerPhase::Release, Some(hit)) => {
+                self.selection.select(hit.id);
+            }
+            _ => {}
+        }
+    }
+
+    fn render_cell(&self, frame: &mut Frame, id: GridPosition, area: Rect) {
+        let color = PALETTE[id.row * 3 + id.column];
+        let mut style = Style::new().fg(color.color);
+        if self.selection.is_selected(id) {
+            style = style.bg(Color::White).fg(Color::Black);
+        } else if self.focus.focused() == Some(id) || self.mouse.hovered() == Some(id) {
+            style = style.add_modifier(Modifier::REVERSED);
+        } else {
+            style = style.bg(Color::Reset);
+        }
+        frame.render_widget(
+            Paragraph::new(format!("  {}", color.name))
+                .block(Block::new().borders(Borders::ALL))
+                .style(style),
+            area,
+        );
+    }
+}
+
+const fn pointer_phase(kind: MouseEventKind) -> Option<PointerPhase> {
+    match kind {
+        MouseEventKind::Moved => Some(PointerPhase::Hover),
+        MouseEventKind::Down(_) => Some(PointerPhase::Press),
+        MouseEventKind::Up(_) => Some(PointerPhase::Release),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Swatch {
+    name: &'static str,
+    color: Color,
+}
+
+const PALETTE: [Swatch; 6] = [
+    Swatch {
+        name: "red",
+        color: Color::Red,
+    },
+    Swatch {
+        name: "green",
+        color: Color::Green,
+    },
+    Swatch {
+        name: "yellow",
+        color: Color::Yellow,
+    },
+    Swatch {
+        name: "blue",
+        color: Color::Blue,
+    },
+    Swatch {
+        name: "magenta",
+        color: Color::Magenta,
+    },
+    Swatch {
+        name: "cyan",
+        color: Color::Cyan,
+    },
+];
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width.min(area.width),
+        height.min(area.height),
+    )
+}

--- a/crates/ratatui-layout/examples/left_right_row.rs
+++ b/crates/ratatui-layout/examples/left_right_row.rs
@@ -1,0 +1,65 @@
+//! Split each row into left and right regions without hand-calculating x positions.
+//!
+//! A normal `Layout::horizontal(...).areas(area)` call works for one row. This example uses `Row`
+//! because every row repeats the same split and the returned plan makes the two render targets
+//! explicit before rendering.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::Paragraph;
+use ratatui_layout::linear::Row;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(render)?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+fn render(frame: &mut Frame) {
+    let rows = [
+        ("Inbox", "14 unread"),
+        ("Builds", "2 running"),
+        ("Deploys", "healthy"),
+        ("Backups", "03:00"),
+    ];
+
+    for (index, (name, status)) in rows.iter().enumerate() {
+        let area = Rect::new(0, index as u16, frame.area().width, 1);
+        render_status_row(frame, area, name, status, index == 0);
+    }
+}
+
+fn render_status_row(frame: &mut Frame, area: Rect, name: &str, status: &str, selected: bool) {
+    // The row planner is the important part: the caller describes the two regions, receives a
+    // plan, and then renders ordinary Ratatui widgets into the assigned rectangles.
+    let row_columns = [
+        Constraint::Min(0),
+        Constraint::Length(status.chars().count() as u16),
+    ];
+    let plan = Row::new(row_columns).regions(area);
+    let name_area = plan.regions()[0].area;
+    let status_area = plan.regions()[1].area;
+    let style = if selected {
+        Style::new().add_modifier(Modifier::REVERSED)
+    } else {
+        Style::new()
+    };
+
+    frame.render_widget(Paragraph::new(name).style(style), name_area);
+    frame.render_widget(
+        Paragraph::new(status).right_aligned().style(style),
+        status_area,
+    );
+}

--- a/crates/ratatui-layout/examples/modal_prompt.rs
+++ b/crates/ratatui-layout/examples/modal_prompt.rs
@@ -1,0 +1,260 @@
+//! Coordinate a modal prompt without turning it into a form framework.
+//!
+//! The page behind the prompt still renders, but input is routed through the prompt's previous
+//! `FrameSnapshot`. The prompt contributes only shell geometry, button targets, focus order,
+//! z-order, and an explicit backdrop target for outside clicks.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui_layout::container::{Container, Padding};
+use ratatui_layout::focus::{FocusFallback, FocusState};
+use ratatui_layout::frame::{FrameSnapshot, FrameTargets};
+use ratatui_layout::linear::Row;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+fn run() -> Result<()> {
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    prompt_open: bool,
+    deployment_cancelled: bool,
+    message: String,
+    focus: FocusState<PromptTarget>,
+    previous_prompt: FrameSnapshot<PromptTarget>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            prompt_open: true,
+            deployment_cancelled: false,
+            message: String::from("prompt is open; click outside to dismiss"),
+            focus: FocusState::default(),
+            previous_prompt: FrameSnapshot::new(Rect::default()),
+        }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        self.render_release_page(frame);
+        self.previous_prompt = FrameSnapshot::new(frame.area());
+
+        if self.prompt_open {
+            self.previous_prompt = self.render_prompt(frame);
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        if self.prompt_open {
+            self.handle_prompt_key(key);
+            return true;
+        }
+
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => false,
+            KeyCode::Char('o') => {
+                self.open_prompt();
+                true
+            }
+            _ => true,
+        }
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        if !self.prompt_open || !matches!(mouse.kind, MouseEventKind::Down(_)) {
+            return;
+        }
+
+        let position = (mouse.column, mouse.row);
+        let Some(hit) = self.previous_prompt.route_click(position) else {
+            self.message = String::from("negative hit: prompt ignored page target");
+            return;
+        };
+        self.activate(hit.id);
+    }
+
+    fn handle_prompt_key(&mut self, key: KeyCode) {
+        match key {
+            KeyCode::Esc | KeyCode::Char('n') => self.dismiss_prompt("cancelled by keyboard"),
+            KeyCode::Tab | KeyCode::Right => self.focus.next(&self.previous_prompt.focus),
+            KeyCode::BackTab | KeyCode::Left => self.focus.previous(&self.previous_prompt.focus),
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                if let Some(target) = self.focus.focused() {
+                    self.activate(target);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn activate(&mut self, target: PromptTarget) {
+        match target {
+            PromptTarget::Backdrop => self.dismiss_prompt("dismissed by backdrop click"),
+            PromptTarget::Button(PromptButton::Cancel) => {
+                self.dismiss_prompt("cancelled; deployment is still running");
+            }
+            PromptTarget::Button(PromptButton::Confirm) => {
+                self.prompt_open = false;
+                self.deployment_cancelled = true;
+                self.message = String::from("deployment cancelled");
+            }
+        }
+    }
+
+    fn open_prompt(&mut self) {
+        self.prompt_open = true;
+        self.message = String::from("prompt is open; click outside to dismiss");
+        self.focus.clear();
+    }
+
+    fn dismiss_prompt(&mut self, message: &'static str) {
+        self.prompt_open = false;
+        self.message = String::from(message);
+        self.focus.clear();
+    }
+
+    fn render_release_page(&self, frame: &mut Frame) {
+        let [summary_area, status_area] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(frame.area());
+        let status = if self.deployment_cancelled {
+            "cancelled"
+        } else {
+            "running"
+        };
+        let summary = format!(
+            "release train\n\nstate: {status}\nowner: release\n\n\
+             o opens prompt   q quits after prompt closes"
+        );
+
+        frame.render_widget(
+            Paragraph::new(summary).block(
+                Block::new()
+                    .borders(Borders::ALL)
+                    .title("page behind modal"),
+            ),
+            summary_area,
+        );
+        frame.render_widget(Paragraph::new(self.message.as_str()), status_area);
+    }
+
+    fn render_prompt(&mut self, frame: &mut Frame) -> FrameSnapshot<PromptTarget> {
+        let outer = centered(frame.area(), 44, 9);
+        let container = Container::<PromptTarget>::new()
+            .padding(Padding::new(2, 2, 2, 1))
+            .layout(outer);
+        let [question_area, button_area] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).areas(container.inner);
+        let button_constraints = [
+            (PromptButton::Cancel, Constraint::Length(10)),
+            (PromptButton::Confirm, Constraint::Length(14)),
+        ];
+        let buttons = Row::named(button_constraints)
+            .spacing(2)
+            .flex(Flex::Center)
+            .regions(button_area);
+        let prompt_frame = FrameTargets::new(frame.area(), 100)
+            .z(20)
+            .mouse_region(PromptTarget::Backdrop, frame.area())
+            .build_focusable(buttons.regions().iter().copied(), PromptTarget::Button);
+        self.focus
+            .ensure_visible(&prompt_frame.focus, FocusFallback::First);
+
+        frame.render_widget(Clear, container.outer);
+        frame.render_widget(
+            Block::new()
+                .borders(Borders::ALL)
+                .title("cancel deployment"),
+            container.outer,
+        );
+        frame.render_widget(
+            Paragraph::new("Cancel the deployment now?").centered(),
+            question_area,
+        );
+        for region in buttons.regions() {
+            self.render_button(frame, region.id, region.area);
+        }
+
+        prompt_frame
+    }
+
+    fn render_button(&self, frame: &mut Frame, button: PromptButton, area: Rect) {
+        let target = PromptTarget::Button(button);
+        let focused = self.focus.focused() == Some(target);
+        let style = if focused {
+            Style::new()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::new().fg(Color::White).bg(Color::DarkGray)
+        };
+        frame.render_widget(
+            Paragraph::new(button.label())
+                .centered()
+                .style(style)
+                .block(Block::new().borders(Borders::ALL)),
+            area,
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum PromptTarget {
+    Backdrop,
+    Button(PromptButton),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum PromptButton {
+    Cancel,
+    Confirm,
+}
+
+impl PromptButton {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Cancel => "cancel",
+            Self::Confirm => "confirm",
+        }
+    }
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/modal_shell.rs
+++ b/crates/ratatui-layout/examples/modal_shell.rs
@@ -1,0 +1,217 @@
+//! Build a modal shell, then merge child button targets into it.
+//!
+//! `ModalShell` solves the centered dialog area, padded content area, and optional backdrop target.
+//! The app still chooses the form fields, buttons, styles, and whether an outside click dismisses
+//! the dialog.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui_layout::action::ActionSurface;
+use ratatui_layout::container::Padding;
+use ratatui_layout::focus::{FocusFallback, FocusState};
+use ratatui_layout::frame::FrameSnapshot;
+use ratatui_layout::modal::ModalShell;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+fn run() -> Result<()> {
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    open: bool,
+    message: &'static str,
+    focus: FocusState<Target>,
+    previous_frame: FrameSnapshot<Target>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            open: true,
+            message: "modal open; click outside to cancel",
+            focus: FocusState::default(),
+            previous_frame: FrameSnapshot::new(Rect::default()),
+        }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        self.render_page(frame);
+        self.previous_frame = FrameSnapshot::new(frame.area());
+        if self.open {
+            self.previous_frame = self.render_modal(frame);
+        }
+    }
+
+    fn render_page(&self, frame: &mut Frame) {
+        let [body, status] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(frame.area());
+        frame.render_widget(
+            Paragraph::new("release action pending\n\npress o to reopen, q to quit").block(
+                Block::new()
+                    .borders(Borders::ALL)
+                    .title("page behind modal"),
+            ),
+            body,
+        );
+        frame.render_widget(Paragraph::new(self.message), status);
+    }
+
+    fn render_modal(&mut self, frame: &mut Frame) -> FrameSnapshot<Target> {
+        let modal = ModalShell::new(44, 9)
+            .padding(Padding::new(2, 2, 2, 1))
+            .backdrop(Target::Backdrop)
+            .layout(frame.area());
+        let [question, buttons] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(modal.inner());
+        let button_slots = [
+            (Target::Cancel, Constraint::Length(10)),
+            (Target::Confirm, Constraint::Length(12)),
+        ];
+        let button_layout = ActionSurface::horizontal(button_slots)
+            .spacing(2)
+            .flex(Flex::Center)
+            .focus_start(100)
+            .z(101)
+            .layout(buttons);
+        let child_frame = button_layout.clone().into_frame();
+        let next_frame = modal.clone().merge_child(child_frame);
+        self.focus
+            .ensure_visible(&next_frame.focus, FocusFallback::First);
+
+        frame.render_widget(Clear, modal.outer());
+        frame.render_widget(
+            Block::new().borders(Borders::ALL).title("modal shell"),
+            modal.outer(),
+        );
+        frame.render_widget(Paragraph::new("Ship this release?").centered(), question);
+        for region in button_layout.regions().regions() {
+            self.render_button(frame, region.id, region.area);
+        }
+
+        next_frame
+    }
+
+    fn render_button(&self, frame: &mut Frame, target: Target, area: Rect) {
+        let focused = self.focus.focused() == Some(target);
+        let style = if focused {
+            Style::new()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::new().fg(Color::White).bg(Color::DarkGray)
+        };
+        frame.render_widget(Paragraph::new(target.label()).centered().style(style), area);
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        if self.open {
+            self.handle_modal_key(key);
+            return true;
+        }
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => false,
+            KeyCode::Char('o') => {
+                self.open_modal();
+                true
+            }
+            _ => true,
+        }
+    }
+
+    fn handle_modal_key(&mut self, key: KeyCode) {
+        match key {
+            KeyCode::Esc => self.cancel("cancelled with Esc"),
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Tab => {
+                self.focus.next(&self.previous_frame.focus);
+            }
+            KeyCode::Char('h') | KeyCode::Left | KeyCode::BackTab => {
+                self.focus.previous(&self.previous_frame.focus);
+            }
+            KeyCode::Char(' ') | KeyCode::Enter => {
+                if let Some(target) = self.focus.focused() {
+                    self.activate(target);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        if !self.open || !matches!(mouse.kind, MouseEventKind::Down(_)) {
+            return;
+        }
+        if let Some(hit) = self.previous_frame.route_click((mouse.column, mouse.row)) {
+            self.activate(hit.id);
+        }
+    }
+
+    fn activate(&mut self, target: Target) {
+        match target {
+            Target::Backdrop | Target::Cancel => self.cancel("modal cancelled"),
+            Target::Confirm => {
+                self.open = false;
+                self.message = "release confirmed";
+                self.focus.clear();
+            }
+        }
+    }
+
+    fn cancel(&mut self, message: &'static str) {
+        self.open = false;
+        self.message = message;
+        self.focus.clear();
+    }
+
+    const fn open_modal(&mut self) {
+        self.open = true;
+        self.message = "modal open; click outside to cancel";
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Target {
+    Backdrop,
+    Cancel,
+    Confirm,
+}
+
+impl Target {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Backdrop => "",
+            Self::Cancel => "cancel",
+            Self::Confirm => "confirm",
+        }
+    }
+}

--- a/crates/ratatui-layout/examples/pointer_only_scroll_region.rs
+++ b/crates/ratatui-layout/examples/pointer_only_scroll_region.rs
@@ -1,0 +1,216 @@
+//! Route wheel input with `PointerTargets` instead of a full `FrameSnapshot`.
+//!
+//! A scrollable pane often needs only one previous-frame value: which pane was under the pointer
+//! when the wheel event arrived. This example stores a `PointerTargets` with one whole-region
+//! target per pane. The app owns scroll offsets, and `ScrollMetrics` handles the render-time range
+//! math.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::pointer::PointerTargets;
+use ratatui_layout::scroll::ScrollMetrics;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+/// Runs the terminal event loop.
+///
+/// Rendering rebuilds the pointer target collection from the current pane rectangles. Mouse-wheel
+/// events then use that stored plan to choose which persistent offset should change.
+fn run() -> Result<()> {
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !App::should_continue(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+/// Persistent app state for two independently scrollable panes.
+#[derive(Debug)]
+struct App {
+    /// Scroll offset for the queue pane.
+    queue_offset: u32,
+    /// Scroll offset for the log pane.
+    log_offset: u32,
+    /// Mouse data produced by the previous render.
+    previous_mouse: PointerTargets<Pane>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            queue_offset: 0,
+            log_offset: 0,
+            previous_mouse: PointerTargets::new(),
+        }
+    }
+}
+
+impl App {
+    /// Renders panes and stores whole-pane mouse targets for the next wheel event.
+    fn render(&mut self, frame: &mut Frame) {
+        let pane_constraints = [Constraint::Percentage(50), Constraint::Percentage(50)];
+        let panes = Layout::horizontal(pane_constraints)
+            .spacing(1)
+            .split(frame.area());
+
+        self.render_pane(frame, panes[0], Pane::Queue);
+        self.render_pane(frame, panes[1], Pane::Log);
+        self.previous_mouse = PointerTargets::new()
+            .region(Pane::Queue, panes[0])
+            .region(Pane::Log, panes[1]);
+    }
+
+    /// Returns whether the app should keep running for a key press.
+    const fn should_continue(key: KeyCode) -> bool {
+        !matches!(key, KeyCode::Char('q') | KeyCode::Esc)
+    }
+
+    /// Applies wheel movement to the pane under the pointer.
+    ///
+    /// The wheel changes only scroll offset. It does not move selection, focus, or any richer frame
+    /// aggregate because this surface does not need that data.
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        let delta = match mouse.kind {
+            MouseEventKind::ScrollDown => 1,
+            MouseEventKind::ScrollUp => -1,
+            _ => return,
+        };
+        let position = (mouse.column, mouse.row);
+        let Some(hit) = self.previous_mouse.hit_test(position) else {
+            return;
+        };
+        self.scroll(hit.id, delta);
+    }
+
+    /// Scrolls one pane by a signed line delta.
+    const fn scroll(&mut self, pane: Pane, delta: i32) {
+        let offset = match pane {
+            Pane::Queue => &mut self.queue_offset,
+            Pane::Log => &mut self.log_offset,
+        };
+        *offset = offset.saturating_add_signed(delta);
+    }
+
+    /// Renders one pane from its persistent scroll offset.
+    fn render_pane(&mut self, frame: &mut Frame, area: Rect, pane: Pane) {
+        let offset = self.offset_mut(pane);
+        let inner = inner_area(area);
+        let content_height = inner.height.saturating_sub(1);
+        let metrics = ScrollMetrics::new(pane.rows().len() as u32, content_height, *offset);
+        *offset = metrics.offset;
+
+        frame.render_widget(Block::new().borders(Borders::ALL).title(pane.title()), area);
+        for (line, row) in pane.rows()[metrics.visible_range()].iter().enumerate() {
+            let row_area = Rect::new(inner.x, inner.y + line as u16, inner.width, 1);
+            frame.render_widget(Paragraph::new(*row), row_area);
+        }
+        let status = format!(
+            "wheel scroll only    offset {} / {}",
+            metrics.offset, metrics.max_offset
+        );
+        let status_area = Rect::new(inner.x, inner.bottom().saturating_sub(1), inner.width, 1);
+        frame.render_widget(Paragraph::new(status), status_area);
+    }
+
+    /// Returns mutable scroll offset storage for a pane.
+    const fn offset_mut(&mut self, pane: Pane) -> &mut u32 {
+        match pane {
+            Pane::Queue => &mut self.queue_offset,
+            Pane::Log => &mut self.log_offset,
+        }
+    }
+}
+
+/// Scrollable pane ids used by the pointer target collection.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Pane {
+    /// Work queue pane.
+    Queue,
+    /// Activity log pane.
+    Log,
+}
+
+impl Pane {
+    /// Returns the pane title.
+    const fn title(self) -> &'static str {
+        match self {
+            Self::Queue => "queue",
+            Self::Log => "log",
+        }
+    }
+
+    /// Returns the static rows rendered by the pane.
+    const fn rows(self) -> &'static [&'static str] {
+        match self {
+            Self::Queue => &QUEUE_ROWS,
+            Self::Log => &LOG_ROWS,
+        }
+    }
+}
+
+/// Returns the drawable interior of a bordered pane.
+const fn inner_area(area: Rect) -> Rect {
+    Rect::new(
+        area.x + 1,
+        area.y + 1,
+        area.width.saturating_sub(2),
+        area.height.saturating_sub(2),
+    )
+}
+
+const QUEUE_ROWS: [&str; 14] = [
+    "build api",
+    "build worker",
+    "publish docs",
+    "promote cache",
+    "drain queue",
+    "validate backup",
+    "check migrations",
+    "stage release",
+    "run smoke tests",
+    "notify on-call",
+    "verify dashboards",
+    "tag release",
+    "archive bundle",
+    "close window",
+];
+
+const LOG_ROWS: [&str; 16] = [
+    "feed imported",
+    "inputs normalized",
+    "checks started",
+    "cache warmed",
+    "worker heartbeat",
+    "doc publish queued",
+    "release window open",
+    "operator acknowledged",
+    "traffic split updated",
+    "metrics stable",
+    "rollback plan ready",
+    "handoff complete",
+    "release tagged",
+    "artifact mirrored",
+    "status broadcast",
+    "cleanup complete",
+];

--- a/crates/ratatui-layout/examples/pointer_targets.rs
+++ b/crates/ratatui-layout/examples/pointer_targets.rs
@@ -1,0 +1,204 @@
+//! Route hover, press, release, disabled controls, and overlays through one pointer target
+//! collection.
+//!
+//! Ratatui can draw overlapping rectangles, but it does not remember which app control owned each
+//! rectangle after the frame is gone. This example stores `PointerTargets` from the last render
+//! pass, so the next mouse event can route through z-order and disabled-state rules.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::pointer::{PointerPhase, PointerState, PointerTarget, PointerTargets};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+fn run() -> Result<()> {
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    enabled: bool,
+    mouse: PointerState<Target>,
+    previous_mouse: PointerTargets<Target>,
+    message: String,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            mouse: PointerState::default(),
+            previous_mouse: PointerTargets::new(),
+            message: String::from("move or click; d toggles the disabled target"),
+        }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let area = centered(frame.area(), 54, 9);
+        let [buttons, status] =
+            Layout::vertical([Constraint::Length(5), Constraint::Length(1)]).areas(area);
+        let button_areas = Layout::horizontal([
+            Constraint::Length(16),
+            Constraint::Length(16),
+            Constraint::Length(16),
+        ])
+        .spacing(1)
+        .flex(Flex::Center)
+        .split(buttons);
+
+        self.previous_mouse = PointerTargets::from_targets([
+            PointerTarget::new(Target::Open, button_areas[0]),
+            PointerTarget::new(Target::Save, button_areas[1]).disabled(!self.enabled),
+            PointerTarget::new(Target::Overlay, overlay_area(buttons)).z(10),
+            PointerTarget::new(Target::Close, button_areas[2]),
+        ]);
+
+        frame.render_widget(
+            Block::new().borders(Borders::ALL).title("mouse targets"),
+            area,
+        );
+        self.render_button(frame, Target::Open, button_areas[0]);
+        self.render_button(frame, Target::Save, button_areas[1]);
+        self.render_button(frame, Target::Close, button_areas[2]);
+        frame.render_widget(
+            Paragraph::new("z=10 overlay").centered().style(
+                Style::new()
+                    .fg(Color::Black)
+                    .bg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            overlay_area(buttons),
+        );
+        frame.render_widget(Paragraph::new(self.message.as_str()), status);
+    }
+
+    const fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Char('d') => self.enabled = !self.enabled,
+            _ => {}
+        }
+        true
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        let position = (mouse.column, mouse.row);
+        let Some(phase) = pointer_phase(mouse.kind) else {
+            return;
+        };
+        let hit = self.mouse.route(&self.previous_mouse, position, phase);
+        match (phase, hit) {
+            (PointerPhase::Hover, Some(hit)) => {
+                self.message = format!(
+                    "hover {:?} at local {},{}",
+                    hit.id, hit.relative_x, hit.relative_y
+                );
+            }
+            (PointerPhase::Press, Some(hit)) => {
+                self.message = format!("pressed {:?}", hit.id);
+            }
+            (PointerPhase::Release, Some(hit)) => {
+                self.message = format!(
+                    "clicked {:?} at local {},{}",
+                    hit.id, hit.relative_x, hit.relative_y
+                );
+            }
+            (PointerPhase::Release, None) => {
+                self.message = String::from("release did not match the pressed target");
+            }
+            (PointerPhase::Hover | PointerPhase::Press, None) => {}
+        }
+    }
+
+    fn render_button(&self, frame: &mut Frame, target: Target, area: Rect) {
+        let disabled = target == Target::Save && !self.enabled;
+        let style = if disabled {
+            Style::new().fg(Color::DarkGray)
+        } else if self.mouse.hovered() == Some(target) {
+            Style::new().fg(Color::Black).bg(Color::Cyan)
+        } else {
+            Style::new().fg(Color::White)
+        };
+        frame.render_widget(
+            Paragraph::new(target.label())
+                .centered()
+                .style(style)
+                .block(Block::new().borders(Borders::ALL).title(if disabled {
+                    "disabled"
+                } else {
+                    ""
+                })),
+            area,
+        );
+    }
+}
+
+const fn pointer_phase(kind: MouseEventKind) -> Option<PointerPhase> {
+    match kind {
+        MouseEventKind::Moved => Some(PointerPhase::Hover),
+        MouseEventKind::Down(_) => Some(PointerPhase::Press),
+        MouseEventKind::Up(_) => Some(PointerPhase::Release),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Target {
+    Open,
+    Save,
+    Close,
+    Overlay,
+}
+
+impl Target {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Save => "save",
+            Self::Close => "close",
+            Self::Overlay => "overlay",
+        }
+    }
+}
+
+const fn overlay_area(area: Rect) -> Rect {
+    Rect::new(area.x + 20, area.y + 1, 14, 3)
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/profile_editor.rs
+++ b/crates/ratatui-layout/examples/profile_editor.rs
@@ -1,0 +1,743 @@
+//! Edit a saved connection profile through a pending draft.
+//!
+//! This example shows the form flow that appears in many TUIs: copy a saved value into editable
+//! fields, let the user move between fields and buttons, validate the draft, and only apply the
+//! draft when Save is activated. `ratatui-layout` supplies the planned regions, focus repair,
+//! button-row movement, and text-field cursor mechanics. The application still owns the domain
+//! data and chooses the rendering style.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui_layout::cursor::CursorRequests;
+use ratatui_layout::focus::{FocusFallback, FocusState, FocusTarget, FocusTargets};
+use ratatui_layout::input::{ButtonRow, TextFieldState};
+use ratatui_layout::linear::{Column, Row};
+use ratatui_layout::regions::Regions;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && !app.handle_key(key.code)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+/// Application state for the whole editor.
+///
+/// The saved profile is the committed value. The draft is the editable buffer. Field and button
+/// state only store control mechanics, so Save and Cancel stay ordinary domain actions.
+#[derive(Debug)]
+struct App {
+    /// Last committed value shown in the summary row.
+    saved: Profile,
+    /// Pending user edits that can be saved or discarded.
+    draft: ProfileDraft,
+    /// Cursor positions for each editable string in the draft.
+    fields: FieldStates,
+    /// App-level focus, using one id enum for fields and commands.
+    focus: FocusState<Target>,
+    /// Row-local focus for the horizontal command buttons.
+    buttons: ButtonRow<Command>,
+    /// Focus data produced by the previous render and used by the next key event.
+    focus_plan: FocusTargets<Target>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        let saved = Profile::example();
+        let draft = ProfileDraft::from_profile(&saved);
+        Self {
+            fields: FieldStates::from_draft(&draft),
+            saved,
+            draft,
+            focus: FocusState::default(),
+            buttons: ButtonRow::new(Command::ALL),
+            focus_plan: FocusTargets::new(),
+        }
+    }
+}
+
+impl App {
+    /// Renders the current frame and stores the focus target data needed by the next input event.
+    ///
+    /// The render pass owns geometry. It computes field and button regions, builds a focus target
+    /// collection from those regions, repairs stale focus, and then draws the domain state into
+    /// the planned areas.
+    fn render(&mut self, frame: &mut Frame) {
+        let areas = PageAreas::new(frame.area());
+        let field_plan = areas.field_plan();
+        let button_plan = areas.button_plan();
+        let validation = self.draft.validate_against(&self.saved);
+
+        self.focus_plan = Self::build_focus_plan(&field_plan, &button_plan, validation);
+        self.focus
+            .ensure_visible(&self.focus_plan, FocusFallback::First);
+        self.sync_button_focus();
+
+        frame.render_widget(Clear, areas.panel);
+        let block = Block::new()
+            .borders(Borders::ALL)
+            .title("connection profile");
+        frame.render_widget(block, areas.panel);
+        self.render_summary(frame, areas.summary);
+        self.render_fields(frame, &field_plan);
+        Self::render_validation(frame, areas.validation, validation);
+        self.render_buttons(frame, &button_plan, validation);
+        self.place_cursor(frame, &field_plan);
+    }
+
+    /// Routes one key press to the current focus target.
+    ///
+    /// Fields use ordinary text editing keys. Buttons use left/right movement. Tab and vertical
+    /// movement traverse the app-level focus target collection that was produced by the last
+    /// render.
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Esc => return self.escape(),
+            KeyCode::Tab | KeyCode::Down => self.focus.next(&self.focus_plan),
+            KeyCode::BackTab | KeyCode::Up => self.focus.previous(&self.focus_plan),
+            KeyCode::Left => self.move_left(),
+            KeyCode::Right => self.move_right(),
+            KeyCode::Home => self.edit_focused(Edit::Home),
+            KeyCode::End => self.edit_focused(Edit::End),
+            KeyCode::Backspace => self.edit_focused(Edit::Backspace),
+            KeyCode::Delete => self.edit_focused(Edit::Delete),
+            KeyCode::Enter => self.activate_focused(),
+            KeyCode::Char(ch) => self.edit_focused(Edit::Insert(ch)),
+            _ => {}
+        }
+        true
+    }
+
+    /// Cancels dirty edits, or exits when there is nothing left to discard.
+    fn escape(&mut self) -> bool {
+        if self.draft.changed_from(&self.saved) {
+            self.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Moves left inside a field or to the previous enabled command in the button row.
+    fn move_left(&mut self) {
+        match self.focus.focused() {
+            Some(Target::Field(_)) => self.edit_focused(Edit::Left),
+            Some(Target::Command(_)) => self.move_button(Direction::Previous),
+            None => {}
+        }
+    }
+
+    /// Moves right inside a field or to the next enabled command in the button row.
+    fn move_right(&mut self) {
+        match self.focus.focused() {
+            Some(Target::Field(_)) => self.edit_focused(Edit::Right),
+            Some(Target::Command(_)) => self.move_button(Direction::Next),
+            None => {}
+        }
+    }
+
+    /// Moves button-row focus while skipping disabled commands.
+    ///
+    /// `ButtonRow` knows only left-to-right movement. The app applies the domain rule that Save is
+    /// unavailable until the draft is valid and changed.
+    fn move_button(&mut self, direction: Direction) {
+        let button_count = self.buttons.ids().len();
+        for _ in 0..button_count {
+            match direction {
+                Direction::Previous => self.buttons.move_previous(),
+                Direction::Next => self.buttons.move_next(),
+            }
+
+            let Some(command) = self.buttons.focused_id() else {
+                return;
+            };
+            if self.command_enabled(command) {
+                self.focus.focus(Some(Target::Command(command)));
+                return;
+            }
+        }
+    }
+
+    /// Applies a text-edit command to the currently focused field.
+    fn edit_focused(&mut self, edit: Edit) {
+        let Some(Target::Field(field)) = self.focus.focused() else {
+            return;
+        };
+
+        let value = self.draft.value_mut(field);
+        let state = self.fields.state_mut(field);
+        edit.apply(state, value);
+    }
+
+    /// Activates the focused field or command.
+    ///
+    /// Enter advances out of a field, activates Cancel, or attempts Save. Save performs its own
+    /// validation check because disabled focus is a UI affordance, not the domain guard.
+    fn activate_focused(&mut self) {
+        match self.focus.focused() {
+            Some(Target::Field(_)) => self.focus.next(&self.focus_plan),
+            Some(Target::Command(Command::Cancel)) => self.cancel(),
+            Some(Target::Command(Command::Save)) => self.save(),
+            None => {}
+        }
+    }
+
+    /// Restores the draft and field cursors from the saved profile.
+    fn cancel(&mut self) {
+        self.draft = ProfileDraft::from_profile(&self.saved);
+        self.fields = FieldStates::from_draft(&self.draft);
+    }
+
+    /// Commits a valid draft to the saved profile.
+    fn save(&mut self) {
+        if !self.draft.validate_against(&self.saved).save_enabled {
+            return;
+        }
+        self.draft.apply_to(&mut self.saved);
+        self.fields = FieldStates::from_draft(&self.draft);
+    }
+
+    /// Returns whether a command can currently be focused or activated.
+    fn command_enabled(&self, command: Command) -> bool {
+        match command {
+            Command::Cancel => true,
+            Command::Save => self.draft.validate_against(&self.saved).save_enabled,
+        }
+    }
+
+    /// Keeps row-local button focus aligned with app-level focus.
+    ///
+    /// This lets Tab move into the command row while left/right still use `ButtonRow`.
+    fn sync_button_focus(&mut self) {
+        if let Some(Target::Command(command)) = self.focus.focused() {
+            self.buttons.focus_id(&command);
+        }
+    }
+
+    /// Builds app-level focus from field regions and button regions.
+    ///
+    /// Field regions map directly into `Target::Field`. Button regions are rebuilt as focus targets
+    /// so the Save command can stay visible while being skipped by traversal.
+    fn build_focus_plan(
+        fields: &Regions<Field>,
+        buttons: &Regions<Command>,
+        validation: Validation,
+    ) -> FocusTargets<Target> {
+        let field_slots = fields.regions().iter().copied();
+        let field_focus = FocusTargets::from_regions(field_slots).map_id(Target::Field);
+        let button_targets = buttons
+            .iter()
+            .enumerate()
+            .map(|(index, region)| {
+                let command = region.id;
+                let disabled = command == Command::Save && !validation.save_enabled;
+                let order = Field::ALL.len() as u16 + index as u16;
+                FocusTarget::new(Target::Command(command), region.area, order).disabled(disabled)
+            })
+            .collect::<Vec<_>>();
+        let button_focus = FocusTargets::from_targets(button_targets);
+        field_focus.merge(button_focus)
+    }
+
+    /// Renders the committed value so the draft/save relationship is visible.
+    fn render_summary(&self, frame: &mut Frame, area: Rect) {
+        let text = format!(
+            "saved: {}@{}:{}/{}",
+            self.saved.name, self.saved.host, self.saved.port, self.saved.database
+        );
+        frame.render_widget(
+            Paragraph::new(text).style(Style::new().fg(Color::Gray)),
+            area,
+        );
+    }
+
+    /// Renders every planned field region.
+    fn render_fields(&self, frame: &mut Frame, plan: &Regions<Field>) {
+        for field in Field::ALL {
+            let Some(area) = plan.area_for(field) else {
+                continue;
+            };
+            self.render_field(frame, area, field);
+        }
+    }
+
+    /// Renders one label/value row and highlights the focused editable value.
+    fn render_field(&self, frame: &mut Frame, area: Rect, field: Field) {
+        let text = format!("{}: {}", field.label(), self.draft.value(field));
+        let style = match self.focus.focused() {
+            Some(Target::Field(focused)) if focused == field => Style::new()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+            _ => Style::new(),
+        };
+        frame.render_widget(Paragraph::new(text).style(style), area);
+    }
+
+    /// Renders the validation message that explains whether Save is available.
+    fn render_validation(frame: &mut Frame, area: Rect, validation: Validation) {
+        let style = if validation.save_enabled {
+            Style::new().fg(Color::Green)
+        } else {
+            Style::new().fg(Color::Yellow)
+        };
+        frame.render_widget(Paragraph::new(validation.message).style(style), area);
+    }
+
+    /// Renders the command row from its planned button regions.
+    fn render_buttons(&self, frame: &mut Frame, plan: &Regions<Command>, validation: Validation) {
+        for command in Command::ALL {
+            let Some(area) = plan.area_for(command) else {
+                continue;
+            };
+            self.render_button(frame, area, command, validation);
+        }
+    }
+
+    /// Renders one command button with enabled, disabled, and focused states.
+    fn render_button(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        command: Command,
+        validation: Validation,
+    ) {
+        let enabled = command != Command::Save || validation.save_enabled;
+        let focused = self.focus.focused() == Some(Target::Command(command));
+        let style = match (enabled, focused) {
+            (false, _) => Style::new().fg(Color::DarkGray).bg(Color::Black),
+            (true, true) => Style::new()
+                .fg(Color::Black)
+                .bg(command.selected_color())
+                .add_modifier(Modifier::BOLD),
+            (true, false) => Style::new().fg(Color::Black).bg(command.color()),
+        };
+        frame.render_widget(Paragraph::new(command.label()).style(style), area);
+    }
+
+    /// Places the terminal cursor at the focused field's text cursor.
+    ///
+    /// `TextFieldState` stores a character index. The cursor request combines that index with the
+    /// field's rendered label prefix and current frame area.
+    fn place_cursor(&self, frame: &mut Frame, plan: &Regions<Field>) {
+        let Some(Target::Field(field)) = self.focus.focused() else {
+            return;
+        };
+        let Some(area) = plan.area_for(field) else {
+            return;
+        };
+        let request = self
+            .fields
+            .state(field)
+            .cursor_request_after_prefix(area, field.prefix_width());
+        if let Some(cursor) = CursorRequests::new().request(request).final_cursor() {
+            frame.set_cursor_position(cursor.position);
+        }
+    }
+}
+
+/// Committed connection settings.
+///
+/// A real app would load this from disk or a service. Keeping it separate from `ProfileDraft` shows
+/// how a form can edit safely without mutating committed data on every key press.
+#[derive(Debug, Clone)]
+struct Profile {
+    /// Display name for the connection.
+    name: String,
+    /// Hostname or address.
+    host: String,
+    /// Validated numeric port.
+    port: u16,
+    /// Database name.
+    database: String,
+}
+
+impl Profile {
+    /// Builds the initial saved profile used by the example.
+    fn example() -> Self {
+        Self {
+            name: "release-bot".into(),
+            host: "db.internal".into(),
+            port: 5432,
+            database: "ratatui".into(),
+        }
+    }
+}
+
+/// Editable copy of a [`Profile`].
+///
+/// The port is a string here because users can temporarily type invalid text. Validation decides
+/// when that draft can be converted back into the committed domain value.
+#[derive(Debug, Clone)]
+struct ProfileDraft {
+    /// Editable profile name.
+    name: String,
+    /// Editable host.
+    host: String,
+    /// Editable port text, which may be invalid while typing.
+    port: String,
+    /// Editable database name.
+    database: String,
+}
+
+impl ProfileDraft {
+    /// Copies a committed profile into an editable draft.
+    fn from_profile(profile: &Profile) -> Self {
+        Self {
+            name: profile.name.clone(),
+            host: profile.host.clone(),
+            port: profile.port.to_string(),
+            database: profile.database.clone(),
+        }
+    }
+
+    /// Returns the string value for a field.
+    ///
+    /// Rendering and cursor placement use this read-only path.
+    fn value(&self, field: Field) -> &str {
+        match field {
+            Field::Name => &self.name,
+            Field::Host => &self.host,
+            Field::Port => &self.port,
+            Field::Database => &self.database,
+        }
+    }
+
+    /// Returns the mutable string value for a field.
+    ///
+    /// Text editing uses this to keep field state and domain draft state separate but adjacent.
+    const fn value_mut(&mut self, field: Field) -> &mut String {
+        match field {
+            Field::Name => &mut self.name,
+            Field::Host => &mut self.host,
+            Field::Port => &mut self.port,
+            Field::Database => &mut self.database,
+        }
+    }
+
+    /// Validates the draft and reports whether Save should be enabled.
+    ///
+    /// The same result drives both the status text and the disabled Save focus target.
+    fn validate_against(&self, saved: &Profile) -> Validation {
+        if self.name.trim().is_empty() {
+            return Validation::disabled("name is required");
+        }
+        if self.host.trim().is_empty() {
+            return Validation::disabled("host is required");
+        }
+        if !self.port_is_valid() {
+            return Validation::disabled("port must be 1-65535");
+        }
+        if self.database.trim().is_empty() {
+            return Validation::disabled("database is required");
+        }
+        if !self.changed_from(saved) {
+            return Validation::disabled("no pending changes");
+        }
+        Validation::enabled("ready to save")
+    }
+
+    /// Returns whether the port can become the committed numeric port.
+    fn port_is_valid(&self) -> bool {
+        self.port.parse::<u16>().is_ok_and(|port| port > 0)
+    }
+
+    /// Returns whether the draft differs from the committed profile.
+    fn changed_from(&self, saved: &Profile) -> bool {
+        self.name != saved.name
+            || self.host != saved.host
+            || self.database != saved.database
+            || self.port.parse::<u16>().ok() != Some(saved.port)
+    }
+
+    /// Applies a previously validated draft to the committed profile.
+    fn apply_to(&self, profile: &mut Profile) {
+        profile.name.clone_from(&self.name);
+        profile.host.clone_from(&self.host);
+        profile.port = self.port.parse::<u16>().unwrap_or(profile.port);
+        profile.database.clone_from(&self.database);
+    }
+}
+
+/// Result of validating a draft for display and command availability.
+#[derive(Debug, Clone, Copy)]
+struct Validation {
+    /// Whether the Save command should be focusable and actionable.
+    save_enabled: bool,
+    /// Short status text shown below the fields.
+    message: &'static str,
+}
+
+impl Validation {
+    /// Creates a validation result that enables Save.
+    const fn enabled(message: &'static str) -> Self {
+        Self {
+            save_enabled: true,
+            message,
+        }
+    }
+
+    /// Creates a validation result that keeps Save visible but disabled.
+    const fn disabled(message: &'static str) -> Self {
+        Self {
+            save_enabled: false,
+            message,
+        }
+    }
+}
+
+/// Editable fields in visual traversal order.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Field {
+    /// Profile display name.
+    Name,
+    /// Hostname or address.
+    Host,
+    /// Port text.
+    Port,
+    /// Database name.
+    Database,
+}
+
+impl Field {
+    /// All fields in top-to-bottom render and focus order.
+    const ALL: [Self; 4] = [Self::Name, Self::Host, Self::Port, Self::Database];
+
+    /// Returns the label rendered before the editable value.
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Name => "name",
+            Self::Host => "host",
+            Self::Port => "port",
+            Self::Database => "database",
+        }
+    }
+
+    /// Returns the terminal width before editable text begins.
+    const fn prefix_width(self) -> u16 {
+        self.label().len() as u16 + 2
+    }
+}
+
+/// Commands in the bottom button row.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Command {
+    /// Discard pending edits.
+    Cancel,
+    /// Commit a valid changed draft.
+    Save,
+}
+
+impl Command {
+    /// All commands in left-to-right render and movement order.
+    const ALL: [Self; 2] = [Self::Cancel, Self::Save];
+
+    /// Returns the rendered button text, including horizontal padding.
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Cancel => " cancel ",
+            Self::Save => " save ",
+        }
+    }
+
+    /// Returns the base background color for an enabled button.
+    const fn color(self) -> Color {
+        match self {
+            Self::Cancel => Color::DarkGray,
+            Self::Save => Color::Green,
+        }
+    }
+
+    /// Returns the brighter background color for a focused button.
+    const fn selected_color(self) -> Color {
+        match self {
+            Self::Cancel => Color::Gray,
+            Self::Save => Color::LightGreen,
+        }
+    }
+}
+
+/// App-level focus target.
+///
+/// A single focus id lets vertical traversal move through fields and then into the horizontal
+/// command row. The inner ids stay domain-specific.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Target {
+    /// One editable field row.
+    Field(Field),
+    /// One command button.
+    Command(Command),
+}
+
+/// Horizontal movement direction for the command row.
+#[derive(Debug, Clone, Copy)]
+enum Direction {
+    /// Move to the previous enabled command.
+    Previous,
+    /// Move to the next enabled command.
+    Next,
+}
+
+/// Text edit operation routed to the focused field.
+#[derive(Debug, Clone, Copy)]
+enum Edit {
+    /// Insert one character at the field cursor.
+    Insert(char),
+    /// Delete the character before the field cursor.
+    Backspace,
+    /// Delete the character under the field cursor.
+    Delete,
+    /// Move the field cursor one character left.
+    Left,
+    /// Move the field cursor one character right.
+    Right,
+    /// Move the field cursor to the start.
+    Home,
+    /// Move the field cursor to the end.
+    End,
+}
+
+impl Edit {
+    /// Applies the edit to a cursor state and its externally owned value.
+    fn apply(self, field: &mut TextFieldState, value: &mut String) {
+        match self {
+            Self::Insert(ch) => field.insert_char(value, ch),
+            Self::Backspace => field.backspace(value),
+            Self::Delete => field.delete(value),
+            Self::Left => field.move_left(),
+            Self::Right => field.move_right(value),
+            Self::Home => field.move_home(),
+            Self::End => field.move_end(value),
+        }
+    }
+}
+
+/// Cursor state for each field in the draft.
+///
+/// This mirrors the draft fields because `TextFieldState` deliberately owns only cursor position,
+/// not the text itself.
+#[derive(Debug, Clone)]
+struct FieldStates {
+    /// Cursor state for [`Field::Name`].
+    name: TextFieldState,
+    /// Cursor state for [`Field::Host`].
+    host: TextFieldState,
+    /// Cursor state for [`Field::Port`].
+    port: TextFieldState,
+    /// Cursor state for [`Field::Database`].
+    database: TextFieldState,
+}
+
+impl FieldStates {
+    /// Creates field states with each cursor at the end of its current draft value.
+    fn from_draft(draft: &ProfileDraft) -> Self {
+        Self {
+            name: TextFieldState::at_end(&draft.name),
+            host: TextFieldState::at_end(&draft.host),
+            port: TextFieldState::at_end(&draft.port),
+            database: TextFieldState::at_end(&draft.database),
+        }
+    }
+
+    /// Returns a copy of the state for rendering cursor placement.
+    const fn state(&self, field: Field) -> TextFieldState {
+        match field {
+            Field::Name => self.name,
+            Field::Host => self.host,
+            Field::Port => self.port,
+            Field::Database => self.database,
+        }
+    }
+
+    /// Returns mutable state for editing the focused field.
+    const fn state_mut(&mut self, field: Field) -> &mut TextFieldState {
+        match field {
+            Field::Name => &mut self.name,
+            Field::Host => &mut self.host,
+            Field::Port => &mut self.port,
+            Field::Database => &mut self.database,
+        }
+    }
+}
+
+/// Page-level areas solved before field and button values are created.
+#[derive(Debug, Clone, Copy)]
+struct PageAreas {
+    /// Outer panel containing the whole editor.
+    panel: Rect,
+    /// Summary of committed settings.
+    summary: Rect,
+    /// Area for the vertical field plan.
+    fields: Rect,
+    /// Status and validation text.
+    validation: Rect,
+    /// Area for the horizontal command plan.
+    buttons: Rect,
+}
+
+impl PageAreas {
+    /// Centers and splits the editor panel into named sections.
+    fn new(area: Rect) -> Self {
+        let panel = centered(area, 64, 14);
+        let rows = [
+            Constraint::Length(1),
+            Constraint::Length(7),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ];
+        let [summary, fields, validation, buttons] =
+            Layout::vertical(rows).margin(1).spacing(1).areas(panel);
+        Self {
+            panel,
+            summary,
+            fields,
+            validation,
+            buttons,
+        }
+    }
+
+    /// Builds typed field regions from the field section.
+    fn field_plan(self) -> Regions<Field> {
+        let rows = [
+            (Field::Name, Constraint::Length(1)),
+            (Field::Host, Constraint::Length(1)),
+            (Field::Port, Constraint::Length(1)),
+            (Field::Database, Constraint::Length(1)),
+        ];
+        Column::named(rows).spacing(1).regions(self.fields)
+    }
+
+    /// Builds typed command regions from the button section.
+    fn button_plan(self) -> Regions<Command> {
+        let buttons = [
+            (Command::Cancel, Constraint::Length(8)),
+            (Command::Save, Constraint::Length(6)),
+        ];
+        let row = Row::named(buttons).spacing(2).flex(Flex::End);
+        row.regions(self.buttons)
+    }
+}
+
+/// Centers a fixed-size rectangle inside `area`.
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/scroll_regions.rs
+++ b/crates/ratatui-layout/examples/scroll_regions.rs
@@ -1,0 +1,170 @@
+//! Route wheel events to the pane under the pointer, including blank space.
+//!
+//! Row hit testing only works when the pointer is over a row. Scrollable panes usually need the
+//! whole pane to be a wheel target, so this example stores one mouse region per pane in
+//! `FrameSnapshot`.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::frame::{FrameSnapshot, FrameTargets};
+use ratatui_layout::scroll::ScrollMetrics;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+fn run() -> Result<()> {
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !App::should_continue(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    left_offset: u32,
+    right_offset: u32,
+    previous_frame: FrameSnapshot<Pane>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            left_offset: 0,
+            right_offset: 0,
+            previous_frame: FrameSnapshot::new(Rect::default()),
+        }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let panes = Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .spacing(1)
+            .split(frame.area());
+        let left = render_pane(frame, panes[0], Pane::Builds, &mut self.left_offset);
+        let right = render_pane(frame, panes[1], Pane::Logs, &mut self.right_offset);
+        self.previous_frame = FrameSnapshot::new(frame.area()).merge(left).merge(right);
+    }
+
+    const fn should_continue(key: KeyCode) -> bool {
+        !matches!(key, KeyCode::Char('q') | KeyCode::Esc)
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        let delta = match mouse.kind {
+            MouseEventKind::ScrollDown => 1,
+            MouseEventKind::ScrollUp => -1,
+            _ => return,
+        };
+        let Some(hit) = self.previous_frame.route_scroll((mouse.column, mouse.row)) else {
+            return;
+        };
+        self.scroll(hit.id, delta);
+    }
+
+    const fn scroll(&mut self, pane: Pane, delta: i32) {
+        let offset = match pane {
+            Pane::Builds => &mut self.left_offset,
+            Pane::Logs => &mut self.right_offset,
+        };
+        *offset = offset.saturating_add_signed(delta);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Pane {
+    Builds,
+    Logs,
+}
+
+impl Pane {
+    const fn title(self) -> &'static str {
+        match self {
+            Self::Builds => "builds",
+            Self::Logs => "logs",
+        }
+    }
+
+    const fn rows(self) -> &'static [&'static str] {
+        match self {
+            Self::Builds => &BUILD_ROWS,
+            Self::Logs => &LOG_ROWS,
+        }
+    }
+}
+
+fn render_pane(frame: &mut Frame, area: Rect, pane: Pane, offset: &mut u32) -> FrameSnapshot<Pane> {
+    let inner = Rect::new(
+        area.x + 1,
+        area.y + 1,
+        area.width.saturating_sub(2),
+        area.height.saturating_sub(2),
+    );
+    let content_height = inner.height.saturating_sub(1);
+    let metrics = ScrollMetrics::new(pane.rows().len() as u32, content_height, *offset);
+    *offset = metrics.offset;
+
+    frame.render_widget(Block::new().borders(Borders::ALL).title(pane.title()), area);
+    for (line, row) in pane.rows()[metrics.visible_range()].iter().enumerate() {
+        let row_area = Rect::new(inner.x, inner.y + line as u16, inner.width, 1);
+        frame.render_widget(Paragraph::new(*row), row_area);
+    }
+    let status = format!("offset {} / {}", metrics.offset, metrics.max_offset);
+    frame.render_widget(
+        Paragraph::new(status),
+        Rect::new(inner.x, inner.bottom().saturating_sub(1), inner.width, 1),
+    );
+
+    FrameTargets::new(area, 0)
+        .mouse_region(pane, area)
+        .region(pane, area)
+}
+
+const BUILD_ROWS: [&str; 10] = [
+    "queued: api",
+    "running: worker",
+    "running: docs",
+    "blocked: gateway",
+    "done: cli",
+    "done: parser",
+    "queued: website",
+    "queued: fixtures",
+    "done: release notes",
+    "blocked: deploy",
+];
+
+const LOG_ROWS: [&str; 12] = [
+    "feed imported",
+    "inputs normalized",
+    "checks started",
+    "cache warmed",
+    "worker heartbeat",
+    "doc publish queued",
+    "release window open",
+    "operator acknowledged",
+    "traffic split updated",
+    "metrics stable",
+    "rollback plan ready",
+    "handoff complete",
+];

--- a/crates/ratatui-layout/examples/scrollable_pane.rs
+++ b/crates/ratatui-layout/examples/scrollable_pane.rs
@@ -1,0 +1,152 @@
+//! Route wheel input to a pane even when the pointer is over blank space.
+//!
+//! `ScrollablePane` computes simple fixed-row scroll metrics and creates one pointer target for the
+//! whole pane. That target lets the app scroll the viewport without changing selection.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::frame::FrameSnapshot;
+use ratatui_layout::pane::ScrollablePane;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+fn run() -> Result<()> {
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    offset: usize,
+    previous_frame: FrameSnapshot<Pane>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            offset: 0,
+            previous_frame: FrameSnapshot::new(Rect::default()),
+        }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let area = centered(frame.area(), 54, 12);
+        let inner = area.inner(ratatui::layout::Margin {
+            horizontal: 1,
+            vertical: 1,
+        });
+        let layout = ScrollablePane::new(Pane::Log).status_line(true).layout(
+            inner,
+            LOG_LINES.len(),
+            self.offset,
+        );
+        self.offset = layout.metrics().offset as usize;
+
+        frame.render_widget(
+            Block::new().borders(Borders::ALL).title("scrollable pane"),
+            area,
+        );
+        let visible = &LOG_LINES[layout.metrics().visible_range()];
+        frame.render_widget(Paragraph::new(visible.join("\n")), layout.content_area());
+        if let Some(status_area) = layout.status_area() {
+            let status = format!(
+                "rows {}..{} / {}",
+                layout.metrics().visible_range().start,
+                layout.metrics().visible_range().end,
+                LOG_LINES.len()
+            );
+            frame.render_widget(Paragraph::new(status), status_area);
+        }
+        self.previous_frame = layout.frame().clone();
+    }
+
+    const fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Char('j') | KeyCode::Down => self.scroll_by(1),
+            KeyCode::Char('k') | KeyCode::Up => self.scroll_by(-1),
+            _ => {}
+        }
+        true
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        let Some(hit) = self.previous_frame.route_scroll((mouse.column, mouse.row)) else {
+            return;
+        };
+        if hit.id != Pane::Log {
+            return;
+        }
+        match mouse.kind {
+            MouseEventKind::ScrollDown => self.scroll_by(1),
+            MouseEventKind::ScrollUp => self.scroll_by(-1),
+            _ => {}
+        }
+    }
+
+    const fn scroll_by(&mut self, delta: isize) {
+        self.offset = self.offset.saturating_add_signed(delta);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Pane {
+    Log,
+}
+
+const LOG_LINES: [&str; 18] = [
+    "feed imported",
+    "workspace inputs normalized",
+    "schema check started",
+    "cache warmup requested",
+    "worker drain rehearsed",
+    "manual approval pending",
+    "release window opened",
+    "traffic ramp at 10%",
+    "traffic ramp at 25%",
+    "traffic ramp at 50%",
+    "traffic ramp at 75%",
+    "traffic ramp complete",
+    "docs published",
+    "operator guide linked",
+    "post-release checks queued",
+    "metrics stable",
+    "archive generated",
+    "release closed",
+];
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/selection_modes.rs
+++ b/crates/ratatui-layout/examples/selection_modes.rs
@@ -1,0 +1,158 @@
+//! Compare none, single, and multi selection with the same visible ids.
+//!
+//! Selection is app state, not layout state. This example keeps the visible ids in a simple slice
+//! and lets `SelectionState` enforce how Enter and Space affect the selected commands.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::linear::Column;
+use ratatui_layout::selection::{SelectionMode, SelectionState};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && !app.handle_key(key.code)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    mode: SelectionMode,
+    cursor: usize,
+    selection: SelectionState<Item>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            mode: SelectionMode::Single,
+            cursor: 0,
+            selection: SelectionState::new(SelectionMode::Single),
+        }
+    }
+}
+
+impl App {
+    fn render(&self, frame: &mut Frame) {
+        let area = centered(frame.area(), 44, 9);
+        let rows = [Constraint::Length(1); ITEMS.len()];
+        let plan = Column::new(rows).vertical_margin(1).regions(area);
+
+        frame.render_widget(Block::new().borders(Borders::ALL).title("selection"), area);
+        for (region, item) in plan.zip_ids(&ITEMS) {
+            self.render_item(frame, item, region.area);
+        }
+        self.render_status(
+            frame,
+            Rect::new(area.x + 1, area.bottom() - 2, area.width - 2, 1),
+        );
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Char('n') => self.set_mode(SelectionMode::None),
+            KeyCode::Char('s') => self.set_mode(SelectionMode::Single),
+            KeyCode::Char('m') => self.set_mode(SelectionMode::Multi),
+            KeyCode::Char('j') | KeyCode::Down => self.move_cursor(1),
+            KeyCode::Char('k') | KeyCode::Up => self.move_cursor(-1),
+            KeyCode::Char(' ') | KeyCode::Enter => self.toggle_current(),
+            KeyCode::Char('c') => self.selection.clear(),
+            _ => {}
+        }
+        true
+    }
+
+    fn set_mode(&mut self, mode: SelectionMode) {
+        self.mode = mode;
+        self.selection.set_mode(mode);
+    }
+
+    fn move_cursor(&mut self, delta: isize) {
+        let last = ITEMS.len() - 1;
+        self.cursor = self.cursor.saturating_add_signed(delta).min(last);
+    }
+
+    fn toggle_current(&mut self) {
+        let item = ITEMS[self.cursor];
+        match self.mode {
+            SelectionMode::None | SelectionMode::Single => self.selection.select(item),
+            SelectionMode::Multi => self.selection.toggle(item),
+        }
+    }
+
+    fn render_item(&self, frame: &mut Frame, item: Item, area: Rect) {
+        let cursor = ITEMS[self.cursor] == item;
+        let selected = self.selection.is_selected(item);
+        let marker = match (cursor, selected) {
+            (true, true) => "> [x]",
+            (true, false) => "> [ ]",
+            (false, true) => "  [x]",
+            (false, false) => "  [ ]",
+        };
+        let style = if selected {
+            Style::new().fg(Color::Black).bg(Color::Green)
+        } else if cursor {
+            Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        } else {
+            Style::new().fg(Color::White)
+        };
+        frame.render_widget(
+            Paragraph::new(format!("{marker} {}", item.label())).style(style),
+            area,
+        );
+    }
+
+    fn render_status(&self, frame: &mut Frame, area: Rect) {
+        let text = format!(
+            "n none  s single  m multi  c clear   mode: {:?}  selected: {:?}",
+            self.mode,
+            self.selection.selected(),
+        );
+        frame.render_widget(Paragraph::new(text), area);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Item {
+    Build,
+    Test,
+    Package,
+    Publish,
+}
+
+impl Item {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Build => "build artifacts",
+            Self::Test => "run tests",
+            Self::Package => "package release",
+            Self::Publish => "publish notes",
+        }
+    }
+}
+
+const ITEMS: [Item; 4] = [Item::Build, Item::Test, Item::Package, Item::Publish];
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/table_inspector.rs
+++ b/crates/ratatui-layout/examples/table_inspector.rs
@@ -1,0 +1,175 @@
+//! Inspect a virtual table with app-owned cells, pinned headers, and two-axis selection.
+//!
+//! The important part is that the table owns layout policy, while `Rows` owns cell rendering. The
+//! returned `TableLayout` still exposes hit-testable cells and scroll metrics for app chrome.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Paragraph, Widget};
+use ratatui_layout::table::{
+    CellPosition, TableCellContext, TableItems, TableLayout, VirtualTable, VirtualTableState,
+};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+fn run() -> Result<()> {
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+const HEADERS: [&str; 5] = ["id", "name", "state", "owner", "age"];
+
+#[derive(Default)]
+struct App {
+    state: VirtualTableState,
+    previous_layout: Option<TableLayout>,
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        self.ensure_selection();
+        let table_area = Rect::new(
+            0,
+            0,
+            frame.area().width,
+            frame.area().height.saturating_sub(1),
+        );
+        let mut rows = Rows;
+        let layout = VirtualTable::new([
+            Constraint::Length(5),
+            Constraint::Length(18),
+            Constraint::Length(12),
+            Constraint::Length(14),
+            Constraint::Length(8),
+        ])
+        .scroll_padding(1)
+        .render(table_area, frame.buffer_mut(), &mut self.state, &mut rows);
+        self.previous_layout = Some(layout.clone());
+
+        let status = format!(
+            "row {} of {}  col {} of {}  click select  wheel scrolls rows only",
+            layout.vertical_metrics().offset + 1,
+            layout.row_count,
+            layout.horizontal_metrics().offset + 1,
+            layout.column_count,
+        );
+        let status_area = Rect::new(0, table_area.bottom(), frame.area().width, 1);
+        frame.render_widget(Paragraph::new(status), status_area);
+    }
+
+    const fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('j') | KeyCode::Down => self.move_selection(1, 0),
+            KeyCode::Char('k') | KeyCode::Up => self.move_selection(-1, 0),
+            KeyCode::Char('l') | KeyCode::Right => self.move_selection(0, 1),
+            KeyCode::Char('h') | KeyCode::Left => self.move_selection(0, -1),
+            KeyCode::Char('q') | KeyCode::Esc => return Self::quit(),
+            _ => {}
+        }
+        true
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        match mouse.kind {
+            MouseEventKind::ScrollDown => self.state.scroll_rows_by(1),
+            MouseEventKind::ScrollUp => self.state.scroll_rows_by(-1),
+            MouseEventKind::Down(_) => self.select_at((mouse.column, mouse.row)),
+            _ => {}
+        }
+    }
+
+    const fn ensure_selection(&mut self) {
+        if self.state.selected().is_none() {
+            self.state.select(Some(CellPosition::body(0, 0)));
+        }
+    }
+
+    const fn move_selection(&mut self, row_delta: isize, column_delta: isize) {
+        self.state
+            .select_relative(row_delta, column_delta, Rows::ROW_COUNT, HEADERS.len());
+    }
+
+    fn select_at(&mut self, position: (u16, u16)) {
+        if let Some(layout) = self.previous_layout.as_ref() {
+            layout.select_hit(position, &mut self.state);
+        }
+    }
+
+    const fn quit() -> bool {
+        false
+    }
+}
+
+struct Rows;
+
+impl Rows {
+    const ROW_COUNT: usize = 40;
+
+    fn cell(position: CellPosition) -> String {
+        match position.row {
+            None => HEADERS[position.column].to_string(),
+            Some(row) => match position.column {
+                0 => format!("#{row:03}"),
+                1 => format!("task-{row:02}"),
+                2 => ["queued", "running", "done", "blocked"][row % 4].to_string(),
+                3 => ["ops", "ui", "core", "docs"][row % 4].to_string(),
+                4 => format!("{}m", 3 + row * 2),
+                _ => String::new(),
+            },
+        }
+    }
+}
+
+impl TableItems for Rows {
+    fn row_count(&self) -> usize {
+        Self::ROW_COUNT
+    }
+
+    fn column_count(&self) -> usize {
+        HEADERS.len()
+    }
+
+    fn render_cell(
+        &mut self,
+        position: CellPosition,
+        area: Rect,
+        buf: &mut Buffer,
+        ctx: TableCellContext,
+    ) {
+        let header = position.row.is_none();
+        let selected = ctx.render.state.selected;
+        let style = match (header, selected) {
+            (true, _) => Style::new().add_modifier(Modifier::BOLD),
+            (false, true) => Style::new().add_modifier(Modifier::REVERSED),
+            (false, false) => Style::new(),
+        };
+        Paragraph::new(Self::cell(position))
+            .style(style)
+            .render(area, buf);
+    }
+}

--- a/crates/ratatui-layout/examples/text_input.rs
+++ b/crates/ratatui-layout/examples/text_input.rs
@@ -1,0 +1,145 @@
+//! Edit a single-line value while keeping cursor and pointer behavior aligned.
+//!
+//! The app owns the text. `TextInputState` owns only the cursor, `TextEdit` applies common edit
+//! commands, and `TextInput` produces the field target plus cursor request for the current frame.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::frame::FrameSnapshot;
+use ratatui_layout::text_input::{TextEdit, TextInput, TextInputLayout, TextInputState};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+fn run() -> Result<()> {
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    title: String,
+    state: TextInputState,
+    previous_layout: Option<TextInputLayout<Field>>,
+    previous_frame: FrameSnapshot<Field>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        let title = String::from("release train");
+        Self {
+            state: TextInputState::at_end(&title),
+            title,
+            previous_layout: None,
+            previous_frame: FrameSnapshot::new(Rect::default()),
+        }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let area = centered(frame.area(), 50, 5);
+        let field_area = area.inner(ratatui::layout::Margin {
+            horizontal: 2,
+            vertical: 2,
+        });
+        let input = TextInput::new(Field::Title).prefix_width(Field::label_width());
+        let layout = input.layout(field_area, self.state, true);
+
+        frame.render_widget(Block::new().borders(Borders::ALL).title("text input"), area);
+        self.render_field(frame, &layout);
+        if let Some(cursor) = layout.frame().cursor.final_cursor() {
+            frame.set_cursor_position(cursor.position);
+        }
+
+        self.previous_frame = layout.frame().clone();
+        self.previous_layout = Some(layout);
+    }
+
+    fn render_field(&self, frame: &mut Frame, layout: &TextInputLayout<Field>) {
+        let text = format!("{}: {}", Field::label(), self.title);
+        frame.render_widget(
+            Paragraph::new(text).style(Style::new().fg(Color::Black).bg(Color::Green)),
+            layout.area(),
+        );
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Char(character) => {
+                self.state
+                    .apply(TextEdit::Insert(character), &mut self.title);
+            }
+            KeyCode::Backspace => self.state.apply(TextEdit::Backspace, &mut self.title),
+            KeyCode::Delete => self.state.apply(TextEdit::Delete, &mut self.title),
+            KeyCode::Left => self.state.apply(TextEdit::Left, &mut self.title),
+            KeyCode::Right => self.state.apply(TextEdit::Right, &mut self.title),
+            KeyCode::Home => self.state.apply(TextEdit::Home, &mut self.title),
+            KeyCode::End => self.state.apply(TextEdit::End, &mut self.title),
+            _ => {}
+        }
+        true
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        if !matches!(mouse.kind, MouseEventKind::Down(_)) {
+            return;
+        }
+        let position = (mouse.column, mouse.row);
+        if self.previous_frame.route_click(position).is_some()
+            && let Some(layout) = &self.previous_layout
+        {
+            layout.place_cursor_from_position(position, &self.title, &mut self.state);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Field {
+    Title,
+}
+
+impl Field {
+    const fn label() -> &'static str {
+        "title"
+    }
+
+    const fn label_width() -> u16 {
+        7
+    }
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/toolbar_targets.rs
+++ b/crates/ratatui-layout/examples/toolbar_targets.rs
@@ -1,0 +1,172 @@
+//! Build toolbar regions once, then reuse them for rendering, focus, and mouse routing.
+//!
+//! Ratatui's `Layout` can split the toolbar, but event handlers still need to know which command
+//! occupied each rectangle in the previous frame. This example keeps command ids beside the planned
+//! regions, then asks `FrameTargets` to produce the matching `FrameSnapshot`.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode, MouseEventKind};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::focus::{FocusFallback, FocusState};
+use ratatui_layout::frame::{FrameSnapshot, FrameTargets};
+use ratatui_layout::linear::Row;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    dirty: bool,
+    focus: FocusState<Command>,
+    selected: Command,
+    previous_frame: FrameSnapshot<Command>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            dirty: false,
+            focus: FocusState::default(),
+            selected: Command::Open,
+            previous_frame: FrameSnapshot::new(Rect::default()),
+        }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let area = centered(frame.area(), 40, 3);
+        let commands = Command::regions();
+        let plan = Row::named(commands)
+            .spacing(1)
+            .flex(Flex::Center)
+            .regions(area);
+
+        let next_frame = FrameTargets::from_regions(plan, 0)
+            .disabled(|command| !self.is_enabled(command))
+            .build();
+        self.focus
+            .ensure_visible(&next_frame.focus, FocusFallback::First);
+
+        frame.render_widget(Block::new().borders(Borders::ALL).title("toolbar"), area);
+        for region in next_frame.layout.regions() {
+            self.render_command(frame, region.id, region.area);
+        }
+        self.previous_frame = next_frame;
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Char('d') => self.dirty = !self.dirty,
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Tab => {
+                self.focus.next(&self.previous_frame.focus);
+            }
+            KeyCode::Char('h') | KeyCode::Left | KeyCode::BackTab => {
+                self.focus.previous(&self.previous_frame.focus);
+            }
+            KeyCode::Char(' ') | KeyCode::Enter => self.activate_focused(),
+            _ => {}
+        }
+        true
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        if !matches!(mouse.kind, MouseEventKind::Down(_)) {
+            return;
+        }
+
+        if let Some(hit) = self.previous_frame.route_click((mouse.column, mouse.row)) {
+            self.activate(hit.id);
+        }
+    }
+
+    fn activate_focused(&mut self) {
+        if let Some(command) = self.focus.focused() {
+            self.activate(command);
+        }
+    }
+
+    fn activate(&mut self, command: Command) {
+        if !self.is_enabled(command) {
+            return;
+        }
+        self.selected = command;
+        self.dirty = command == Command::Open;
+    }
+
+    fn is_enabled(&self, command: Command) -> bool {
+        command != Command::Save || self.dirty
+    }
+
+    fn render_command(&self, frame: &mut Frame, command: Command, area: Rect) {
+        let enabled = self.is_enabled(command);
+        let style = if !enabled {
+            Style::new().fg(Color::DarkGray)
+        } else if self.selected == command {
+            Style::new().fg(Color::Black).bg(Color::Green)
+        } else if self.focus.focused() == Some(command) {
+            Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+        } else {
+            Style::new().fg(Color::White)
+        };
+
+        frame.render_widget(
+            Paragraph::new(command.label()).centered().style(style),
+            area,
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Command {
+    Open,
+    Save,
+    Close,
+}
+
+impl Command {
+    const fn regions() -> [(Self, Constraint); 3] {
+        [
+            (Self::Open, Constraint::Length(10)),
+            (Self::Save, Constraint::Length(10)),
+            (Self::Close, Constraint::Length(10)),
+        ]
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Save => "save",
+            Self::Close => "close",
+        }
+    }
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/tree_browser.rs
+++ b/crates/ratatui-layout/examples/tree_browser.rs
@@ -1,0 +1,254 @@
+//! Flatten app-owned tree state into a virtual list without giving the list tree semantics.
+//!
+//! Expansion, stable ids, and indentation belong to `App`. `VirtualList` only measures and renders
+//! the visible rows by index, then returns a hit-testable layout for the current frame.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Paragraph, Widget};
+use ratatui_layout::list::{
+    ListHeightCache, ListItemContext, ListItems, VirtualList, VirtualListState,
+};
+use ratatui_layout::participant::MeasureContext;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && !app.handle_key(key.code)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+#[derive(Default)]
+struct App {
+    state: VirtualListState,
+    cache: ListHeightCache,
+    expanded: Expanded,
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let visible = self.visible_nodes();
+        self.ensure_selection(&visible);
+        let mut rows = TreeRows {
+            visible,
+            expanded: self.expanded,
+        };
+        VirtualList::new().render_cached(
+            frame.area(),
+            frame.buffer_mut(),
+            &mut self.state,
+            &mut rows,
+            &mut self.cache,
+        );
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('j') | KeyCode::Down => self.select_next(),
+            KeyCode::Char('k') | KeyCode::Up => self.select_previous(),
+            KeyCode::Char(' ') | KeyCode::Enter => self.toggle_selected(),
+            KeyCode::Char('q') | KeyCode::Esc => return Self::quit(),
+            _ => {}
+        }
+        true
+    }
+
+    fn visible_nodes(&self) -> Vec<VisibleNode> {
+        let mut visible = Vec::new();
+        visible.push(VisibleNode {
+            id: NodeId::Project,
+            depth: 0,
+        });
+        if self.expanded.project {
+            visible.push(VisibleNode {
+                id: NodeId::Src,
+                depth: 1,
+            });
+            if self.expanded.src {
+                visible.push(VisibleNode {
+                    id: NodeId::Lib,
+                    depth: 2,
+                });
+                visible.push(VisibleNode {
+                    id: NodeId::Main,
+                    depth: 2,
+                });
+            }
+            visible.push(VisibleNode {
+                id: NodeId::Docs,
+                depth: 1,
+            });
+            if self.expanded.docs {
+                visible.push(VisibleNode {
+                    id: NodeId::Readme,
+                    depth: 2,
+                });
+                visible.push(VisibleNode {
+                    id: NodeId::Guide,
+                    depth: 2,
+                });
+            }
+        }
+        visible
+    }
+
+    const fn ensure_selection(&mut self, visible: &[VisibleNode]) {
+        if visible.is_empty() {
+            self.state.select(None);
+            return;
+        }
+
+        if self.state.selected().is_none() {
+            self.state.select(Some(0));
+        }
+    }
+
+    fn select_next(&mut self) {
+        let len = self.visible_nodes().len();
+        self.state.select_relative(1, len);
+    }
+
+    fn select_previous(&mut self) {
+        let len = self.visible_nodes().len();
+        self.state.select_relative(-1, len);
+    }
+
+    fn toggle_selected(&mut self) {
+        let visible = self.visible_nodes();
+        let Some(index) = self.state.selected() else {
+            return;
+        };
+        let Some(node) = visible.get(index).copied() else {
+            return;
+        };
+        self.expanded.toggle(node.id);
+        self.cache.clear();
+    }
+
+    const fn quit() -> bool {
+        false
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Expanded {
+    project: bool,
+    src: bool,
+    docs: bool,
+}
+
+impl Default for Expanded {
+    fn default() -> Self {
+        Self {
+            project: true,
+            src: false,
+            docs: false,
+        }
+    }
+}
+
+impl Expanded {
+    const fn toggle(&mut self, id: NodeId) {
+        match id {
+            NodeId::Project => self.project = !self.project,
+            NodeId::Src => self.src = !self.src,
+            NodeId::Docs => self.docs = !self.docs,
+            NodeId::Lib | NodeId::Main | NodeId::Readme | NodeId::Guide => {}
+        }
+    }
+
+    const fn is_expanded(self, id: NodeId) -> bool {
+        match id {
+            NodeId::Project => self.project,
+            NodeId::Src => self.src,
+            NodeId::Docs => self.docs,
+            NodeId::Lib | NodeId::Main | NodeId::Readme | NodeId::Guide => false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum NodeId {
+    Project,
+    Src,
+    Lib,
+    Main,
+    Docs,
+    Readme,
+    Guide,
+}
+
+impl NodeId {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Project => "ratatui-layout",
+            Self::Src => "src",
+            Self::Lib => "lib.rs",
+            Self::Main => "main.rs",
+            Self::Docs => "docs",
+            Self::Readme => "README.md",
+            Self::Guide => "layout.md",
+        }
+    }
+
+    const fn expandable(self) -> bool {
+        matches!(self, Self::Project | Self::Src | Self::Docs)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct VisibleNode {
+    id: NodeId,
+    depth: u16,
+}
+
+struct TreeRows {
+    visible: Vec<VisibleNode>,
+    expanded: Expanded,
+}
+
+impl ListItems for TreeRows {
+    fn len(&self) -> usize {
+        self.visible.len()
+    }
+
+    fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+        1
+    }
+
+    fn render_item(&mut self, index: usize, area: Rect, buf: &mut Buffer, ctx: ListItemContext) {
+        let node = self.visible[index];
+        let style = if ctx.render.state.selected {
+            Style::new().add_modifier(Modifier::REVERSED)
+        } else {
+            Style::new()
+        };
+        let marker = if self.expanded.is_expanded(node.id) {
+            "-"
+        } else if node.id.expandable() {
+            "+"
+        } else {
+            " "
+        };
+        let text = format!(
+            "{}{} {}",
+            "  ".repeat(node.depth as usize),
+            marker,
+            node.id.label()
+        );
+        Paragraph::new(text).style(style).render(area, buf);
+    }
+}

--- a/crates/ratatui-layout/examples/viewport.rs
+++ b/crates/ratatui-layout/examples/viewport.rs
@@ -1,0 +1,88 @@
+//! Clamp a requested scroll offset and expose the visible content rectangle.
+//!
+//! A normal layout split gives a screen rectangle. `Viewport` adds content-space state: the
+//! requested offset is clamped to the content size and returned with the visible content rectangle.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::layout::{Rect, Size};
+use ratatui::widgets::Paragraph;
+use ratatui_layout::viewport::{Viewport, ViewportState};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && !app.handle_key(key.code)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+#[derive(Default)]
+struct App {
+    viewport: ViewportState,
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let content_size = Size::new(120, 80);
+        let viewport = Viewport::new(content_size).layout(frame.area(), &mut self.viewport);
+        let visible = viewport.visible_content;
+        let mut text = format!(
+            "requested offset is clamped in ViewportState\n\
+             offset: {}\n\
+             visible content rect: {}\n\n",
+            self.viewport.offset, visible,
+        );
+
+        for y in visible.y..visible.bottom().min(visible.y.saturating_add(10)) {
+            let row = format!("content row {y:02}, visible from x {}\n", visible.x);
+            text.push_str(&row);
+        }
+
+        frame.render_widget(
+            Paragraph::new(text),
+            Rect::new(0, 0, frame.area().width, 14),
+        );
+    }
+
+    const fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('j') | KeyCode::Down => self.scroll_down(),
+            KeyCode::Char('k') | KeyCode::Up => self.scroll_up(),
+            KeyCode::Char('l') | KeyCode::Right => self.scroll_right(),
+            KeyCode::Char('h') | KeyCode::Left => self.scroll_left(),
+            KeyCode::Char('q') | KeyCode::Esc => return Self::quit(),
+            _ => {}
+        }
+        true
+    }
+
+    const fn scroll_down(&mut self) {
+        self.viewport.offset.y = self.viewport.offset.y.saturating_add(1);
+    }
+
+    const fn scroll_up(&mut self) {
+        self.viewport.offset.y = self.viewport.offset.y.saturating_sub(1);
+    }
+
+    const fn scroll_right(&mut self) {
+        self.viewport.offset.x = self.viewport.offset.x.saturating_add(4);
+    }
+
+    const fn scroll_left(&mut self) {
+        self.viewport.offset.x = self.viewport.offset.x.saturating_sub(4);
+    }
+
+    const fn quit() -> bool {
+        false
+    }
+}

--- a/crates/ratatui-layout/examples/virtual_list.rs
+++ b/crates/ratatui-layout/examples/virtual_list.rs
@@ -1,0 +1,128 @@
+//! Measure and render variable-height list rows by index, without storing row widgets.
+//!
+//! The built-in `List` is simpler for text rows. `VirtualList` is useful when rows are external app
+//! data, have variable measured heights, and should only be rendered when visible.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::widgets::{Paragraph, Widget};
+use ratatui_layout::list::{ListItemContext, ListItems, VirtualList, VirtualListState};
+use ratatui_layout::participant::MeasureContext;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && !app.handle_key(key.code)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+const ROWS: [&str; 6] = [
+    "Short row.",
+    "This row is longer and measures itself from the final list width.",
+    "A much longer row shows why item-index scrolling is not enough for multiline terminal content.",
+    "Only visible rows are rendered.",
+    "The app owns row data; the list owns viewport math.",
+    "Selection is passed through ListItemContext.",
+];
+
+struct App {
+    state: VirtualListState,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        let mut state = VirtualListState::default();
+        state.select(Some(0));
+        Self { state }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let mut rows = Rows;
+        let layout = VirtualList::new().scroll_padding(1).render(
+            frame.area(),
+            frame.buffer_mut(),
+            &mut self.state,
+            &mut rows,
+        );
+
+        let status = format!(
+            "visible indexes: {:?}  scroll: {:?}",
+            layout
+                .visible_items
+                .iter()
+                .map(|item| item.index)
+                .collect::<Vec<_>>(),
+            layout.scroll,
+        );
+        let status_area = Rect::new(
+            0,
+            frame.area().bottom().saturating_sub(1),
+            frame.area().width,
+            1,
+        );
+        frame.render_widget(Paragraph::new(status), status_area);
+    }
+
+    const fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('j') | KeyCode::Down => self.select_next(),
+            KeyCode::Char('k') | KeyCode::Up => self.select_previous(),
+            KeyCode::Char('q') | KeyCode::Esc => return Self::quit(),
+            _ => {}
+        }
+        true
+    }
+
+    const fn select_next(&mut self) {
+        self.state.select_relative(1, ROWS.len());
+    }
+
+    const fn select_previous(&mut self) {
+        self.state.select_relative(-1, ROWS.len());
+    }
+
+    const fn quit() -> bool {
+        false
+    }
+}
+
+struct Rows;
+
+impl ListItems for Rows {
+    fn len(&self) -> usize {
+        ROWS.len()
+    }
+
+    fn height_for_width(&self, index: usize, width: u16, _: MeasureContext) -> u16 {
+        let text_width = width.saturating_sub(5).max(1) as usize;
+        ROWS[index].len().div_ceil(text_width).max(1) as u16
+    }
+
+    fn render_item(&mut self, index: usize, area: Rect, buf: &mut Buffer, ctx: ListItemContext) {
+        let style = if ctx.render.state.selected {
+            Style::new().add_modifier(Modifier::REVERSED)
+        } else {
+            Style::new()
+        };
+        let clipped = if ctx.clipped_top { "^" } else { " " };
+        let text = format!("{clipped}{:02} {}", index + 1, ROWS[index]);
+
+        Paragraph::new(text).style(style).render(area, buf);
+    }
+}

--- a/crates/ratatui-layout/examples/virtual_record_list.rs
+++ b/crates/ratatui-layout/examples/virtual_record_list.rs
@@ -1,0 +1,247 @@
+//! Keep selection on durable record ids while rendering through a virtual list.
+//!
+//! `VirtualList` measures and renders by source index. `VirtualRecordList` adds a durable id layer
+//! so clicks, keyboard movement, and app commands can keep referring to records after sorting or
+//! filtering changes the visible order.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Paragraph, Widget};
+use ratatui_layout::frame::{FrameSnapshot, FrameTargets};
+use ratatui_layout::list::{ListItemContext, ListItems};
+use ratatui_layout::participant::MeasureContext;
+use ratatui_layout::record_list::{VirtualRecordList, VirtualRecordListState};
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+fn run() -> Result<()> {
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    reversed: bool,
+    state: VirtualRecordListState<RecordId>,
+    previous_frame: FrameSnapshot<Target>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        let mut state = VirtualRecordListState::new();
+        state.select_id(RecordId::Api, &RecordId::normal_order());
+        Self {
+            reversed: false,
+            state,
+            previous_frame: FrameSnapshot::new(Rect::default()),
+        }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let ids = self.visible_ids();
+        let mut rows = ReleaseRows::new(ids);
+        let area = centered(frame.area(), 56, 10);
+        let list_area = area.inner(ratatui::layout::Margin {
+            horizontal: 1,
+            vertical: 1,
+        });
+        let layout = VirtualRecordList::new().render(
+            list_area,
+            frame.buffer_mut(),
+            &mut self.state,
+            ids,
+            &mut rows,
+        );
+        let row_regions = layout.regions().clone().map_id(Target::Row);
+
+        self.previous_frame = FrameTargets::from_regions(row_regions, 0)
+            .mouse_region(Target::Pane, list_area)
+            .build();
+
+        frame.render_widget(
+            Block::new()
+                .borders(Borders::ALL)
+                .title("virtual record list"),
+            area,
+        );
+        let selected = self.state.selected_id().map_or("none", RecordId::label);
+        let status = format!("selected: {selected}    r reverses order");
+        let status_area = Rect {
+            y: area.bottom().saturating_sub(1),
+            height: 1,
+            ..area
+        };
+        frame.render_widget(Paragraph::new(status), status_area);
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        let ids = self.visible_ids();
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Char('r') => self.reversed = !self.reversed,
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.state.move_selection_by(1, ids);
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.state.move_selection_by(-1, ids);
+            }
+            _ => {}
+        }
+        true
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        let ids = self.visible_ids();
+        match mouse.kind {
+            MouseEventKind::Down(_) => {
+                if let Some(hit) = self.previous_frame.route_click((mouse.column, mouse.row))
+                    && let Target::Row(id) = hit.id
+                {
+                    self.state.select_id(id, ids);
+                }
+            }
+            MouseEventKind::ScrollDown => self.state.scroll_viewport_by(1),
+            MouseEventKind::ScrollUp => self.state.scroll_viewport_by(-1),
+            _ => {}
+        }
+    }
+
+    const fn visible_ids(&self) -> &'static [RecordId] {
+        if self.reversed {
+            &RecordId::REVERSED
+        } else {
+            &RecordId::NORMAL
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ReleaseRows {
+    ids: &'static [RecordId],
+}
+
+impl ReleaseRows {
+    const fn new(ids: &'static [RecordId]) -> Self {
+        Self { ids }
+    }
+}
+
+impl ListItems for ReleaseRows {
+    fn len(&self) -> usize {
+        self.ids.len()
+    }
+
+    fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+        1
+    }
+
+    fn render_item(&mut self, index: usize, area: Rect, buf: &mut Buffer, ctx: ListItemContext) {
+        let record = self.ids[index];
+        let style = if ctx.render.state.selected {
+            Style::new().fg(Color::Black).bg(Color::Green)
+        } else {
+            Style::new().fg(Color::White)
+        };
+        let line = format!("{:<8} {}", record.code(), record.label());
+        Line::from(line).style(style).render(area, buf);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Target {
+    Pane,
+    Row(RecordId),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum RecordId {
+    Api,
+    Worker,
+    Docs,
+    Ops,
+    Data,
+    Traffic,
+}
+
+impl RecordId {
+    const NORMAL: [Self; 6] = [
+        Self::Api,
+        Self::Worker,
+        Self::Docs,
+        Self::Ops,
+        Self::Data,
+        Self::Traffic,
+    ];
+    const REVERSED: [Self; 6] = [
+        Self::Traffic,
+        Self::Data,
+        Self::Ops,
+        Self::Docs,
+        Self::Worker,
+        Self::Api,
+    ];
+
+    const fn normal_order() -> [Self; 6] {
+        Self::NORMAL
+    }
+
+    const fn code(self) -> &'static str {
+        match self {
+            Self::Api => "API",
+            Self::Worker => "WRK",
+            Self::Docs => "DOC",
+            Self::Ops => "OPS",
+            Self::Data => "DATA",
+            Self::Traffic => "TRAF",
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Api => "schema compatibility sweep",
+            Self::Worker => "queue drain rehearsal",
+            Self::Docs => "operator guide publish",
+            Self::Ops => "go/no-go review",
+            Self::Data => "backfill safety check",
+            Self::Traffic => "edge cache promote",
+        }
+    }
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let [vertical] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [horizontal] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(vertical);
+    horizontal
+}

--- a/crates/ratatui-layout/examples/visible_selection_filter.rs
+++ b/crates/ratatui-layout/examples/visible_selection_filter.rs
@@ -1,0 +1,235 @@
+//! Keep selection tied to record ids while the visible list changes.
+//!
+//! A normal selected row index breaks as soon as filtering hides rows above it. `VisibleSelection`
+//! stores the durable record id and the current visible position together, so rendering can use the
+//! visible position while commands can still act on the selected record.
+
+use color_eyre::Result;
+use crossterm::event::{self, KeyCode};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui_layout::selection::VisibleSelection;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut app = App::default();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            if let Some(key) = event::read()?.as_key_press_event()
+                && !app.handle_key(key.code)
+            {
+                break Ok(());
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    show_blocked_only: bool,
+    selection: VisibleSelection<TaskId>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            show_blocked_only: false,
+            selection: VisibleSelection::new(),
+        }
+    }
+}
+
+impl App {
+    fn render(&mut self, frame: &mut Frame) {
+        let [list_area, status_area] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(frame.area());
+        let visible = self.visible_tasks();
+        let visible_ids = task_ids(&visible);
+        self.sync_selection(&visible_ids);
+
+        frame.render_widget(Block::new().borders(Borders::ALL).title("tasks"), list_area);
+        for (position, task) in visible.iter().enumerate() {
+            self.render_task(frame, list_area, position, task);
+        }
+        self.render_status(frame, status_area, &visible);
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        let visible = self.visible_tasks();
+        let visible_ids = task_ids(&visible);
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Char('b') => self.toggle_blocked_filter(),
+            KeyCode::Char('j') | KeyCode::Down => self.move_selection(1, &visible_ids),
+            KeyCode::Char('k') | KeyCode::Up => self.move_selection(-1, &visible_ids),
+            _ => {}
+        }
+        true
+    }
+
+    fn toggle_blocked_filter(&mut self) {
+        self.show_blocked_only = !self.show_blocked_only;
+        let visible = self.visible_tasks();
+        let visible_ids = task_ids(&visible);
+        self.sync_selection(&visible_ids);
+    }
+
+    fn move_selection(&mut self, delta: isize, visible_ids: &[TaskId]) {
+        self.selection.move_by(delta, visible_ids);
+    }
+
+    fn sync_selection(&mut self, visible_ids: &[TaskId]) {
+        self.selection.sync_ids(visible_ids);
+    }
+
+    fn visible_tasks(&self) -> Vec<&'static Task> {
+        TASKS
+            .iter()
+            .filter(|task| !self.show_blocked_only || task.state == TaskState::Blocked)
+            .collect()
+    }
+
+    fn render_task(&self, frame: &mut Frame, list_area: Rect, position: usize, task: &Task) {
+        let row = list_area.y + 1 + position as u16;
+        if row >= list_area.bottom().saturating_sub(1) {
+            return;
+        }
+
+        let selected = self.selection.selected_id() == Some(task.id);
+        let style = task.state.style(selected);
+        let text = format!(
+            "{:<8} {:<9} {}",
+            task.id.label(),
+            task.state.label(),
+            task.title
+        );
+        let area = Rect::new(list_area.x + 1, row, list_area.width.saturating_sub(2), 1);
+        frame.render_widget(Paragraph::new(text).style(style), area);
+    }
+
+    fn render_status(&self, frame: &mut Frame, area: Rect, visible: &[&Task]) {
+        let filter = if self.show_blocked_only {
+            "blocked only"
+        } else {
+            "all tasks"
+        };
+        let selected = self.selection.selected_id().map_or("none", |id| id.label());
+        let text = format!(
+            "b filter: {filter}   j/k move   selected: {selected}   visible: {}",
+            visible.len(),
+        );
+        frame.render_widget(Paragraph::new(text), area);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+struct TaskId(u8);
+
+impl TaskId {
+    fn label(self) -> &'static str {
+        TASKS
+            .iter()
+            .find(|task| task.id == self)
+            .map_or("unknown", |task| task.key)
+    }
+}
+
+#[derive(Debug)]
+struct Task {
+    id: TaskId,
+    key: &'static str,
+    title: &'static str,
+    state: TaskState,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum TaskState {
+    Queued,
+    Running,
+    Blocked,
+    Done,
+}
+
+impl TaskState {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Blocked => "blocked",
+            Self::Done => "done",
+        }
+    }
+
+    const fn style(self, selected: bool) -> Style {
+        let style = match self {
+            Self::Queued => Style::new().fg(Color::Cyan),
+            Self::Running => Style::new().fg(Color::Yellow),
+            Self::Blocked => Style::new().fg(Color::Red),
+            Self::Done => Style::new().fg(Color::Green),
+        };
+        if selected {
+            style.add_modifier(Modifier::REVERSED)
+        } else {
+            style
+        }
+    }
+}
+
+const TASKS: [Task; 8] = [
+    Task {
+        id: TaskId(0),
+        key: "API-001",
+        title: "schema compatibility sweep",
+        state: TaskState::Running,
+    },
+    Task {
+        id: TaskId(1),
+        key: "WEB-002",
+        title: "edge cache config promote",
+        state: TaskState::Blocked,
+    },
+    Task {
+        id: TaskId(2),
+        key: "WRK-003",
+        title: "queue drain rehearsal",
+        state: TaskState::Queued,
+    },
+    Task {
+        id: TaskId(3),
+        key: "DOC-004",
+        title: "operator guide publish",
+        state: TaskState::Done,
+    },
+    Task {
+        id: TaskId(4),
+        key: "OPS-005",
+        title: "go/no-go review",
+        state: TaskState::Blocked,
+    },
+    Task {
+        id: TaskId(5),
+        key: "API-006",
+        title: "rollout metrics audit",
+        state: TaskState::Running,
+    },
+    Task {
+        id: TaskId(6),
+        key: "DB-007",
+        title: "backup restore verification",
+        state: TaskState::Blocked,
+    },
+    Task {
+        id: TaskId(7),
+        key: "QA-008",
+        title: "smoke test signoff",
+        state: TaskState::Queued,
+    },
+];
+
+fn task_ids(tasks: &[&Task]) -> Vec<TaskId> {
+    tasks.iter().map(|task| task.id).collect()
+}

--- a/crates/ratatui-layout/examples/visible_selection_virtual_list.rs
+++ b/crates/ratatui-layout/examples/visible_selection_virtual_list.rs
@@ -1,0 +1,501 @@
+//! Keep durable record selection while a virtual list filters, clicks, and scrolls.
+//!
+//! `VirtualListState` selects by visible source index because that is what row rendering needs.
+//! `VisibleSelection` stores the selected task id because that is what commands and details panes
+//! need after filtering or sorting changes the visible rows.
+
+use std::io;
+
+use color_eyre::Result;
+use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, KeyCode, MouseEventKind};
+use crossterm::execute;
+use ratatui::Frame;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Paragraph, Widget};
+use ratatui_layout::list::{ListItemContext, ListItems, ListLayout, VirtualList, VirtualListState};
+use ratatui_layout::participant::MeasureContext;
+use ratatui_layout::selection::VisibleSelection;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    execute!(io::stdout(), EnableMouseCapture)?;
+    let result = run();
+    execute!(io::stdout(), DisableMouseCapture)?;
+    result
+}
+
+fn run() -> Result<()> {
+    let mut app = App::new();
+    ratatui::run(|terminal| {
+        loop {
+            terminal.draw(|frame| app.render(frame))?;
+            match event::read()? {
+                event::Event::Key(key) if key.is_press() && !app.handle_key(key.code) => {
+                    break Ok(());
+                }
+                event::Event::Mouse(mouse) => app.handle_mouse(mouse),
+                _ => {}
+            }
+        }
+    })
+}
+
+#[derive(Debug)]
+struct App {
+    filter: TaskFilter,
+    selection: VisibleSelection<TaskId>,
+    list_state: VirtualListState,
+    previous_layout: Option<ListLayout>,
+    reveal_selection: bool,
+}
+
+impl App {
+    fn new() -> Self {
+        let mut app = Self {
+            filter: TaskFilter::All,
+            selection: VisibleSelection::new(),
+            list_state: VirtualListState::default(),
+            previous_layout: None,
+            reveal_selection: true,
+        };
+        app.sync_selection_to_visible_tasks();
+        app
+    }
+
+    fn render(&mut self, frame: &mut Frame) {
+        let [list_area, details_area, status_area] = page_areas(frame.area());
+        let rows = TaskRows::new(self.filter);
+        self.apply_selection_to_virtual_list();
+
+        frame.render_widget(Block::new().borders(Borders::ALL).title("tasks"), list_area);
+        let inner_list_area = inner(list_area);
+        let list = VirtualList::new().scroll_padding(1);
+        let mut row_items = rows.clone();
+        self.previous_layout = Some(list.render(
+            inner_list_area,
+            frame.buffer_mut(),
+            &mut self.list_state,
+            &mut row_items,
+        ));
+
+        self.render_details(frame, details_area);
+        self.render_status(frame, status_area, &rows);
+        self.reveal_selection = false;
+    }
+
+    fn handle_key(&mut self, key: KeyCode) -> bool {
+        match key {
+            KeyCode::Char('q') | KeyCode::Esc => return false,
+            KeyCode::Char('b') => self.toggle_blocked_filter(),
+            KeyCode::Char('j') | KeyCode::Down => self.move_selection(1),
+            KeyCode::Char('k') | KeyCode::Up => self.move_selection(-1),
+            _ => {}
+        }
+        true
+    }
+
+    fn handle_mouse(&mut self, mouse: event::MouseEvent) {
+        let position = (mouse.column, mouse.row);
+        match mouse.kind {
+            MouseEventKind::ScrollDown => self.scroll_viewport(1),
+            MouseEventKind::ScrollUp => self.scroll_viewport(-1),
+            MouseEventKind::Down(_) => self.select_at(position),
+            _ => {}
+        }
+    }
+
+    fn toggle_blocked_filter(&mut self) {
+        self.filter = self.filter.toggled_blocked();
+        self.sync_selection_to_visible_tasks();
+        self.reveal_selection = true;
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        let visible_ids = self.visible_task_ids();
+        self.selection.move_by(delta, &visible_ids);
+        self.reveal_selection = true;
+    }
+
+    const fn scroll_viewport(&mut self, delta: isize) {
+        self.list_state.scroll_viewport_by(delta);
+        self.reveal_selection = false;
+    }
+
+    fn select_at(&mut self, position: (u16, u16)) {
+        let Some(layout) = self.previous_layout.as_ref() else {
+            return;
+        };
+        let visible_ids = self.visible_task_ids();
+        if layout
+            .select_hit(position, &mut self.selection, &visible_ids)
+            .is_some()
+        {
+            self.reveal_selection = true;
+        }
+    }
+
+    fn sync_selection_to_visible_tasks(&mut self) {
+        let visible_ids = self.visible_task_ids();
+        self.selection.sync_ids(&visible_ids);
+    }
+
+    const fn apply_selection_to_virtual_list(&mut self) {
+        if self.reveal_selection {
+            self.list_state.select(self.selection.position());
+        } else {
+            self.list_state
+                .select_without_scrolling(self.selection.position());
+        }
+    }
+
+    fn render_details(&self, frame: &mut Frame, area: Rect) {
+        frame.render_widget(Block::new().borders(Borders::ALL).title("selected"), area);
+        let task = self.selection.selected_id().and_then(Task::find);
+        let text = task.map_or_else(
+            || "no task selected".to_string(),
+            |task| {
+                format!(
+                    "{}\nstate: {}\nowner: {}\n\nCommands use this durable task id even when the \
+                     visible row index changes.",
+                    task.id.label(),
+                    task.state.label(),
+                    task.owner,
+                )
+            },
+        );
+        frame.render_widget(Paragraph::new(text), inner(area));
+    }
+
+    fn render_status(&self, frame: &mut Frame, area: Rect, rows: &TaskRows) {
+        let selected = self.selection.selected_id().map_or("none", TaskId::label);
+        let status = format!(
+            "b filter: {}   j/k move   click select   wheel scrolls only   selected: {}   visible: {}",
+            self.filter.label(),
+            selected,
+            rows.len(),
+        );
+        frame.render_widget(Paragraph::new(status), area);
+    }
+
+    fn visible_task_ids(&self) -> Vec<TaskId> {
+        TaskRows::new(self.filter).ids()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TaskRows {
+    tasks: Vec<&'static Task>,
+}
+
+impl TaskRows {
+    fn new(filter: TaskFilter) -> Self {
+        let tasks = TASKS.iter().filter(|task| filter.matches(task)).collect();
+        Self { tasks }
+    }
+
+    fn ids(&self) -> Vec<TaskId> {
+        self.tasks.iter().map(|task| task.id).collect()
+    }
+}
+
+impl ListItems for TaskRows {
+    fn len(&self) -> usize {
+        self.tasks.len()
+    }
+
+    fn height_for_width(&self, index: usize, width: u16, _: MeasureContext) -> u16 {
+        let text_width = width.saturating_sub(26).max(1) as usize;
+        self.tasks[index].summary.len().div_ceil(text_width).max(1) as u16
+    }
+
+    fn render_item(&mut self, index: usize, area: Rect, buf: &mut Buffer, ctx: ListItemContext) {
+        let task = self.tasks[index];
+        let style = task.state.style(ctx.render.state.selected);
+        let clipped = if ctx.clipped_top { "^" } else { " " };
+        let text = format!(
+            "{clipped}{:<7} {:<8} {:<9} {}",
+            task.id.label(),
+            task.state.label(),
+            task.owner,
+            task.summary,
+        );
+        Paragraph::new(text).style(style).render(area, buf);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+struct TaskId(u8);
+
+impl TaskId {
+    fn label(self) -> &'static str {
+        Task::find(self).map_or("unknown", |task| task.key)
+    }
+}
+
+#[derive(Debug)]
+struct Task {
+    id: TaskId,
+    key: &'static str,
+    summary: &'static str,
+    owner: &'static str,
+    state: TaskState,
+}
+
+impl Task {
+    fn find(id: TaskId) -> Option<&'static Self> {
+        TASKS.iter().find(|task| task.id == id)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum TaskFilter {
+    All,
+    Blocked,
+}
+
+impl TaskFilter {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::All => "all tasks",
+            Self::Blocked => "blocked only",
+        }
+    }
+
+    const fn toggled_blocked(self) -> Self {
+        match self {
+            Self::All => Self::Blocked,
+            Self::Blocked => Self::All,
+        }
+    }
+
+    const fn matches(self, task: &Task) -> bool {
+        match self {
+            Self::All => true,
+            Self::Blocked => matches!(task.state, TaskState::Blocked),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum TaskState {
+    Queued,
+    Running,
+    Blocked,
+    Done,
+}
+
+impl TaskState {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Blocked => "blocked",
+            Self::Done => "done",
+        }
+    }
+
+    const fn style(self, selected: bool) -> Style {
+        let style = match self {
+            Self::Queued => Style::new().fg(Color::Cyan),
+            Self::Running => Style::new().fg(Color::Yellow),
+            Self::Blocked => Style::new().fg(Color::Red),
+            Self::Done => Style::new().fg(Color::Green),
+        };
+        if selected {
+            style.add_modifier(Modifier::REVERSED)
+        } else {
+            style
+        }
+    }
+}
+
+fn page_areas(area: Rect) -> [Rect; 3] {
+    let columns = [Constraint::Percentage(62), Constraint::Percentage(38)];
+    let [body_area, status_area] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(area);
+    let [list_area, details_area] = Layout::horizontal(columns).areas(body_area);
+    [list_area, details_area, status_area]
+}
+
+const fn inner(area: Rect) -> Rect {
+    Rect::new(
+        area.x.saturating_add(1),
+        area.y.saturating_add(1),
+        area.width.saturating_sub(2),
+        area.height.saturating_sub(2),
+    )
+}
+
+const TASKS: [Task; 24] = [
+    Task {
+        id: TaskId(0),
+        key: "API-00",
+        summary: "schema compatibility sweep before the release branch closes",
+        owner: "platform",
+        state: TaskState::Running,
+    },
+    Task {
+        id: TaskId(1),
+        key: "WEB-01",
+        summary: "edge cache config promote with rollback notes attached",
+        owner: "traffic",
+        state: TaskState::Blocked,
+    },
+    Task {
+        id: TaskId(2),
+        key: "WRK-02",
+        summary: "queue drain rehearsal for long-running background jobs",
+        owner: "runtime",
+        state: TaskState::Queued,
+    },
+    Task {
+        id: TaskId(3),
+        key: "DOC-03",
+        summary: "operator guide publish after screenshots are refreshed",
+        owner: "docs",
+        state: TaskState::Done,
+    },
+    Task {
+        id: TaskId(4),
+        key: "OPS-04",
+        summary: "go/no-go review waiting on signoff from release captain",
+        owner: "release",
+        state: TaskState::Blocked,
+    },
+    Task {
+        id: TaskId(5),
+        key: "API-05",
+        summary: "rollout metrics audit for the canary region",
+        owner: "platform",
+        state: TaskState::Running,
+    },
+    Task {
+        id: TaskId(6),
+        key: "DB-06",
+        summary: "backup restore verification on the staging dataset",
+        owner: "data",
+        state: TaskState::Blocked,
+    },
+    Task {
+        id: TaskId(7),
+        key: "QA-07",
+        summary: "smoke test signoff for desktop and wasm targets",
+        owner: "qa",
+        state: TaskState::Queued,
+    },
+    Task {
+        id: TaskId(8),
+        key: "SEC-08",
+        summary: "dependency exception review for the CLI packaging job",
+        owner: "security",
+        state: TaskState::Blocked,
+    },
+    Task {
+        id: TaskId(9),
+        key: "REL-09",
+        summary: "release notes diff against the previous public tag",
+        owner: "release",
+        state: TaskState::Done,
+    },
+    Task {
+        id: TaskId(10),
+        key: "API-10",
+        summary: "rate-limit dashboard verification for partner traffic",
+        owner: "platform",
+        state: TaskState::Queued,
+    },
+    Task {
+        id: TaskId(11),
+        key: "WEB-11",
+        summary: "browser preview bundle smoke test after theme asset rebuild",
+        owner: "ui",
+        state: TaskState::Running,
+    },
+    Task {
+        id: TaskId(12),
+        key: "WRK-12",
+        summary: "worker drain timeout calibration with delayed retries",
+        owner: "runtime",
+        state: TaskState::Blocked,
+    },
+    Task {
+        id: TaskId(13),
+        key: "DOC-13",
+        summary: "migration guide trim pass for repeated setup instructions",
+        owner: "docs",
+        state: TaskState::Queued,
+    },
+    Task {
+        id: TaskId(14),
+        key: "OPS-14",
+        summary: "incident handoff dry run with paging policy notes",
+        owner: "ops",
+        state: TaskState::Done,
+    },
+    Task {
+        id: TaskId(15),
+        key: "DB-15",
+        summary: "read replica lag audit before traffic moves to the new pool",
+        owner: "data",
+        state: TaskState::Running,
+    },
+    Task {
+        id: TaskId(16),
+        key: "SEC-16",
+        summary: "signing key rotation checklist waiting on hardware token access",
+        owner: "security",
+        state: TaskState::Blocked,
+    },
+    Task {
+        id: TaskId(17),
+        key: "QA-17",
+        summary: "mobile terminal viewport pass for narrow-width rendering",
+        owner: "qa",
+        state: TaskState::Queued,
+    },
+    Task {
+        id: TaskId(18),
+        key: "REL-18",
+        summary: "artifact mirror verification across both package registries",
+        owner: "release",
+        state: TaskState::Running,
+    },
+    Task {
+        id: TaskId(19),
+        key: "WEB-19",
+        summary: "settings page copy review for the launch banner",
+        owner: "ui",
+        state: TaskState::Done,
+    },
+    Task {
+        id: TaskId(20),
+        key: "API-20",
+        summary: "customer import backfill paused on malformed legacy payloads",
+        owner: "platform",
+        state: TaskState::Blocked,
+    },
+    Task {
+        id: TaskId(21),
+        key: "WRK-21",
+        summary: "scheduled job ownership transfer for overnight maintenance",
+        owner: "runtime",
+        state: TaskState::Queued,
+    },
+    Task {
+        id: TaskId(22),
+        key: "DOC-22",
+        summary: "troubleshooting page publish after support review",
+        owner: "docs",
+        state: TaskState::Running,
+    },
+    Task {
+        id: TaskId(23),
+        key: "OPS-23",
+        summary: "launch room checklist blocked on final stakeholder attendance",
+        owner: "ops",
+        state: TaskState::Blocked,
+    },
+];

--- a/crates/ratatui-layout/src/action.rs
+++ b/crates/ratatui-layout/src/action.rs
@@ -1,0 +1,468 @@
+//! Action surfaces for command rows, toolbars, tabs, and menus.
+//!
+//! Many terminal controls are the same coordination problem with different rendering: a row of
+//! commands, a vertical menu, a tab bar, or a segmented control lays out named actions, skips
+//! disabled actions for input, and routes pointer hits back to app-owned ids. This module packages
+//! that pattern without choosing labels, colors, shortcuts, or command effects.
+//!
+//! Use [`ActionSurface`](crate::action::ActionSurface) when the app already owns persistent focus
+//! or selection state and only needs the current frame's regions and targets. Use
+//! [`CommandRow`](crate::action::CommandRow) when a horizontal command surface also needs a small
+//! focused-button cursor for left/right keyboard movement.
+//!
+//! # Types
+//!
+//! - [`ActionOrientation`](crate::action::ActionOrientation) chooses horizontal or vertical layout.
+//! - [`ActionSurface`](crate::action::ActionSurface) stores action ids, constraints, spacing, flex
+//!   policy, and target policy.
+//! - [`ActionSurfaceLayout`](crate::action::ActionSurfaceLayout) is the solved frame-local output
+//!   for one render pass.
+//! - [`CommandRow`](crate::action::CommandRow) combines a horizontal
+//!   [`ActionSurface`](crate::action::ActionSurface) with [`crate::input::ButtonRowState`].
+//!
+//! # Examples
+//!
+//! Build a horizontal command strip whose disabled `Save` command remains visible but does not
+//! receive focus or pointer activation:
+//!
+//! ```rust
+//! use ratatui_core::layout::{Constraint, Rect};
+//! use ratatui_layout::action::ActionSurface;
+//! use ratatui_layout::focus::{FocusFallback, FocusState};
+//!
+//! #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+//! enum Command {
+//!     Open,
+//!     Save,
+//! }
+//!
+//! let command_slots = [
+//!     (Command::Open, Constraint::Length(8)),
+//!     (Command::Save, Constraint::Length(8)),
+//! ];
+//! let layout = ActionSurface::horizontal(command_slots)
+//!     .spacing(1)
+//!     .layout_with(Rect::new(0, 0, 17, 1), |id| id == Command::Save);
+//! let mut focus = FocusState::default();
+//!
+//! focus.ensure_visible(&layout.frame().focus, FocusFallback::First);
+//!
+//! assert_eq!(focus.focused(), Some(Command::Open));
+//! assert!(layout.frame().route_click((10, 0)).is_none());
+//! ```
+
+use alloc::vec::Vec;
+
+use ratatui_core::layout::{Constraint, Flex, Rect};
+
+use crate::frame::{FrameSnapshot, FrameTargets};
+use crate::input::ButtonRowState;
+use crate::linear::{Column, Row};
+use crate::regions::Regions;
+
+/// Direction used to solve an [`ActionSurface`](crate::action::ActionSurface).
+///
+/// The same action model appears in horizontal controls such as command rows and tabs and in
+/// vertical controls such as menus. The orientation changes layout only; ids, disabled policy,
+/// focus targets, and pointer routing work the same way.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ActionOrientation {
+    /// Lay actions out left to right.
+    #[default]
+    Horizontal,
+    /// Lay actions out top to bottom.
+    Vertical,
+}
+
+/// Layout and target policy for a visible set of actions.
+///
+/// [`ActionSurface`](crate::action::ActionSurface) owns the frame-invariant description of an
+/// action strip: app-owned ids, size constraints, spacing, flex policy, focus order, and z-order.
+/// It does not own labels, styles, command callbacks, selected values, or persistent focus.
+/// Rendering code uses the returned [`ActionSurfaceLayout`](crate::action::ActionSurfaceLayout) to
+/// draw labels and stores its [`FrameSnapshot`](crate::frame::FrameSnapshot) for the next input
+/// event.
+///
+/// Common uses include:
+///
+/// - command strips where disabled commands are still visible;
+/// - tab bars that route clicks to tab ids while selection lives in app state;
+/// - vertical menus where each menu item is a focus and pointer target;
+/// - segmented controls that share layout and input routing with button rows.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct ActionSurface<Id = usize> {
+    orientation: ActionOrientation,
+    items: Vec<(Id, Constraint)>,
+    spacing: u16,
+    flex: Flex,
+    focus_start: u16,
+    z: u16,
+}
+
+impl<Id> ActionSurface<Id> {
+    /// Creates a horizontal action surface.
+    ///
+    /// Pair each id with the constraint used to size that action. Keeping the id beside the sizing
+    /// rule makes later routing easier to audit than indexing anonymous slots.
+    pub fn horizontal<I>(items: I) -> Self
+    where
+        I: IntoIterator<Item = (Id, Constraint)>,
+    {
+        Self::new(ActionOrientation::Horizontal, items)
+    }
+
+    /// Creates a vertical action surface.
+    ///
+    /// Vertical surfaces are useful for menus, command palettes, and radio-like option lists where
+    /// the same focus and pointer rules as a toolbar apply top to bottom.
+    pub fn vertical<I>(items: I) -> Self
+    where
+        I: IntoIterator<Item = (Id, Constraint)>,
+    {
+        Self::new(ActionOrientation::Vertical, items)
+    }
+
+    fn new<I>(orientation: ActionOrientation, items: I) -> Self
+    where
+        I: IntoIterator<Item = (Id, Constraint)>,
+    {
+        Self {
+            orientation,
+            items: items.into_iter().collect(),
+            spacing: 0,
+            flex: Flex::Start,
+            focus_start: 0,
+            z: 0,
+        }
+    }
+
+    /// Sets fixed spacing between actions.
+    ///
+    /// Spacing is delegated to Ratatui's layout solver, so it follows the same behavior as
+    /// [`ratatui_core::layout::Layout::spacing`].
+    #[must_use = "method returns the modified action surface"]
+    pub const fn spacing(mut self, spacing: u16) -> Self {
+        self.spacing = spacing;
+        self
+    }
+
+    /// Sets how extra space is distributed around the action group.
+    ///
+    /// Use this when a toolbar should be centered, right-aligned, or spread using Ratatui's
+    /// existing flex behavior while still returning inspectable action regions.
+    #[must_use = "method returns the modified action surface"]
+    pub const fn flex(mut self, flex: Flex) -> Self {
+        self.flex = flex;
+        self
+    }
+
+    /// Sets the first focus order assigned to the actions.
+    ///
+    /// Parent components can reserve focus ranges so a merged page traverses in reader order.
+    #[must_use = "method returns the modified action surface"]
+    pub const fn focus_start(mut self, focus_start: u16) -> Self {
+        self.focus_start = focus_start;
+        self
+    }
+
+    /// Sets the z-order for generated layout and pointer targets.
+    ///
+    /// Higher z values route before lower values when action areas overlap other UI, which is
+    /// common for menus and floating command palettes.
+    #[must_use = "method returns the modified action surface"]
+    pub const fn z(mut self, z: u16) -> Self {
+        self.z = z;
+        self
+    }
+
+    /// Returns the action ids in layout order.
+    ///
+    /// This is useful when rendering labels from a parallel application data structure or when
+    /// repairing a focused id after the command set changes.
+    pub fn ids(&self) -> impl Iterator<Item = Id> + '_
+    where
+        Id: Copy,
+    {
+        self.items.iter().map(|(id, _)| *id)
+    }
+
+    /// Solves action regions and creates enabled focus and pointer targets for every action.
+    ///
+    /// This is the common path when all visible actions are available. Use
+    /// [`ActionSurface::layout_with`](crate::action::ActionSurface::layout_with) when some actions
+    /// should remain visible while disabled.
+    pub fn layout(&self, area: Rect) -> ActionSurfaceLayout<Id>
+    where
+        Id: Copy,
+    {
+        self.layout_with(area, |_| false)
+    }
+
+    /// Solves action regions and creates targets while marking disabled actions.
+    ///
+    /// Disabled actions remain in
+    /// [`ActionSurfaceLayout::regions`](crate::action::ActionSurfaceLayout::regions) so rendering
+    /// can draw them, but generated focus and pointer targets are disabled so keyboard
+    /// traversal and pointer routing skip them.
+    pub fn layout_with(&self, area: Rect, disabled: impl Fn(Id) -> bool) -> ActionSurfaceLayout<Id>
+    where
+        Id: Copy,
+    {
+        let regions = match self.orientation {
+            ActionOrientation::Horizontal => Row::named(self.items.iter().copied())
+                .spacing(self.spacing)
+                .flex(self.flex)
+                .regions(area),
+            ActionOrientation::Vertical => Column::named(self.items.iter().copied())
+                .spacing(self.spacing)
+                .flex(self.flex)
+                .regions(area),
+        };
+        let frame = FrameTargets::from_regions(regions.clone(), self.focus_start)
+            .z(self.z)
+            .disabled(disabled)
+            .build();
+        ActionSurfaceLayout { regions, frame }
+    }
+}
+
+/// Solved output for one [`ActionSurface`](crate::action::ActionSurface) render pass.
+///
+/// The layout exposes both the regions used for drawing labels and the
+/// [`FrameSnapshot`](crate::frame::FrameSnapshot) that the app stores for the next event. It owns
+/// no persistent state; rebuild it every frame from the visible action surface.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct ActionSurfaceLayout<Id = usize> {
+    regions: Regions<Id>,
+    frame: FrameSnapshot<Id>,
+}
+
+impl<Id> ActionSurfaceLayout<Id> {
+    /// Returns the visible action regions for rendering.
+    pub const fn regions(&self) -> &Regions<Id> {
+        &self.regions
+    }
+
+    /// Returns the frame snapshot for focus, pointer, and hit-test routing.
+    pub const fn frame(&self) -> &FrameSnapshot<Id> {
+        &self.frame
+    }
+
+    /// Converts the layout into its owned frame snapshot.
+    ///
+    /// Use this when a component returns only routing data to its parent after rendering labels.
+    pub fn into_frame(self) -> FrameSnapshot<Id> {
+        self.frame
+    }
+}
+
+/// Horizontal action surface with persistent button-row focus state.
+///
+/// [`CommandRow`](crate::action::CommandRow) covers the common toolbar and command-strip case. It
+/// uses [`ActionSurface`](crate::action::ActionSurface) for the current frame's geometry and
+/// targets, and [`ButtonRowState`](crate::input::ButtonRowState) for keyboard movement among
+/// buttons. Rendering remains application-owned so command labels, shortcuts, and styles can match
+/// the app.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct CommandRow<Id = usize> {
+    surface: ActionSurface<Id>,
+    state: ButtonRowState,
+}
+
+impl<Id> CommandRow<Id> {
+    /// Creates a horizontal command row from `(id, constraint)` pairs.
+    ///
+    /// Use enum ids for normal app commands, string ids in examples and diagnostics, and integers
+    /// for generated command sets where position is the stable identity.
+    pub fn new<I>(items: I) -> Self
+    where
+        I: IntoIterator<Item = (Id, Constraint)>,
+    {
+        Self {
+            surface: ActionSurface::horizontal(items),
+            state: ButtonRowState::new(),
+        }
+    }
+
+    /// Sets fixed spacing between command buttons.
+    #[must_use = "method returns the modified command row"]
+    pub fn spacing(mut self, spacing: u16) -> Self {
+        self.surface = self.surface.spacing(spacing);
+        self
+    }
+
+    /// Sets the row flex policy.
+    #[must_use = "method returns the modified command row"]
+    pub fn flex(mut self, flex: Flex) -> Self {
+        self.surface = self.surface.flex(flex);
+        self
+    }
+
+    /// Sets the first focus order assigned to the row.
+    #[must_use = "method returns the modified command row"]
+    pub fn focus_start(mut self, focus_start: u16) -> Self {
+        self.surface = self.surface.focus_start(focus_start);
+        self
+    }
+
+    /// Sets the z-order assigned to generated targets.
+    #[must_use = "method returns the modified command row"]
+    pub fn z(mut self, z: u16) -> Self {
+        self.surface = self.surface.z(z);
+        self
+    }
+
+    /// Returns the persistent focused-button state.
+    pub const fn state(&self) -> &ButtonRowState {
+        &self.state
+    }
+
+    /// Returns mutable access to the persistent focused-button state.
+    pub const fn state_mut(&mut self) -> &mut ButtonRowState {
+        &mut self.state
+    }
+
+    /// Returns the focused command id, if the row has any commands.
+    pub fn focused_id(&self) -> Option<Id>
+    where
+        Id: Copy,
+    {
+        self.surface.ids().nth(self.state.focused_index())
+    }
+
+    /// Focuses a command by id.
+    ///
+    /// This repairs row-local focus from app-level focus or pointer input without exposing index
+    /// math at the call site.
+    pub fn focus_id(&mut self, id: Id) -> bool
+    where
+        Id: Copy + Eq,
+    {
+        if let Some(index) = self.surface.ids().position(|item| item == id) {
+            self.state.focus_index(index, self.surface.items.len());
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Moves focus to the next command, wrapping at the end.
+    pub const fn move_next(&mut self) {
+        self.state.move_next(self.surface.items.len());
+    }
+
+    /// Moves focus to the previous command, wrapping at the start.
+    pub const fn move_previous(&mut self) {
+        self.state.move_previous(self.surface.items.len());
+    }
+
+    /// Moves focus to the next enabled command.
+    ///
+    /// Use this for left/right command-row movement when disabled commands should stay visible but
+    /// keyboard focus should not stop on them.
+    pub fn move_next_enabled(&mut self, disabled: impl Fn(Id) -> bool)
+    where
+        Id: Copy,
+    {
+        self.move_enabled(1, disabled);
+    }
+
+    /// Moves focus to the previous enabled command.
+    ///
+    /// This is the mirror of
+    /// [`CommandRow::move_next_enabled`](crate::action::CommandRow::move_next_enabled) for
+    /// left-arrow or shift-tab style movement inside a command row.
+    pub fn move_previous_enabled(&mut self, disabled: impl Fn(Id) -> bool)
+    where
+        Id: Copy,
+    {
+        self.move_enabled(-1, disabled);
+    }
+
+    fn move_enabled(&mut self, delta: isize, disabled: impl Fn(Id) -> bool)
+    where
+        Id: Copy,
+    {
+        if self.surface.items.is_empty() {
+            return;
+        }
+        for _ in 0..self.surface.items.len() {
+            if delta.is_negative() {
+                self.move_previous();
+            } else {
+                self.move_next();
+            }
+            if self.focused_id().is_some_and(|id| !disabled(id)) {
+                break;
+            }
+        }
+    }
+
+    /// Solves the command row and creates frame-local targets.
+    ///
+    /// The returned layout is used for rendering labels and for storing routing data. It does not
+    /// mutate row-local focus state.
+    pub fn layout(&self, area: Rect) -> ActionSurfaceLayout<Id>
+    where
+        Id: Copy,
+    {
+        self.surface.layout(area)
+    }
+
+    /// Solves the command row while marking disabled commands.
+    ///
+    /// Disabled commands remain in the returned regions for rendering but are skipped by generated
+    /// focus and pointer targets.
+    pub fn layout_with(&self, area: Rect, disabled: impl Fn(Id) -> bool) -> ActionSurfaceLayout<Id>
+    where
+        Id: Copy,
+    {
+        self.surface.layout_with(area, disabled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui_core::layout::{Constraint, Rect};
+
+    use super::{ActionSurface, CommandRow};
+
+    #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    enum Command {
+        Edit,
+        Save,
+        Cancel,
+    }
+
+    #[test]
+    fn disabled_actions_remain_visible_but_do_not_route() {
+        let slots = [
+            (Command::Edit, Constraint::Length(4)),
+            (Command::Save, Constraint::Length(4)),
+        ];
+        let layout = ActionSurface::horizontal(slots)
+            .layout_with(Rect::new(0, 0, 8, 1), |id| id == Command::Save);
+
+        assert_eq!(layout.regions().regions().len(), 2);
+        assert_eq!(
+            layout.frame().route_click((1, 0)).unwrap().id,
+            Command::Edit
+        );
+        assert!(layout.frame().route_click((5, 0)).is_none());
+    }
+
+    #[test]
+    fn command_row_moves_over_disabled_commands() {
+        let slots = [
+            (Command::Edit, Constraint::Length(4)),
+            (Command::Save, Constraint::Length(4)),
+            (Command::Cancel, Constraint::Length(6)),
+        ];
+        let mut row = CommandRow::new(slots);
+
+        row.move_next_enabled(|id| id == Command::Save);
+
+        assert_eq!(row.focused_id(), Some(Command::Cancel));
+    }
+}

--- a/crates/ratatui-layout/src/container.rs
+++ b/crates/ratatui-layout/src/container.rs
@@ -1,0 +1,600 @@
+//! Container geometry without retained child widgets.
+//!
+//! Dialogs, panels, and tool surfaces often need two related rectangles: the outer rectangle where
+//! a border or background is drawn, and the inner rectangle where application content is rendered.
+//! Ratatui already has good widgets for the visual part, so this module only records the geometry
+//! when that geometry must be reused after rendering.
+//!
+//! The usual flow is higher level than a single rectangle calculation:
+//!
+//! 1. Configure a [`Container`](crate::container::Container) with
+//!    [`Padding`](crate::container::Padding) and, when the inner area should be named, a child id.
+//! 2. Call [`Container::layout`](crate::container::Container::layout) during rendering to get a
+//!    [`ContainerLayout`](crate::container::ContainerLayout) for that frame.
+//! 3. Render ordinary Ratatui widgets into
+//!    [`ContainerLayout::outer`](crate::container::ContainerLayout::outer) and
+//!    [`ContainerLayout::inner`](crate::container::ContainerLayout::inner).
+//! 4. Convert the optional child region into a [`Regions`](crate::regions::Regions) with
+//!    [`ContainerLayout::regions`](crate::container::ContainerLayout::regions), or clip child
+//!    regions with
+//!    [`ContainerLayout::clip_child_regions`](crate::container::ContainerLayout::clip_child_regions)
+//!    before merging them into a parent [`crate::frame::FrameSnapshot`].
+//!
+//! This separation keeps the container useful for common UI shapes without asking it to own child
+//! widgets. A dialog can use a `Block` for its border, a form widget for its body, a
+//! [`crate::focus::FocusTargets`] for tab order, and this module only for the outer/inner/clipping
+//! geometry that later input events need.
+//!
+//! # Types
+//!
+//! - [`Padding`](crate::container::Padding) stores per-edge cell counts and can derive the inner
+//!   rectangle for any [`ratatui_core::layout::Rect`].
+//! - [`Container`](crate::container::Container) is reusable configuration: padding plus an optional
+//!   app-owned child id.
+//! - [`ContainerLayout`](crate::container::ContainerLayout) is the solved frame-local result: outer
+//!   area, inner area, clip boundary, and optional child [`Region`](crate::regions::Region).
+//!
+//! Use this module when padding, child regions, or clipping boundaries need to become frame-local
+//! data that can be merged into a [`crate::frame::FrameSnapshot`] or inspected in tests. For a
+//! one-off split inside a render function, Ratatui's `Block::inner` or `Rect::inner` is usually
+//! simpler because there is no need to name or store the geometry.
+//!
+//! See [`crate::docs::containers`] for the broader composition model and examples that combine
+//! containers with ordinary Ratatui widgets.
+//!
+//! # Examples
+//!
+//! Solve dialog geometry, render chrome in the outer area, and render content in the inner area:
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::container::{Container, Padding};
+//!
+//! let dialog = Container::<()>::new()
+//!     .padding(Padding::symmetric(2, 1))
+//!     .layout(Rect::new(10, 5, 40, 8));
+//!
+//! assert_eq!(dialog.outer, Rect::new(10, 5, 40, 8));
+//! assert_eq!(dialog.inner, Rect::new(12, 6, 36, 6));
+//! ```
+//!
+//! When the child area needs to become a parent-visible region, give it an id:
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::container::{Container, Padding};
+//!
+//! let layout = Container::new()
+//!     .padding(Padding::all(1))
+//!     .child("body")
+//!     .layout(Rect::new(0, 0, 10, 4));
+//! let body_regions = layout.regions();
+//!
+//! assert_eq!(body_regions.hit_test((2, 2)).unwrap().id, "body");
+//! ```
+
+use ratatui_core::layout::Rect;
+
+use crate::regions::{Region, Regions};
+
+/// Per-edge padding used to derive an inner content rectangle.
+///
+/// [`Padding`](crate::container::Padding) exists when horizontal/vertical margins are not
+/// expressive enough. It owns only cell counts for the four edges and does not render any visual
+/// decoration. Use it with [`Container::padding`](crate::container::Container::padding) or
+/// [`Padding::inner`](crate::container::Padding::inner) when edge-specific spacing should be part
+/// of the frame-local geometry.
+///
+/// # Methods
+///
+/// - [`Padding::new`](crate::container::Padding::new) creates edge-specific padding for asymmetric
+///   chrome.
+/// - [`Padding::all`](crate::container::Padding::all) creates a uniform inset for simple panels.
+/// - [`Padding::symmetric`](crate::container::Padding::symmetric) creates a common terminal inset
+///   with separate horizontal and vertical values.
+/// - [`Padding::inner`](crate::container::Padding::inner) applies the padding to a [`Rect`] with
+///   saturating resize behavior.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::container::Padding;
+///
+/// let inner = Padding::new(1, 2, 3, 4).inner(Rect::new(0, 0, 20, 10));
+/// assert_eq!(inner, Rect::new(1, 2, 16, 4));
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Padding {
+    /// Cells reserved on the left edge before child content begins.
+    pub left: u16,
+    /// Cells reserved on the top edge before child content begins.
+    pub top: u16,
+    /// Cells reserved on the right edge after child content ends.
+    pub right: u16,
+    /// Cells reserved on the bottom edge after child content ends.
+    pub bottom: u16,
+}
+
+impl Padding {
+    /// Creates padding with explicit edge values.
+    ///
+    /// Use this when the visual treatment is asymmetric, such as a title row at the top and a
+    /// narrow inset on the remaining edges.
+    ///
+    /// # Examples
+    ///
+    /// Reserve extra space below a title while keeping the left and right insets narrow:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::container::Padding;
+    ///
+    /// let area = Rect::new(0, 0, 30, 8);
+    /// let content = Padding::new(1, 2, 1, 1).inner(area);
+    ///
+    /// assert_eq!(content, Rect::new(1, 2, 28, 5));
+    /// ```
+    pub const fn new(left: u16, top: u16, right: u16, bottom: u16) -> Self {
+        Self {
+            left,
+            top,
+            right,
+            bottom,
+        }
+    }
+
+    /// Creates equal padding on all edges.
+    ///
+    /// This is the common case for simple panels where content should be inset uniformly.
+    ///
+    /// # Examples
+    ///
+    /// Give a bordered panel one cell of content padding on every side:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::container::{Container, Padding};
+    ///
+    /// let panel = Container::<()>::new()
+    ///     .padding(Padding::all(1))
+    ///     .layout(Rect::new(5, 3, 20, 6));
+    ///
+    /// assert_eq!(panel.inner, Rect::new(6, 4, 18, 4));
+    /// ```
+    pub const fn all(value: u16) -> Self {
+        Self::new(value, value, value, value)
+    }
+
+    /// Creates symmetric horizontal and vertical padding.
+    ///
+    /// This matches the common terminal pattern of wider horizontal breathing room and tighter
+    /// vertical spacing.
+    ///
+    /// # Examples
+    ///
+    /// Use wider horizontal padding for dialog text while keeping the dialog compact vertically:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::container::{Container, Padding};
+    ///
+    /// let dialog = Container::<()>::new()
+    ///     .padding(Padding::symmetric(2, 1))
+    ///     .layout(Rect::new(0, 0, 24, 5));
+    ///
+    /// assert_eq!(dialog.inner, Rect::new(2, 1, 20, 3));
+    /// ```
+    pub const fn symmetric(horizontal: u16, vertical: u16) -> Self {
+        Self::new(horizontal, vertical, horizontal, vertical)
+    }
+
+    /// Returns the rectangle inside this padding, saturating when the area is too small.
+    ///
+    /// Saturation matters for resize handling. A dialog may temporarily be smaller than its
+    /// padding; returning a zero-sized inner rectangle lets callers skip rendering child content
+    /// without panicking or producing underflowed coordinates.
+    ///
+    /// # Examples
+    ///
+    /// A very small terminal resize produces a safe empty content area:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::container::Padding;
+    ///
+    /// let content = Padding::all(3).inner(Rect::new(0, 0, 4, 2));
+    ///
+    /// assert_eq!(content, Rect::new(3, 2, 0, 0));
+    /// ```
+    pub const fn inner(self, area: Rect) -> Rect {
+        let horizontal = self.left.saturating_add(self.right);
+        let vertical = self.top.saturating_add(self.bottom);
+        let left = if self.left > area.width {
+            area.width
+        } else {
+            self.left
+        };
+        let top = if self.top > area.height {
+            area.height
+        } else {
+            self.top
+        };
+        Rect::new(
+            area.x.saturating_add(left),
+            area.y.saturating_add(top),
+            area.width.saturating_sub(horizontal),
+            area.height.saturating_sub(vertical),
+        )
+    }
+}
+
+/// A geometry-only container configuration for one child region.
+///
+/// [`Container`](crate::container::Container) owns [`Padding`](crate::container::Padding) and an
+/// optional child id. It does not own child widgets, blocks, titles, focus, or input state. A
+/// render pass asks it to produce [`ContainerLayout`](crate::container::ContainerLayout), then
+/// renders normal Ratatui widgets into the outer or inner areas as needed.
+///
+/// The optional child id is useful when the container is part of a larger screen snapshot and the
+/// inner area should be hit-testable or mapped to app-owned content. Leave it unset when the caller
+/// only needs the outer and inner rectangles.
+///
+/// # Constructors and setters
+///
+/// - [`Container::new`](crate::container::Container::new) creates reusable geometry configuration
+///   with no padding or child region.
+/// - [`Container::padding`](crate::container::Container::padding) sets the
+///   [`Padding`](crate::container::Padding) applied when solving a frame.
+/// - [`Container::child`](crate::container::Container::child) names the inner area so it can become
+///   a [`Region`](crate::regions::Region) in a [`Regions`](crate::regions::Regions).
+/// - [`Container::padding_value`](crate::container::Container::padding_value) returns the
+///   configured padding for diagnostics or aligned decoration.
+///
+/// # Solving
+///
+/// - [`Container::layout`](crate::container::Container::layout) solves the configuration against a
+///   frame area and returns [`ContainerLayout`](crate::container::ContainerLayout).
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::container::{Container, Padding};
+///
+/// let layout = Container::new()
+///     .padding(Padding::all(1))
+///     .child("form")
+///     .layout(Rect::new(0, 0, 12, 5));
+///
+/// assert_eq!(layout.child.unwrap().id, "form");
+/// assert_eq!(layout.inner, Rect::new(1, 1, 10, 3));
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Container<Id = usize> {
+    padding: Padding,
+    child: Option<Id>,
+}
+
+impl<Id> Container<Id> {
+    /// Creates a container with no padding and no child region.
+    ///
+    /// This is a neutral starting point for builder-style configuration.
+    ///
+    /// # Examples
+    ///
+    /// Start from an empty container and add only the frame-local data the view needs:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::container::{Container, Padding};
+    ///
+    /// let layout = Container::new()
+    ///     .padding(Padding::all(1))
+    ///     .child("body")
+    ///     .layout(Rect::new(0, 0, 10, 4));
+    ///
+    /// assert_eq!(layout.child.unwrap().id, "body");
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            padding: Padding::new(0, 0, 0, 0),
+            child: None,
+        }
+    }
+
+    /// Sets per-edge padding.
+    ///
+    /// Padding is applied when [`Container::layout`](crate::container::Container::layout) is
+    /// called; it does not affect the supplied outer area itself.
+    ///
+    /// # Examples
+    ///
+    /// Keep the assigned outer area for chrome while deriving an inset content area:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::container::{Container, Padding};
+    ///
+    /// let area = Rect::new(2, 1, 16, 5);
+    /// let layout = Container::<()>::new()
+    ///     .padding(Padding::symmetric(2, 1))
+    ///     .layout(area);
+    ///
+    /// assert_eq!(layout.outer, area);
+    /// assert_eq!(layout.inner, Rect::new(4, 2, 12, 3));
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub const fn padding(mut self, padding: Padding) -> Self {
+        self.padding = padding;
+        self
+    }
+
+    /// Sets an optional child id for the inner area.
+    ///
+    /// The id is copied into the [`Region`](crate::regions::Region) stored in
+    /// [`ContainerLayout::child`](crate::container::ContainerLayout::child). This lets a parent
+    /// merge the container into a larger [`Regions`](crate::regions::Regions) without requiring the
+    /// container to know what the child actually renders.
+    ///
+    /// # Examples
+    ///
+    /// Name a dialog body so later hit testing can route a click back to application state:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::container::{Container, Padding};
+    ///
+    /// let plan = Container::new()
+    ///     .padding(Padding::all(1))
+    ///     .child("dialog-body")
+    ///     .layout(Rect::new(0, 0, 12, 5))
+    ///     .regions();
+    ///
+    /// assert_eq!(plan.hit_test((2, 2)).unwrap().id, "dialog-body");
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn child(mut self, child: Id) -> Self {
+        self.child = Some(child);
+        self
+    }
+
+    /// Returns the configured padding.
+    ///
+    /// This is mainly useful for diagnostics or for code that wants to align decoration with the
+    /// same inset policy used by the container.
+    ///
+    /// # Examples
+    ///
+    /// Reuse the configured inset when aligning a title or status line with the content area:
+    ///
+    /// ```rust
+    /// use ratatui_layout::container::{Container, Padding};
+    ///
+    /// let container = Container::<()>::new().padding(Padding::symmetric(2, 1));
+    /// let padding = container.padding_value();
+    ///
+    /// assert_eq!(padding.left, 2);
+    /// assert_eq!(padding.top, 1);
+    /// ```
+    pub const fn padding_value(&self) -> Padding {
+        self.padding
+    }
+
+    /// Solves the container against an outer area.
+    ///
+    /// The returned [`ContainerLayout`](crate::container::ContainerLayout) is the frame-local value
+    /// to keep. The [`Container`](crate::container::Container) itself is just reusable
+    /// configuration and can be rebuilt each frame.
+    ///
+    /// # Examples
+    ///
+    /// Produce the geometry a render pass can use for chrome, content, and later input routing:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::container::{Container, Padding};
+    ///
+    /// let layout = Container::new()
+    ///     .padding(Padding::all(1))
+    ///     .child("form")
+    ///     .layout(Rect::new(10, 4, 30, 8));
+    ///
+    /// assert_eq!(layout.outer, Rect::new(10, 4, 30, 8));
+    /// assert_eq!(layout.inner, Rect::new(11, 5, 28, 6));
+    /// assert_eq!(layout.regions().hit_test((12, 6)).unwrap().id, "form");
+    /// ```
+    pub fn layout(&self, area: Rect) -> ContainerLayout<Id>
+    where
+        Id: Copy,
+    {
+        let inner = self.padding.inner(area);
+        let child = self.child.map(|id| Region::new(id, inner));
+        ContainerLayout {
+            outer: area,
+            inner,
+            clip: inner,
+            child,
+        }
+    }
+}
+
+/// Solved container geometry for one frame.
+///
+/// [`ContainerLayout`](crate::container::ContainerLayout) is the frame-local artifact returned by
+/// [`Container::layout`](crate::container::Container::layout). It records the outer area, inner
+/// area, clipping boundary, and optional child [`Region`](crate::regions::Region). It does not
+/// remember the container configuration or any rendered widget.
+///
+/// # Fields and methods
+///
+/// - [`ContainerLayout::outer`](crate::container::ContainerLayout::outer) is the area for chrome
+///   such as a border, background, or clear pass.
+/// - [`ContainerLayout::inner`](crate::container::ContainerLayout::inner) is the padded content
+///   area for ordinary widgets.
+/// - [`ContainerLayout::clip`](crate::container::ContainerLayout::clip) is the boundary used when
+///   child values must not expose hidden regions.
+/// - [`ContainerLayout::child`](crate::container::ContainerLayout::child) is the optional named
+///   inner [`Region`](crate::regions::Region).
+/// - [`ContainerLayout::regions`](crate::container::ContainerLayout::regions) converts the child
+///   region into a [`Regions`](crate::regions::Regions) for parent composition.
+/// - [`ContainerLayout::clip_child_regions`](crate::container::ContainerLayout::clip_child_regions)
+///   clips child regions to the inner area.
+///
+/// # Examples
+///
+/// Clip child regions to the content area so hidden children do not route input:
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::container::{Container, Padding};
+/// use ratatui_layout::regions::{Region, Regions};
+///
+/// let container = Container::<()>::new()
+///     .padding(Padding::all(1))
+///     .layout(Rect::new(0, 0, 6, 4));
+/// let child = Regions::from_regions(
+///     Rect::new(0, 0, 6, 4),
+///     [Region::new("row", Rect::new(0, 0, 6, 2))],
+/// );
+///
+/// let visible = container.clip_child_regions(child);
+/// assert_eq!(visible.regions()[0].area, Rect::new(1, 1, 4, 1));
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ContainerLayout<Id = usize> {
+    /// Area assigned to the container itself.
+    ///
+    /// Render borders, backgrounds, or clearing widgets here.
+    pub outer: Rect,
+    /// Area inside container padding.
+    ///
+    /// Render child content here when it does not need a separate child region.
+    pub inner: Rect,
+    /// Boundary used to clip child values.
+    ///
+    /// This currently matches
+    /// [`ContainerLayout::inner`](crate::container::ContainerLayout::inner). It is named
+    /// separately because clipping is the behavior downstream code cares about when composing
+    /// child values.
+    pub clip: Rect,
+    /// Optional child region covering the inner area.
+    ///
+    /// This is present only when the source [`Container`](crate::container::Container) was
+    /// configured with [`Container::child`](crate::container::Container::child).
+    pub child: Option<Region<Id>>,
+}
+
+impl<Id> ContainerLayout<Id> {
+    /// Returns a [`Regions`](crate::regions::Regions) containing the child region when one exists.
+    ///
+    /// Use this when the container itself should contribute a child region to a parent region set.
+    /// If there is no child id, the returned region set still records the outer area but has no
+    /// regions.
+    ///
+    /// # Examples
+    ///
+    /// Convert a named inner area into a region set that can be merged with sibling regions:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::container::{Container, Padding};
+    ///
+    /// let dialog_plan = Container::new()
+    ///     .padding(Padding::all(1))
+    ///     .child("body")
+    ///     .layout(Rect::new(0, 0, 20, 6))
+    ///     .regions();
+    ///
+    /// assert_eq!(dialog_plan.regions()[0].id, "body");
+    /// assert_eq!(dialog_plan.regions()[0].area, Rect::new(1, 1, 18, 4));
+    /// ```
+    pub fn regions(self) -> Regions<Id> {
+        match self.child {
+            Some(child) => Regions::from_regions(self.outer, [child]),
+            None => Regions::new(self.outer),
+        }
+    }
+
+    /// Clips a child [`Regions`](crate::regions::Regions) to the inner clipping boundary.
+    ///
+    /// Use this when a child was solved against a larger logical area but should only expose
+    /// visible targets inside the container.
+    ///
+    /// # Examples
+    ///
+    /// Clip scrollable child regions before storing them for the next pointer event:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::container::{Container, Padding};
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let container = Container::<()>::new()
+    ///     .padding(Padding::all(1))
+    ///     .layout(Rect::new(0, 0, 8, 4));
+    /// let child_plan = Regions::from_regions(
+    ///     Rect::new(0, 0, 8, 8),
+    ///     [
+    ///         Region::new("visible-row", Rect::new(0, 1, 8, 1)),
+    ///         Region::new("hidden-row", Rect::new(0, 5, 8, 1)),
+    ///     ],
+    /// );
+    ///
+    /// let visible = container.clip_child_regions(child_plan);
+    ///
+    /// assert_eq!(visible.regions().len(), 1);
+    /// assert_eq!(visible.regions()[0].id, "visible-row");
+    /// assert_eq!(visible.regions()[0].area, Rect::new(1, 1, 6, 1));
+    /// ```
+    pub fn clip_child_regions<ChildId>(&self, regions: Regions<ChildId>) -> Regions<ChildId> {
+        regions.clip_to(self.clip)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn padding_calculates_inner_area() {
+        let layout = Container::new()
+            .padding(Padding::new(1, 2, 3, 4))
+            .child("body")
+            .layout(Rect::new(10, 20, 30, 40));
+
+        assert_eq!(layout.outer, Rect::new(10, 20, 30, 40));
+        assert_eq!(layout.inner, Rect::new(11, 22, 26, 34));
+        assert_eq!(layout.child.unwrap().area, layout.inner);
+    }
+
+    #[test]
+    fn padding_saturates_small_areas() {
+        let layout = Container::<()>::new()
+            .padding(Padding::all(4))
+            .layout(Rect::new(0, 0, 3, 2));
+
+        assert_eq!(layout.inner, Rect::new(3, 2, 0, 0));
+    }
+
+    #[test]
+    fn clips_child_plan_to_inner_area() {
+        let layout = Container::<()>::new()
+            .padding(Padding::all(1))
+            .layout(Rect::new(0, 0, 4, 4));
+        let child = Regions::from_regions(
+            Rect::new(0, 0, 4, 4),
+            [Region::new("row", Rect::new(0, 0, 4, 2))],
+        );
+
+        let clipped = layout.clip_child_regions(child);
+
+        assert_eq!(clipped.area(), Rect::new(1, 1, 2, 2));
+        assert_eq!(clipped.regions()[0].area, Rect::new(1, 1, 2, 1));
+    }
+}

--- a/crates/ratatui-layout/src/cursor.rs
+++ b/crates/ratatui-layout/src/cursor.rs
@@ -1,0 +1,462 @@
+//! Cursor placement metadata for focused app-owned content.
+//!
+//! Terminal cursor placement is layout-related but not widget ownership. These types let a focused
+//! participant report where the cursor should appear after layout without requiring a retained
+//! widget tree or a custom render trait.
+//!
+//! The shared rule is render order: code can collect cursor requests while rendering child
+//! components, then apply the final visible request after the frame is complete. Hiding the cursor
+//! is a request too, but hidden requests do not become the final cursor position; they are useful
+//! as explicit data that a component chose not to show a cursor.
+//!
+//! Use direct `Frame::set_cursor_position` style code when one known widget owns the cursor
+//! decision. Use this module when several app-owned children may request cursor placement and the
+//! final position should follow render-order composition.
+//!
+//! # Types
+//!
+//! - [`CursorRequest`](crate::cursor::CursorRequest) is one frame-local request to show or hide the
+//!   terminal cursor at a [`ratatui_core::layout::Position`].
+//! - [`CursorRequests`](crate::cursor::CursorRequests) stores requests in render order and reports
+//!   the final visible cursor.
+//!
+//! See [`crate::docs::interaction`] for how cursor requests fit with focus, selection, hover, and
+//! disabled state in the frame-local model.
+//!
+//! # Examples
+//!
+//! Collect requests from independently rendered children and apply the last visible one:
+//!
+//! ```rust
+//! use ratatui_core::layout::Position;
+//! use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+//!
+//! let input = CursorRequests::new().request(CursorRequest::visible(Position::new(3, 1)));
+//! let popup = CursorRequests::new().request(CursorRequest::visible(Position::new(12, 4)));
+//! let frame = input.merge(popup);
+//!
+//! assert_eq!(frame.final_cursor().unwrap().position, Position::new(12, 4));
+//! ```
+
+use alloc::vec::Vec;
+
+use ratatui_core::layout::{Position, Rect};
+
+/// A request to place or hide the terminal cursor.
+///
+/// Use [`CursorRequest`](crate::cursor::CursorRequest) when a focused input, editor, or table cell
+/// computes a local cursor position during rendering. The app can collect these requests in a
+/// [`CursorRequests`](crate::cursor::CursorRequests) and apply the final one to the frame.
+///
+/// # Constructors
+///
+/// - [`CursorRequest::visible`](crate::cursor::CursorRequest::visible) records the terminal
+///   position that should show the cursor.
+/// - [`CursorRequest::hidden`](crate::cursor::CursorRequest::hidden) records that a component
+///   considered cursor placement but should not show a cursor.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Position;
+/// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+///
+/// let cursor_requests = CursorRequests::new()
+///     .request(CursorRequest::visible(Position::new(4, 2)))
+///     .request(CursorRequest::hidden(Position::new(8, 2)));
+///
+/// assert_eq!(
+///     cursor_requests.final_cursor(),
+///     Some(CursorRequest::visible(Position::new(4, 2)))
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CursorRequest {
+    /// Terminal position for the cursor.
+    pub position: Position,
+
+    /// Whether the cursor should be visible.
+    pub visible: bool,
+}
+
+impl CursorRequest {
+    /// Creates a visible cursor request.
+    ///
+    /// # Examples
+    ///
+    /// Record the cursor position computed by a focused input field:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Position;
+    /// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+    ///
+    /// let plan = CursorRequests::new().request(CursorRequest::visible(Position::new(12, 3)));
+    ///
+    /// assert_eq!(plan.final_cursor().unwrap().position, Position::new(12, 3));
+    /// ```
+    pub const fn visible(position: Position) -> Self {
+        Self {
+            position,
+            visible: true,
+        }
+    }
+
+    /// Creates a hidden cursor request.
+    ///
+    /// # Examples
+    ///
+    /// A read-only focused view can explicitly avoid showing a terminal cursor:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Position;
+    /// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+    ///
+    /// let plan = CursorRequests::new().request(CursorRequest::hidden(Position::new(0, 0)));
+    ///
+    /// assert_eq!(plan.final_cursor(), None);
+    /// assert!(!plan.requests()[0].visible);
+    /// ```
+    pub const fn hidden(position: Position) -> Self {
+        Self {
+            position,
+            visible: false,
+        }
+    }
+}
+
+/// Cursor requests produced during a render pass.
+///
+/// Use [`CursorRequests`](crate::cursor::CursorRequests) when multiple app-owned participants may
+/// request cursor placement. The last visible [`CursorRequest`](crate::cursor::CursorRequest) wins,
+/// matching normal render-order expectations.
+///
+/// # Constructors and builders
+///
+/// - [`CursorRequests::new`](crate::cursor::CursorRequests::new) creates an empty request list.
+/// - [`CursorRequests::push`](crate::cursor::CursorRequests::push) appends a request to an existing
+///   request list.
+/// - [`CursorRequests::request`](crate::cursor::CursorRequests::request) appends a request in
+///   builder style.
+///
+/// # Composition and inspection
+///
+/// - [`CursorRequests::requests`](crate::cursor::CursorRequests::requests) returns all requests in
+///   render order for diagnostics or custom policies.
+/// - [`CursorRequests::translate`](crate::cursor::CursorRequests::translate) moves child-local
+///   cursor positions into parent coordinates.
+/// - [`CursorRequests::clip_to`](crate::cursor::CursorRequests::clip_to) hides cursor requests
+///   outside a viewport.
+/// - [`CursorRequests::extend`](crate::cursor::CursorRequests::extend) appends another request
+///   list.
+/// - [`CursorRequests::merge`](crate::cursor::CursorRequests::merge) returns a combined request
+///   list.
+/// - [`CursorRequests::final_cursor`](crate::cursor::CursorRequests::final_cursor) returns the last
+///   visible request to apply to the terminal frame.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Position;
+/// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+///
+/// let form = CursorRequests::new().request(CursorRequest::visible(Position::new(2, 1)));
+/// let popup = CursorRequests::new().request(CursorRequest::visible(Position::new(10, 4)));
+/// let frame = form.merge(popup);
+///
+/// assert_eq!(frame.final_cursor().unwrap().position, Position::new(10, 4));
+/// ```
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CursorRequests {
+    requests: Vec<CursorRequest>,
+}
+
+impl CursorRequests {
+    /// Creates an empty cursor request list.
+    ///
+    /// # Examples
+    ///
+    /// Use an empty request list before the first draw or for screens without focused text input:
+    ///
+    /// ```rust
+    /// use ratatui_layout::cursor::CursorRequests;
+    ///
+    /// let cursor_requests = CursorRequests::new();
+    /// assert!(cursor_requests.requests().is_empty());
+    /// assert_eq!(cursor_requests.final_cursor(), None);
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            requests: Vec::new(),
+        }
+    }
+
+    /// Adds a cursor request.
+    ///
+    /// # Examples
+    ///
+    /// Append requests as focused child widgets render:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Position;
+    /// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+    ///
+    /// let mut plan = CursorRequests::new();
+    /// plan.push(CursorRequest::visible(Position::new(6, 1)));
+    ///
+    /// assert_eq!(plan.requests().len(), 1);
+    /// ```
+    pub fn push(&mut self, request: CursorRequest) {
+        self.requests.push(request);
+    }
+
+    /// Adds a request and returns the modified request list.
+    ///
+    /// # Examples
+    ///
+    /// Build a small child request list inline:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Position;
+    /// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+    ///
+    /// let plan = CursorRequests::new().request(CursorRequest::visible(Position::new(1, 1)));
+    /// assert_eq!(plan.final_cursor().unwrap().position, Position::new(1, 1));
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn request(mut self, request: CursorRequest) -> Self {
+        self.push(request);
+        self
+    }
+
+    /// Returns all cursor requests in render order.
+    ///
+    /// # Examples
+    ///
+    /// Inspect child requests when debugging why the final cursor moved:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Position;
+    /// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+    ///
+    /// let plan = CursorRequests::new()
+    ///     .request(CursorRequest::visible(Position::new(1, 1)))
+    ///     .request(CursorRequest::visible(Position::new(2, 1)));
+    ///
+    /// assert_eq!(plan.requests()[0].position, Position::new(1, 1));
+    /// ```
+    pub fn requests(&self) -> &[CursorRequest] {
+        &self.requests
+    }
+
+    /// Moves all cursor requests by a signed offset.
+    ///
+    /// Use this when a child component computed cursor positions in local coordinates and the
+    /// parent places that child at a screen offset. This mirrors
+    /// [`crate::frame::FrameSnapshot::translate`], which translates layout, focus, pointer, and
+    /// cursor requests together.
+    ///
+    /// # Examples
+    ///
+    /// Translate a field-local cursor request into terminal coordinates:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Position;
+    /// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+    ///
+    /// let local = CursorRequests::new().request(CursorRequest::visible(Position::new(2, 1)));
+    /// let screen = local.translate(10, 3);
+    ///
+    /// assert_eq!(
+    ///     screen.final_cursor(),
+    ///     Some(CursorRequest::visible(Position::new(12, 4)))
+    /// );
+    /// ```
+    #[must_use = "method returns the translated request list"]
+    pub fn translate(mut self, dx: i16, dy: i16) -> Self {
+        for request in &mut self.requests {
+            request.position = translate_position(request.position, dx, dy);
+        }
+        self
+    }
+
+    /// Hides cursor requests outside a viewport.
+    ///
+    /// Use this when a child component reports cursor positions inside a clipped pane or scrolling
+    /// viewport. Requests outside the viewport stay in render order for diagnostics, but they no
+    /// longer count as visible final cursor requests.
+    ///
+    /// # Examples
+    ///
+    /// Keep an earlier visible cursor when a later child cursor is clipped away:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Position, Rect};
+    /// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+    ///
+    /// let plan = CursorRequests::new()
+    ///     .request(CursorRequest::visible(Position::new(2, 1)))
+    ///     .request(CursorRequest::visible(Position::new(12, 1)))
+    ///     .clip_to(Rect::new(0, 0, 10, 3));
+    ///
+    /// assert_eq!(
+    ///     plan.final_cursor(),
+    ///     Some(CursorRequest::visible(Position::new(2, 1)))
+    /// );
+    /// ```
+    #[must_use = "method returns the clipped request list"]
+    pub fn clip_to(mut self, viewport: Rect) -> Self {
+        for request in &mut self.requests {
+            if !viewport.contains(request.position) {
+                request.visible = false;
+            }
+        }
+        self
+    }
+
+    /// Extends this request list with another request list.
+    ///
+    /// Requests keep render order. Requests from `other` are appended, so a visible request in the
+    /// child request can become the final cursor for the aggregate frame.
+    ///
+    /// # Examples
+    ///
+    /// Append a child component's cursor requests after the parent request:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Position;
+    /// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+    ///
+    /// let mut parent = CursorRequests::new().request(CursorRequest::visible(Position::new(1, 1)));
+    /// let child = CursorRequests::new().request(CursorRequest::visible(Position::new(5, 5)));
+    /// parent.extend(child);
+    ///
+    /// assert_eq!(parent.final_cursor().unwrap().position, Position::new(5, 5));
+    /// ```
+    pub fn extend(&mut self, other: Self) {
+        self.requests.extend(other.requests);
+    }
+
+    /// Returns a cursor request list containing this list's requests followed by another list's
+    /// requests.
+    ///
+    /// # Examples
+    ///
+    /// Combine sibling component values while preserving render-order cursor priority:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Position;
+    /// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+    ///
+    /// let left = CursorRequests::new().request(CursorRequest::visible(Position::new(2, 0)));
+    /// let right = CursorRequests::new().request(CursorRequest::visible(Position::new(20, 0)));
+    ///
+    /// assert_eq!(
+    ///     left.merge(right).final_cursor().unwrap().position,
+    ///     Position::new(20, 0)
+    /// );
+    /// ```
+    #[must_use = "method returns the merged request list"]
+    pub fn merge(mut self, other: Self) -> Self {
+        self.extend(other);
+        self
+    }
+
+    /// Returns the final visible cursor request.
+    ///
+    /// # Examples
+    ///
+    /// Apply only the last visible request after all children have rendered:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Position;
+    /// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+    ///
+    /// let plan = CursorRequests::new()
+    ///     .request(CursorRequest::visible(Position::new(1, 1)))
+    ///     .request(CursorRequest::hidden(Position::new(3, 1)))
+    ///     .request(CursorRequest::visible(Position::new(5, 1)));
+    ///
+    /// assert_eq!(plan.final_cursor().unwrap().position, Position::new(5, 1));
+    /// ```
+    pub fn final_cursor(&self) -> Option<CursorRequest> {
+        self.requests
+            .iter()
+            .rev()
+            .copied()
+            .find(|request| request.visible)
+    }
+}
+
+const fn translate_position(position: Position, dx: i16, dy: i16) -> Position {
+    Position::new(
+        translate_coordinate(position.x, dx),
+        translate_coordinate(position.y, dy),
+    )
+}
+
+const fn translate_coordinate(coordinate: u16, delta: i16) -> u16 {
+    if delta.is_negative() {
+        coordinate.saturating_sub(delta.unsigned_abs())
+    } else {
+        coordinate.saturating_add(delta as u16)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use ratatui_core::layout::{Position, Rect};
+
+    use super::*;
+
+    #[test]
+    fn final_cursor_uses_last_visible_request() {
+        let plan = CursorRequests::new()
+            .request(CursorRequest::visible(Position::new(1, 1)))
+            .request(CursorRequest::hidden(Position::new(2, 2)))
+            .request(CursorRequest::visible(Position::new(3, 3)));
+
+        assert_eq!(
+            plan.final_cursor(),
+            Some(CursorRequest::visible(Position::new(3, 3)))
+        );
+    }
+
+    #[test]
+    fn translate_moves_cursor_requests() {
+        let plan = CursorRequests::new()
+            .request(CursorRequest::visible(Position::new(2, 1)))
+            .request(CursorRequest::hidden(Position::new(0, 0)))
+            .translate(10, 3);
+
+        assert_eq!(
+            plan.requests(),
+            &[
+                CursorRequest::visible(Position::new(12, 4)),
+                CursorRequest::hidden(Position::new(10, 3)),
+            ]
+        );
+    }
+
+    #[test]
+    fn clip_hides_cursor_requests_outside_viewport() {
+        let plan = CursorRequests::new()
+            .request(CursorRequest::visible(Position::new(2, 1)))
+            .request(CursorRequest::visible(Position::new(12, 1)))
+            .clip_to(Rect::new(0, 0, 10, 3));
+
+        assert_eq!(
+            plan.requests(),
+            &[
+                CursorRequest::visible(Position::new(2, 1)),
+                CursorRequest::hidden(Position::new(12, 1)),
+            ]
+        );
+        assert_eq!(
+            plan.final_cursor(),
+            Some(CursorRequest::visible(Position::new(2, 1)))
+        );
+    }
+}

--- a/crates/ratatui-layout/src/docs.rs
+++ b/crates/ratatui-layout/src/docs.rs
@@ -1,0 +1,440 @@
+//! Guide pages for the frame-local UI coordination model.
+//!
+//! These modules are documentation-only. They describe how the experimental primitives fit
+//! together, where normal Ratatui APIs remain simpler, and which ideas are current behavior versus
+//! future direction.
+//!
+//! Maintainers updating these docs should also read [`crate::docs::documentation_review`]. It
+//! records the standard used for this experimental crate: links should help navigation, but each
+//! page and type should still explain the local problem well enough that readers understand why the
+//! linked concept matters before they click away.
+//!
+//! # Examples
+//!
+//! The guides describe why a render pass can return data that the next input event uses:
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::frame::FrameSnapshot;
+//! use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+//!
+//! let frame = FrameSnapshot::new(Rect::new(0, 0, 20, 1))
+//!     .mouse(PointerTargets::new().target(PointerTarget::new("save", Rect::new(0, 0, 6, 1))));
+//!
+//! assert_eq!(frame.route_position((2, 0)).unwrap().id, "save");
+//! ```
+
+/// Visible regions as frame-local geometry.
+///
+/// # Problem
+///
+/// Many Ratatui render functions split an area and immediately draw widgets. That is still the
+/// simplest path when geometry is only a local implementation detail. The problem starts when the
+/// rectangles need to survive the render function: a later pointer event must hit a row, a test
+/// wants to inspect visible cells, or a parent container needs to merge child regions.
+///
+/// [`crate::regions::Regions`] turns solved rectangles into a region set. It stores the parent area
+/// plus ordered [`crate::regions::Region`] values with ids, clipping metadata, and z-order. It does
+/// not store widgets or application data.
+///
+/// The area/region distinction is deliberate. An area is a [`ratatui_core::layout::Rect`], so it
+/// answers "where can I draw?" A region answers "what app-owned thing was drawn there, and how
+/// should later coordination treat it?" Use areas for local rendering. Use regions when the same
+/// rectangle needs identity, clipping metadata, z-order, hit testing, or composition across a
+/// component boundary.
+///
+/// # Current behavior
+///
+/// Region sets can be built directly, returned by [`crate::linear::Row`],
+/// [`crate::linear::Column`], or [`crate::grid::Grid`], translated, clipped, merged, mapped to
+/// another id type, and hit tested. Generic `Id` parameters are the bridge back to app state:
+/// integers work for generated order, strings make examples and diagnostics readable, enums are
+/// usually best for named app controls, and stable record keys fit filtered or reordered data.
+///
+/// ```rust
+/// use ratatui_core::layout::{Constraint, Rect};
+/// use ratatui_layout::linear::Row;
+///
+/// let row_regions = Row::new([Constraint::Length(8), Constraint::Fill(1)])
+///     .spacing(1)
+///     .regions(Rect::new(0, 0, 20, 1));
+///
+/// assert_eq!(row_regions.hit_test((2, 0)).unwrap().id, 0);
+/// ```
+///
+/// # Tradeoff
+///
+/// A region set is extra ceremony. Prefer `Layout::areas` when the result is consumed immediately
+/// and never routed, stored, merged, clipped, or tested.
+pub mod regions {}
+
+/// Containers, panels, dialogs, flex, grid, overlays, and nested composition.
+///
+/// # Problem
+///
+/// Container-like UI often needs an outer region, an inner content region, and child geometry that
+/// can be clipped or translated. Ratatui already renders blocks and borders well; the missing piece
+/// is a small value that records the geometry without taking ownership of children.
+///
+/// # Current behavior
+///
+/// [`crate::container::Container`] computes outer and inner areas with per-edge
+/// [`crate::container::Padding`]. [`crate::overlay::Overlay`] stacks explicit regions.
+/// [`crate::linear::Row`], [`crate::linear::Column`], and [`crate::grid::Grid`] delegate to
+/// Ratatui's layout solver and expose the solved rectangles as values.
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::container::{Container, Padding};
+///
+/// let layout = Container::new()
+///     .padding(Padding::symmetric(2, 1))
+///     .child("body")
+///     .layout(Rect::new(0, 0, 20, 5));
+///
+/// assert_eq!(layout.inner, Rect::new(2, 1, 16, 3));
+/// ```
+///
+/// # Tradeoff
+///
+/// Use ordinary `Block`, `Layout`, and `Rect::inner` directly when the container has no need to
+/// expose its geometry as a reusable value.
+pub mod containers {}
+
+/// Pointer, focus, selection, cursor, disabled state, hover, and local coordinates.
+///
+/// # Problem
+///
+/// Immediate-mode rendering means the current event usually arrives after the previous frame was
+/// drawn. Pointer and keyboard coordination therefore need a record of what was visible last frame,
+/// but that record should not become a retained widget tree.
+///
+/// # Current behavior
+///
+/// [`crate::focus::FocusTargets`] stores keyboard targets while [`crate::focus::FocusState`] stores
+/// the persistent focused id. [`crate::focus::FocusFallback`] repairs stale focus after filtering
+/// or disabling controls. [`crate::pointer::PointerTargets`] stores pointer targets while
+/// [`crate::pointer::PointerState`] stores hover and pressed ids. [`crate::pointer::PointerPhase`]
+/// lets apps convert backend mouse events into backend-agnostic hover, press, and release
+/// transitions without putting crossterm or another backend in the crate.
+/// [`crate::selection::SelectionState`] stores selection separately from geometry.
+/// [`crate::cursor::CursorRequests`] collects cursor requests produced during rendering.
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::pointer::{PointerPhase, PointerState, PointerTarget, PointerTargets};
+///
+/// let targets = PointerTargets::from_targets([PointerTarget::new("save", Rect::new(0, 0, 6, 1))]);
+/// let mut state = PointerState::default();
+///
+/// state.route(&targets, (2, 0), PointerPhase::Press);
+/// assert_eq!(
+///     state
+///         .route(&targets, (2, 0), PointerPhase::Release)
+///         .unwrap()
+///         .id,
+///     "save"
+/// );
+/// ```
+///
+/// # Tradeoff
+///
+/// Keep input handling local when there is only one known target. Use these values when routing
+/// depends on a set of visible, possibly clipped or overlapping regions.
+pub mod interaction {}
+
+/// Viewports, lists, tables, visible rows/cells, and scroll metrics.
+///
+/// # Problem
+///
+/// Scrollable UI needs two coordinate systems: content-space positions owned by the app and
+/// viewport-space rectangles visible in the terminal. It also needs status math for scrollbars and
+/// efficient rendering of only visible rows or cells.
+///
+/// # Current behavior
+///
+/// [`crate::viewport::Viewport`] clamps a content offset against a viewport.
+/// [`crate::scroll::ScrollMetrics`] reports thumb size and position for status displays.
+/// [`crate::list::VirtualList`] and [`crate::table::VirtualTable`] compute visible app-owned rows
+/// and cells without storing the row or cell widgets. Their state types distinguish selection
+/// reveal from viewport movement: selecting a row or cell asks layout to keep it visible, while
+/// viewport-scroll helpers move the viewport without changing selection. That split is important
+/// for mouse wheels, where users expect the pane under the pointer to scroll without changing the
+/// selected item that commands operate on.
+///
+/// ```rust
+/// use ratatui_core::layout::{Position, Rect, Size};
+/// use ratatui_layout::scroll::ScrollMetrics;
+/// use ratatui_layout::viewport::{Viewport, ViewportState};
+///
+/// let mut state = ViewportState::new(Position::new(0, 10));
+/// let layout = Viewport::new(Size::new(20, 100)).layout(Rect::new(0, 0, 20, 10), &mut state);
+/// let metrics = ScrollMetrics::vertical(&layout);
+///
+/// assert_eq!(metrics.offset, 10);
+/// ```
+///
+/// A virtual table can keep a selected cell for commands while wheel input scrolls only the visible
+/// rows:
+///
+/// ```rust
+/// use ratatui_layout::table::{CellPosition, VirtualTableState};
+///
+/// let mut state = VirtualTableState::default();
+/// state.select(Some(CellPosition::body(0, 0)));
+/// state.scroll_rows_by(4);
+///
+/// assert_eq!(state.selected(), Some(CellPosition::body(0, 0)));
+/// assert_eq!(state.row_scroll(), 4);
+/// assert!(!state.scrolls_selected_into_view());
+/// ```
+///
+/// # Tradeoff
+///
+/// For short, fully visible collections, render the rows directly. Virtualization becomes useful
+/// when clipping, scroll metrics, or app-owned row rendering need a shared contract.
+pub mod virtualization {}
+
+/// How a render pass produces data used by the next event.
+///
+/// # Problem
+///
+/// A complete screen can produce several kinds of visible data at once: regions, keyboard targets,
+/// pointer targets, and cursor requests. Returning each concern separately works, but component
+/// boundaries often want one value to merge into a parent. The important choice is the boundary:
+/// a pane that only routes wheel input can store a [`crate::pointer::PointerTargets`], while a
+/// child component that returns layout, pointer, focus, and cursor requests together is a better
+/// fit for [`crate::frame::FrameSnapshot`].
+///
+/// # Current behavior
+///
+/// [`crate::frame::FrameSnapshot`] aggregates [`crate::regions::Regions`],
+/// [`crate::focus::FocusTargets`], [`crate::pointer::PointerTargets`], and
+/// [`crate::cursor::CursorRequests`]. It can merge child values and map, translate, or clip their
+/// ids and rectangles. [`crate::frame::FrameTargets::from_regions`] adds disabled, focusable,
+/// mouseable, and z-order policy to solved regions. [`crate::frame::FrameSnapshot::route_position`]
+/// is the broad geometry query; click, hover, and wheel helpers use explicit pointer targets when
+/// present.
+///
+/// Use smaller values directly when they describe the whole coordination problem:
+///
+/// - [`crate::regions::Regions`] when geometry and hit testing are enough;
+/// - [`crate::focus::FocusTargets`] when only keyboard traversal needs previous-frame targets;
+/// - [`crate::pointer::PointerTargets`] when pointer routing is independent of focus or cursor
+///   placement;
+/// - [`crate::cursor::CursorRequests`] when rendering only needs to negotiate the terminal cursor.
+///
+/// Use [`crate::frame::FrameSnapshot`] when regions, focus targets, pointer targets, and cursor
+/// requests must be mapped, translated, clipped, or merged as one component result. That keeps
+/// aggregation useful without making it the default return type for every surface.
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::frame::FrameSnapshot;
+/// use ratatui_layout::regions::{Region, Regions};
+///
+/// let frame = FrameSnapshot::from_layout(Regions::from_regions(
+///     Rect::new(0, 0, 10, 1),
+///     [Region::new("tab", Rect::new(0, 0, 5, 1))],
+/// ));
+///
+/// assert_eq!(frame.route_position((1, 0)).unwrap().id, "tab");
+/// ```
+///
+/// A pointer-only pane can stay smaller and store only pointer targets:
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::pointer::PointerTargets;
+///
+/// let previous_mouse = PointerTargets::new()
+///     .region("queue", Rect::new(0, 0, 20, 10))
+///     .region("log", Rect::new(21, 0, 20, 10));
+///
+/// assert_eq!(previous_mouse.hit_test((25, 4)).unwrap().id, "log");
+/// ```
+///
+/// Event handlers can use intent-named routing helpers while still relying on the same stored
+/// frame-local data:
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::frame::FrameSnapshot;
+///
+/// let frame = FrameSnapshot::new(Rect::new(0, 0, 20, 5))
+///     .scroll_region("log-pane", Rect::new(0, 0, 20, 5));
+///
+/// assert_eq!(frame.route_scroll((3, 4)).unwrap().id, "log-pane");
+/// ```
+///
+/// The examples show both sides of this choice. `pointer_only_scroll_region` routes wheel input
+/// with only [`crate::pointer::PointerTargets`]. `component_frames` returns child
+/// [`crate::frame::FrameSnapshot`] values because the parent needs to map ids, place children, clip
+/// hidden data, and merge cursor requests.
+///
+/// # Future direction
+///
+/// Semantic actions and component outcomes are intentionally not part of the first `FrameSnapshot`.
+/// They need examples that prove the shape before becoming API.
+pub mod frame_snapshots {}
+
+/// Future participant, outcome, action, and component contracts.
+///
+/// # Problem
+///
+/// Ratatui's existing `Widget` and `StatefulWidget` traits are intentionally simple render
+/// contracts. Framework-like composition sometimes wants measurement, child rendering,
+/// interaction data, cursor placement, and semantic actions to travel together.
+///
+/// # Current behavior
+///
+/// This crate does not change `ratatui-core` or `ratatui-widgets`. Existing widgets render into
+/// rectangles produced by these values. [`crate::participant::LayoutParticipant`] is an experiment
+/// for measured, app-owned children, while [`crate::frame::FrameSnapshot`] is an experiment for
+/// collecting coordination data after rendering.
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::{Rect, Size};
+/// use ratatui_layout::measure::{MeasureConstraint, SizeHint};
+/// use ratatui_layout::participant::{
+///     LayoutParticipant, MeasureContext, ParticipantFn, RenderContext,
+/// };
+///
+/// let mut label = ParticipantFn::new(
+///     |_: usize, _, _| SizeHint::exact(Size::new(4, 1)),
+///     |_, _: Rect, _: &mut Buffer, _| {},
+/// );
+/// let hint = label.measure(0, MeasureConstraint::Unbounded, MeasureContext);
+/// let mut buffer = Buffer::empty(Rect::new(0, 0, hint.preferred.width, 1));
+/// label.render(0, buffer.area, &mut buffer, RenderContext::default());
+/// ```
+///
+/// # Future direction
+///
+/// A later component layer may return render outcomes, semantic actions, and richer participant
+/// contracts. Those ideas should stay outside core traits until examples show that the additional
+/// concepts reduce complexity for real applications.
+///
+/// # Tradeoff
+///
+/// Keep using normal widgets when a render call is enough. Reach for participants and frame
+/// snapshots only when parent and child need to collaborate across measurement, rendering, and
+/// input routing.
+pub mod widget_contracts {}
+
+/// Documentation review checklist for this crate.
+///
+/// # Problem
+///
+/// Experimental UI crates can easily become a pile of type names: every doc links to every other
+/// doc, but no page explains why the reader should care. That is especially risky here because the
+/// crate is exploring a coordination model, not just a handful of independent helpers.
+///
+/// This checklist is the review bar for new or changed docs in `ratatui-layout`.
+///
+/// A useful review usually looks for a relationship between the overview, the API map, and the
+/// examples:
+///
+/// ```text
+/// - The module names the problem and the simpler Ratatui alternative.
+/// - The type explains ownership and lists its constructors plus common method groups.
+/// - The examples show a realistic method combination, such as layout -> hit_test -> state update.
+/// - Links have enough surrounding explanation that the reader knows why to follow them.
+/// ```
+///
+/// # Checklist
+///
+/// 1. Start with the user problem.
+///
+///    A module or type should say what pressure created it: previous-frame input routing,
+///    externally owned rows, clipped child values, app-owned selection, or another concrete need.
+///    Avoid opening with an implementation inventory.
+///
+/// 2. Show multiple common uses for core primitives.
+///
+///    The more primitive a type is, the more likely it supports several workflows. A core type like
+///    [`crate::regions::Regions`] should explain at least a few uses: input routing, app-owned
+///    rendering, child composition, testing, diagnostics, or clipping. Narrow helper methods can
+///    stay shorter, but should still say when a caller would reach for them.
+///
+/// 3. Couple uses to examples where possible.
+///
+///    A use-case list is easier to trust when at least some items are shown in code. Prefer small
+///    doctests that prove the shape: a previous-frame hit test, child regions translated into a
+///    parent, visible ids driving selection, or disabled pointer targets being skipped. Use prose
+///    only when the example would be noisy or require a full terminal app.
+///
+///    For public modules, at least one example should usually live near the module-level "common
+///    uses" explanation. For primitive structs, examples should cover the most important distinct
+///    workflows rather than repeating the constructor shape.
+///
+/// 4. Keep example density proportional.
+///
+///    Most type pages should have a few examples that cover the workflows a reader is likely to
+///    compare while browsing. More examples are useful for broad primitives such as
+///    [`crate::regions::Regions`], [`crate::pointer::PointerTargets`], or
+///    [`crate::list::VirtualList`]. Fewer examples are enough for simple enums, field containers,
+///    or accessors when the surrounding type already explains the workflow.
+///
+/// 5. Explain generic id choices at the right level.
+///
+///    Generic `Id` parameters are a shared concept, so the crate root and guide pages should
+///    explain the common choices: integers for generated order, string names for examples and
+///    diagnostics, enums for normal app controls, and stable record keys for filtered or reordered
+///    data. Individual types should repeat just enough of that guidance for local context.
+///
+/// 6. Explain ownership boundaries.
+///
+///    Every coordination type should say what it owns and what it deliberately does not own. For
+///    example, [`crate::pointer::PointerTargets`] owns visible pointer targets;
+///    [`crate::pointer::PointerState`] owns hover and press state; neither owns callbacks or
+///    backend events.
+///
+/// 7. Name the simpler Ratatui alternative.
+///
+///    If ordinary `Layout`, `Block`, `Widget`, `StatefulWidget`, `List`, or direct rendering is
+///    better for a small case, say so. This keeps the experimental APIs from sounding mandatory.
+///
+/// 8. Link after giving enough context.
+///
+///    Intra-doc links should be useful exits, not substitutes for explanation. Before linking to a
+///    guide page or related type, give the reader enough local context to understand why that link
+///    matters.
+///
+/// 9. Keep related concepts navigable.
+///
+///    Related snapshot, state, target, and layout values should link to each other:
+///    [`crate::frame::FrameSnapshot`] to its child values, [`crate::focus::FocusTargets`] to
+///    [`crate::focus::FocusState`], [`crate::pointer::PointerTargets`] to
+///    [`crate::pointer::PointerState`], [`crate::list::VirtualList`] to
+///    [`crate::list::VirtualListState`] and [`crate::list::ListLayout`], and so on.
+///
+/// 10. Provide scan-friendly API maps.
+///
+///    Struct docs should list constructors, setters, inspection methods, composition methods, and
+///    routing/state methods when those categories exist. Module docs should list public types and
+///    free functions. These maps should help readers orient themselves before reading individual
+///    method docs.
+///
+/// 11. Document behavior at the field and method level when the name is not enough.
+///
+///    Fields like `z`, `disabled`, `clip`, `visible_row`, and `selected` need semantics, not just
+///    labels. Methods that merge, map, translate, or clip should explain why the operation exists
+///    in component composition.
+///
+/// 12. Separate current behavior from future direction.
+///
+///    If a page mentions semantic actions, components, or stronger widget contracts, mark that as
+///    future direction. Do not imply those contracts already exist.
+///
+/// 13. Prefer small compiling examples for core ideas.
+///
+///    Examples should prove the concept without hiding it behind app scaffolding. Use runnable
+///    examples when a complete terminal app is clearer than a doctest.
+///
+/// 14. Avoid link noise.
+///
+///    Link the first meaningful mention of a type in a local section and important method/field
+///    references. Do not link every repeated word if it makes the prose harder to read.
+pub mod documentation_review {}

--- a/crates/ratatui-layout/src/focus.rs
+++ b/crates/ratatui-layout/src/focus.rs
@@ -1,0 +1,1166 @@
+//! Focus targets and persistent focus state for app-owned controls.
+//!
+//! [`FocusTargets`](crate::focus::FocusTargets) is the keyboard counterpart to hit testing. A
+//! layout can expose the regions that may receive focus, and
+//! [`FocusState`](crate::focus::FocusState) can move between those targets without the container
+//! owning child widgets.
+//!
+//! Keep focus handling local when one widget or one field owns the keyboard interaction. Use this
+//! module when focus must move across app-owned controls that are visible, clipped, filtered, or
+//! composed across component boundaries.
+//!
+//! # Common uses
+//!
+//! - Move through dialog fields with Tab, Shift-Tab, Up, or Down while the application owns the
+//!   actual input state.
+//! - Keep focus on a selected table cell or palette swatch as filtering, scrolling, or resizing
+//!   changes which targets are visible.
+//! - Focus a control under the pointer by using
+//!   [`FocusState::focus_at`](crate::focus::FocusState::focus_at) with the previous frame's focus
+//!   target collection.
+//!
+//! # Types
+//!
+//! - [`FocusTarget`](crate::focus::FocusTarget) describes one focusable region visible in the
+//!   current frame.
+//! - [`FocusTargets`](crate::focus::FocusTargets) stores current-frame focus targets in traversal
+//!   order.
+//! - [`FocusState`](crate::focus::FocusState) stores the app-owned focused id between events and
+//!   frames.
+//! - [`FocusFallback`](crate::focus::FocusFallback) names what should happen when stored focus no
+//!   longer points at an enabled visible target.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::focus::{FocusState, FocusTarget, FocusTargets};
+//!
+//! let targets = FocusTargets::from_targets([
+//!     FocusTarget::new("title", Rect::new(0, 0, 20, 1), 0),
+//!     FocusTarget::new("save", Rect::new(0, 2, 8, 1), 1),
+//! ]);
+//! let mut focus = FocusState::default();
+//!
+//! focus.next(&targets);
+//! assert_eq!(focus.focused(), Some("title"));
+//! focus.next(&targets);
+//! assert_eq!(focus.focused(), Some("save"));
+//! ```
+//!
+//! See [`crate::docs::interaction`] for the split between frame-local focus targets and persistent
+//! app-owned focus state.
+
+use alloc::vec::Vec;
+
+use ratatui_core::layout::{Position, Rect};
+
+use crate::regions::Region;
+
+/// A focusable region in a rendered layout.
+///
+/// Use [`FocusTarget`](crate::focus::FocusTarget) when a button, input, tab, table cell, or row
+/// should participate in keyboard traversal. The id belongs to the application; the target only
+/// records where that id was rendered and whether traversal should currently skip it.
+///
+/// # Common uses
+///
+/// - A form can expose one target per field in visual order.
+/// - A toolbar can disable targets for unavailable commands while leaving them visible.
+/// - A table or grid can expose only visible cells so keyboard traversal matches the current frame.
+///
+/// # Constructors and geometry
+///
+/// - [`FocusTarget::new`](crate::focus::FocusTarget::new) creates an enabled focus target with a
+///   traversal order.
+/// - [`FocusTarget::from_region`](crate::focus::FocusTarget::from_region) derives one focus target
+///   from a layout [`Region`](crate::regions::Region).
+/// - [`FocusTarget::disabled`](crate::focus::FocusTarget::disabled) keeps a target visible but
+///   skipped by traversal.
+/// - [`FocusTarget::translate`](crate::focus::FocusTarget::translate) moves child-local target
+///   geometry into parent coordinates.
+/// - [`FocusTarget::clip_to`](crate::focus::FocusTarget::clip_to) clips target geometry to a
+///   viewport and drops hidden targets.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::focus::{FocusState, FocusTarget, FocusTargets};
+///
+/// let targets = FocusTargets::from_targets([
+///     FocusTarget::new("disabled", Rect::new(0, 0, 10, 1), 0).disabled(true),
+///     FocusTarget::new("enabled", Rect::new(0, 1, 10, 1), 1),
+/// ]);
+/// let mut focus = FocusState::default();
+///
+/// focus.next(&targets);
+/// assert_eq!(focus.focused(), Some("enabled"));
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FocusTarget<Id = usize> {
+    /// Application-owned target id.
+    ///
+    /// This should match the id used by the app to update the focused control, row, or cell. Use
+    /// integers for generated indexed regions, string names for examples or diagnostics, enums for
+    /// normal app controls, and stable record keys for reorderable data.
+    pub id: Id,
+
+    /// Current frame area for the focus target.
+    ///
+    /// This is used for pointer-to-focus routing and for drawing focus indicators.
+    pub area: Rect,
+
+    /// Traversal order. Lower values are visited first.
+    ///
+    /// Use visual order for predictable keyboard navigation. Targets with equal order keep their
+    /// relative order after sorting unspecified by this API, so prefer distinct values.
+    pub order: u16,
+
+    /// Whether focus traversal should skip this target.
+    ///
+    /// Disabled targets stay in the target set for diagnostics and stable structure but are
+    /// skipped by traversal and hit-based focus.
+    pub disabled: bool,
+}
+
+impl<Id> FocusTarget<Id> {
+    /// Creates an enabled focus target.
+    ///
+    /// Use this when a region should participate in traversal for the current frame.
+    ///
+    /// # Examples
+    ///
+    /// Add two rendered form fields to a traversal target set:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([
+    ///     FocusTarget::new("name", Rect::new(0, 0, 20, 1), 0),
+    ///     FocusTarget::new("email", Rect::new(0, 1, 20, 1), 1),
+    /// ]);
+    ///
+    /// assert_eq!(plan.first_enabled().unwrap().id, "name");
+    /// ```
+    pub const fn new(id: Id, area: Rect, order: u16) -> Self {
+        Self {
+            id,
+            area,
+            order,
+            disabled: false,
+        }
+    }
+
+    /// Sets whether the target is disabled.
+    ///
+    /// This supports visible-but-unavailable controls, such as a disabled Save button.
+    ///
+    /// # Examples
+    ///
+    /// Keep a command visible while skipping it during keyboard traversal:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusState, FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([
+    ///     FocusTarget::new("save", Rect::new(0, 0, 6, 1), 0).disabled(true),
+    ///     FocusTarget::new("cancel", Rect::new(7, 0, 8, 1), 1),
+    /// ]);
+    /// let mut focus = FocusState::default();
+    /// focus.next(&plan);
+    ///
+    /// assert_eq!(focus.focused(), Some("cancel"));
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub const fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Creates a focus target from a layout region.
+    ///
+    /// This is the common bridge when every visible region is focusable and traversal order is
+    /// known by the caller.
+    ///
+    /// # Examples
+    ///
+    /// Convert a single layout region into a focus target when the surrounding code owns the order:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::FocusTarget;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let region = Region::new("search", Rect::new(0, 0, 20, 1));
+    /// let target = FocusTarget::from_region(region, 0);
+    ///
+    /// assert_eq!(target.id, "search");
+    /// assert_eq!(target.area, Rect::new(0, 0, 20, 1));
+    /// ```
+    pub fn from_region(region: Region<Id>, order: u16) -> Self {
+        Self::new(region.id, region.area, order)
+    }
+
+    /// Moves the target area by a signed offset.
+    ///
+    /// Use this when a child focus target collection was solved in local coordinates and then
+    /// merged into a parent frame.
+    ///
+    /// # Examples
+    ///
+    /// Place a child-local field target into its parent dialog:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::FocusTarget;
+    ///
+    /// let placed = FocusTarget::new("field", Rect::new(0, 0, 10, 1), 0).translate(5, 3);
+    ///
+    /// assert_eq!(placed.area, Rect::new(5, 3, 10, 1));
+    /// ```
+    #[must_use = "method returns the translated target"]
+    pub const fn translate(mut self, dx: i16, dy: i16) -> Self {
+        self.area = translate_rect(self.area, dx, dy);
+        self
+    }
+
+    /// Clips the target to a visible viewport.
+    ///
+    /// Returns `None` when the target is entirely outside the viewport.
+    ///
+    /// # Examples
+    ///
+    /// Drop focus targets that are outside a scroll viewport:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::FocusTarget;
+    ///
+    /// let target = FocusTarget::new("row", Rect::new(0, 5, 20, 1), 0);
+    ///
+    /// assert!(target.clip_to(Rect::new(0, 0, 20, 3)).is_none());
+    /// ```
+    pub fn clip_to(mut self, viewport: Rect) -> Option<Self> {
+        self.area = intersect(self.area, viewport)?;
+        Some(self)
+    }
+
+    fn contains<P: Into<Position>>(&self, position: P) -> bool {
+        self.area.contains(position.into())
+    }
+}
+
+/// Focusable targets for one frame.
+///
+/// Use [`FocusTargets`](crate::focus::FocusTargets) after solving layout when the app needs to move
+/// focus or route keyboard input. The target set is rebuilt each frame from visible
+/// [`FocusTarget`](crate::focus::FocusTarget) values. Persistent focus lives in
+/// [`FocusState`](crate::focus::FocusState).
+///
+/// # Common uses
+///
+/// - Build from a dialog's visible fields and call
+///   [`FocusState::next`](crate::focus::FocusState::next) on Tab.
+/// - Build from a grid's visible cells and call
+///   [`FocusState::focus_at`](crate::focus::FocusState::focus_at) after a mouse press.
+/// - Clip or translate a child focus target collection before merging it into a parent
+///   [`crate::frame::FrameSnapshot`].
+///
+/// # Constructors and builders
+///
+/// - [`FocusTargets::new`](crate::focus::FocusTargets::new) creates an empty target set.
+/// - [`FocusTargets::from_targets`](crate::focus::FocusTargets::from_targets) creates a target set
+///   and sorts by traversal order.
+/// - [`FocusTargets::from_regions`](crate::focus::FocusTargets::from_regions) creates targets from
+///   layout regions in iterator order.
+/// - [`FocusTargets::target`](crate::focus::FocusTargets::target) appends one target and keeps
+///   traversal sorted.
+/// - [`FocusTargets::extend`](crate::focus::FocusTargets::extend) and
+///   [`FocusTargets::merge`](crate::focus::FocusTargets::merge) combine child target lists.
+///
+/// # Composition and inspection
+///
+/// - [`FocusTargets::targets`](crate::focus::FocusTargets::targets) returns focus targets in
+///   traversal order.
+/// - [`FocusTargets::map_id`](crate::focus::FocusTargets::map_id) converts child ids into app-level
+///   ids.
+/// - [`FocusTargets::translate`](crate::focus::FocusTargets::translate) moves child-local targets
+///   into parent coordinates.
+/// - [`FocusTargets::clip_to`](crate::focus::FocusTargets::clip_to) removes hidden targets.
+/// - [`FocusTargets::first_enabled`](crate::focus::FocusTargets::first_enabled) and
+///   [`FocusTargets::last_enabled`](crate::focus::FocusTargets::last_enabled) find traversal
+///   endpoints.
+/// - [`FocusTargets::target_at`](crate::focus::FocusTargets::target_at) routes a terminal position
+///   to an enabled focus target.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+///
+/// let local = FocusTargets::from_targets([FocusTarget::new(0, Rect::new(0, 0, 10, 1), 0)]);
+/// let parent = local.translate(5, 2).map_id(|id| ("dialog", id));
+///
+/// assert_eq!(parent.targets()[0].id, ("dialog", 0));
+/// assert_eq!(parent.targets()[0].area, Rect::new(5, 2, 10, 1));
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FocusTargets<Id = usize> {
+    targets: Vec<FocusTarget<Id>>,
+}
+
+impl<Id> Default for FocusTargets<Id> {
+    fn default() -> Self {
+        Self {
+            targets: Vec::new(),
+        }
+    }
+}
+
+impl<Id> FocusTargets<Id> {
+    /// Creates an empty focus target collection.
+    ///
+    /// Use this before the first frame or for views with no keyboard-focusable controls.
+    ///
+    /// # Examples
+    ///
+    /// Store an empty target set before the first render has produced focus targets:
+    ///
+    /// ```rust
+    /// use ratatui_layout::focus::FocusTargets;
+    ///
+    /// let previous_frame = FocusTargets::<()>::new();
+    ///
+    /// assert!(previous_frame.targets().is_empty());
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            targets: Vec::new(),
+        }
+    }
+
+    /// Creates a focus target collection from targets.
+    ///
+    /// The targets are sorted by [`FocusTarget::order`](crate::focus::FocusTarget::order) so
+    /// traversal follows the declared order rather than the input iterator.
+    ///
+    /// # Examples
+    ///
+    /// Declare traversal order independently from construction order:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([
+    ///     FocusTarget::new("second", Rect::new(0, 1, 10, 1), 1),
+    ///     FocusTarget::new("first", Rect::new(0, 0, 10, 1), 0),
+    /// ]);
+    ///
+    /// assert_eq!(plan.targets()[0].id, "first");
+    /// ```
+    pub fn from_targets(targets: impl Into<Vec<FocusTarget<Id>>>) -> Self {
+        let mut targets = targets.into();
+        targets.sort_by_key(|target| target.order);
+        Self { targets }
+    }
+
+    /// Creates a focus target collection from layout regions.
+    ///
+    /// Iterator order becomes traversal order. Use this when every visible region should receive
+    /// keyboard focus.
+    ///
+    /// # Examples
+    ///
+    /// Build dialog focus from the same regions used for rendering:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::FocusTargets;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let fields = Regions::from_regions(
+    ///     Rect::new(0, 0, 20, 2),
+    ///     [
+    ///         Region::new("title", Rect::new(0, 0, 20, 1)),
+    ///         Region::new("owner", Rect::new(0, 1, 20, 1)),
+    ///     ],
+    /// );
+    /// let focus = FocusTargets::from_regions(fields.regions().iter().copied());
+    ///
+    /// assert_eq!(focus.targets()[1].id, "owner");
+    /// ```
+    pub fn from_regions(regions: impl IntoIterator<Item = Region<Id>>) -> Self
+    where
+        Id: Copy,
+    {
+        Self::from_targets(
+            regions
+                .into_iter()
+                .enumerate()
+                .map(|(order, region)| FocusTarget::from_region(region, order as u16))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Adds a target and returns the modified target set.
+    ///
+    /// # Examples
+    ///
+    /// Build a small dialog focus target collection as fields are rendered:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::new()
+    ///     .target(FocusTarget::new("title", Rect::new(0, 0, 20, 1), 0))
+    ///     .target(FocusTarget::new("body", Rect::new(0, 2, 20, 1), 1));
+    ///
+    /// assert_eq!(plan.last_enabled().unwrap().id, "body");
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn target(mut self, target: FocusTarget<Id>) -> Self {
+        self.targets.push(target);
+        self.targets.sort_by_key(|target| target.order);
+        self
+    }
+
+    /// Returns all focus targets in traversal order.
+    ///
+    /// # Examples
+    ///
+    /// Render focus indicators in the same order keyboard traversal will use:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([
+    ///     FocusTarget::new("a", Rect::new(0, 0, 1, 1), 0),
+    ///     FocusTarget::new("b", Rect::new(1, 0, 1, 1), 1),
+    /// ]);
+    /// let ids: Vec<_> = plan.targets().iter().map(|target| target.id).collect();
+    ///
+    /// assert_eq!(ids, ["a", "b"]);
+    /// ```
+    pub fn targets(&self) -> &[FocusTarget<Id>] {
+        &self.targets
+    }
+
+    /// Extends the target set with additional targets and keeps traversal order sorted.
+    ///
+    /// Use this when a parent aggregates focus targets from multiple child components.
+    ///
+    /// # Examples
+    ///
+    /// Append footer controls to the current form targets:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// let mut plan =
+    ///     FocusTargets::from_targets([FocusTarget::new("field", Rect::new(0, 0, 20, 1), 0)]);
+    /// plan.extend([FocusTarget::new("save", Rect::new(0, 2, 8, 1), 10)]);
+    ///
+    /// assert_eq!(plan.targets()[1].id, "save");
+    /// ```
+    pub fn extend<I>(&mut self, targets: I)
+    where
+        I: IntoIterator<Item = FocusTarget<Id>>,
+    {
+        self.targets.extend(targets);
+        self.targets.sort_by_key(|target| target.order);
+    }
+
+    /// Returns a target set containing this set's targets and another set's targets.
+    ///
+    /// # Examples
+    ///
+    /// Merge sibling component focus target collections into one frame-local traversal set:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// let form = FocusTargets::from_targets([FocusTarget::new("name", Rect::new(0, 0, 10, 1), 0)]);
+    /// let footer = FocusTargets::from_targets([FocusTarget::new("save", Rect::new(0, 2, 6, 1), 1)]);
+    ///
+    /// assert_eq!(form.merge(footer).last_enabled().unwrap().id, "save");
+    /// ```
+    #[must_use = "method returns the merged plan"]
+    pub fn merge(mut self, other: Self) -> Self {
+        self.extend(other.targets);
+        self
+    }
+
+    /// Maps target ids while preserving areas, order, and disabled state.
+    ///
+    /// This is useful when a child component uses local ids but the parent stores focus using a
+    /// broader app-level id enum.
+    ///
+    /// # Examples
+    ///
+    /// Lift local child ids into an app-level enum before storing focus state:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum Region {
+    ///     Dialog(usize),
+    /// }
+    ///
+    /// let child = FocusTargets::from_targets([FocusTarget::new(0, Rect::new(0, 0, 10, 1), 0)]);
+    /// let parent = child.map_id(Region::Dialog);
+    ///
+    /// assert_eq!(parent.targets()[0].id, Region::Dialog(0));
+    /// ```
+    pub fn map_id<NextId, F>(self, mut map: F) -> FocusTargets<NextId>
+    where
+        F: FnMut(Id) -> NextId,
+    {
+        FocusTargets::from_targets(
+            self.targets
+                .into_iter()
+                .map(|target| FocusTarget {
+                    id: map(target.id),
+                    area: target.area,
+                    order: target.order,
+                    disabled: target.disabled,
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Moves all target areas by a signed offset.
+    ///
+    /// # Examples
+    ///
+    /// Place a child form solved at local origin inside a dialog:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// let child = FocusTargets::from_targets([FocusTarget::new("field", Rect::new(0, 0, 12, 1), 0)]);
+    /// let placed = child.translate(4, 2);
+    ///
+    /// assert_eq!(placed.targets()[0].area, Rect::new(4, 2, 12, 1));
+    /// ```
+    #[must_use = "method returns the translated plan"]
+    pub fn translate(mut self, dx: i16, dy: i16) -> Self {
+        self.targets = self
+            .targets
+            .into_iter()
+            .map(|target| target.translate(dx, dy))
+            .collect();
+        self
+    }
+
+    /// Clips all target areas to a viewport and drops targets outside it.
+    ///
+    /// # Examples
+    ///
+    /// Keep traversal aligned with rows visible inside a scroll viewport:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([
+    ///     FocusTarget::new("visible", Rect::new(0, 1, 20, 1), 0),
+    ///     FocusTarget::new("hidden", Rect::new(0, 5, 20, 1), 1),
+    /// ])
+    /// .clip_to(Rect::new(0, 0, 20, 3));
+    ///
+    /// assert_eq!(plan.targets().len(), 1);
+    /// ```
+    #[must_use = "method returns the clipped plan"]
+    pub fn clip_to(mut self, viewport: Rect) -> Self {
+        self.targets = self
+            .targets
+            .into_iter()
+            .filter_map(|target| target.clip_to(viewport))
+            .collect();
+        self
+    }
+
+    /// Returns the first enabled target.
+    ///
+    /// This is useful for initializing focus after a view first appears.
+    ///
+    /// # Examples
+    ///
+    /// Initialize dialog focus to the first enabled field:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([
+    ///     FocusTarget::new("disabled", Rect::new(0, 0, 10, 1), 0).disabled(true),
+    ///     FocusTarget::new("name", Rect::new(0, 1, 10, 1), 1),
+    /// ]);
+    ///
+    /// assert_eq!(plan.first_enabled().unwrap().id, "name");
+    /// ```
+    pub fn first_enabled(&self) -> Option<&FocusTarget<Id>> {
+        self.targets.iter().find(|target| !target.disabled)
+    }
+
+    /// Returns the last enabled target.
+    ///
+    /// This is useful for reverse traversal when nothing is currently focused.
+    ///
+    /// # Examples
+    ///
+    /// Start reverse traversal at the last enabled target:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([
+    ///     FocusTarget::new("first", Rect::new(0, 0, 10, 1), 0),
+    ///     FocusTarget::new("last", Rect::new(0, 1, 10, 1), 1),
+    /// ]);
+    ///
+    /// assert_eq!(plan.last_enabled().unwrap().id, "last");
+    /// ```
+    pub fn last_enabled(&self) -> Option<&FocusTarget<Id>> {
+        self.targets.iter().rev().find(|target| !target.disabled)
+    }
+}
+
+const fn translate_rect(rect: Rect, dx: i16, dy: i16) -> Rect {
+    Rect::new(
+        translate_coordinate(rect.x, dx),
+        translate_coordinate(rect.y, dy),
+        rect.width,
+        rect.height,
+    )
+}
+
+const fn translate_coordinate(value: u16, delta: i16) -> u16 {
+    if delta.is_negative() {
+        value.saturating_sub(delta.unsigned_abs())
+    } else {
+        value.saturating_add(delta as u16)
+    }
+}
+
+fn intersect(a: Rect, b: Rect) -> Option<Rect> {
+    let x = a.x.max(b.x);
+    let y = a.y.max(b.y);
+    let right = a.right().min(b.right());
+    let bottom = a.bottom().min(b.bottom());
+
+    (x < right && y < bottom).then(|| Rect::new(x, y, right - x, bottom - y))
+}
+
+impl<Id: Copy + Eq> FocusTargets<Id> {
+    /// Returns the enabled target at the given position.
+    ///
+    /// # Examples
+    ///
+    /// Move keyboard focus to the field under a mouse press:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([FocusTarget::new("name", Rect::new(0, 0, 20, 1), 0)]);
+    ///
+    /// assert_eq!(plan.target_at((3, 0)).unwrap().id, "name");
+    /// ```
+    pub fn target_at<P: Into<Position>>(&self, position: P) -> Option<&FocusTarget<Id>> {
+        let position = position.into();
+        self.targets
+            .iter()
+            .rev()
+            .find(|target| !target.disabled && target.contains(position))
+    }
+
+    fn target_index(&self, id: Id) -> Option<usize> {
+        self.targets
+            .iter()
+            .position(|target| !target.disabled && target.id == id)
+    }
+
+    fn next_after(&self, index: usize) -> Option<&FocusTarget<Id>> {
+        self.targets[index + 1..]
+            .iter()
+            .chain(self.targets[..=index].iter())
+            .find(|target| !target.disabled)
+    }
+
+    fn previous_before(&self, index: usize) -> Option<&FocusTarget<Id>> {
+        self.targets[..index]
+            .iter()
+            .rev()
+            .chain(self.targets[index..].iter().rev())
+            .find(|target| !target.disabled)
+    }
+}
+
+/// Fallback policy for stale focus.
+///
+/// [`FocusState`](crate::focus::FocusState) persists between frames, while
+/// [`FocusTargets`](crate::focus::FocusTargets) is rebuilt from visible targets. Filtering,
+/// resizing, or disabling a control can make the stored id stale. This enum names the repair policy
+/// used by [`FocusState::ensure_visible`](crate::focus::FocusState::ensure_visible).
+///
+/// Use [`FocusFallback::First`](crate::focus::FocusFallback::First) for ordinary forms, toolbars,
+/// and menus where focus should remain usable after a target disappears. Use
+/// [`FocusFallback::Last`](crate::focus::FocusFallback::Last) for reverse traversal or footer
+/// controls that should keep focus near the end. Use
+/// [`FocusFallback::Clear`](crate::focus::FocusFallback::Clear) when a view should stop receiving
+/// keyboard input until the app explicitly focuses something else.
+///
+/// # Variants
+///
+/// - [`FocusFallback::Clear`](crate::focus::FocusFallback::Clear) removes focus when the stored id
+///   is stale.
+/// - [`FocusFallback::First`](crate::focus::FocusFallback::First) moves stale focus to the first
+///   enabled target.
+/// - [`FocusFallback::Last`](crate::focus::FocusFallback::Last) moves stale focus to the last
+///   enabled target.
+///
+/// # Examples
+///
+/// Keep toolbar focus usable when the focused command becomes disabled:
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::focus::{FocusFallback, FocusState, FocusTarget, FocusTargets};
+///
+/// let targets = FocusTargets::from_targets([
+///     FocusTarget::new("save", Rect::new(0, 0, 6, 1), 0).disabled(true),
+///     FocusTarget::new("cancel", Rect::new(7, 0, 8, 1), 1),
+/// ]);
+/// let mut focus = FocusState::default();
+/// focus.focus(Some("save"));
+/// focus.ensure_visible(&targets, FocusFallback::First);
+///
+/// assert_eq!(focus.focused(), Some("cancel"));
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum FocusFallback {
+    /// Clear stale focus.
+    ///
+    /// Use this when focus should not jump to another target automatically.
+    #[default]
+    Clear,
+    /// Move stale focus to the first enabled target.
+    ///
+    /// This is the common policy for forms, command strips, and menus.
+    First,
+    /// Move stale focus to the last enabled target.
+    ///
+    /// This supports reverse traversal and footer-like focus groups.
+    Last,
+}
+
+/// Persistent focus state for an app or component.
+///
+/// Use [`FocusState`](crate::focus::FocusState) next to the data it controls. Each frame, pair it
+/// with the current [`FocusTargets`](crate::focus::FocusTargets) to clamp stale focus and move to
+/// the next visible enabled target.
+///
+/// # Common uses
+///
+/// - Store the focused form field while the form is redrawn every frame.
+/// - Keep focus stable across resizes by clamping it to the current
+///   [`FocusTargets`](crate::focus::FocusTargets).
+/// - Move focus from a mouse click by pairing
+///   [`FocusState::focus_at`](crate::focus::FocusState::focus_at) with the previous frame's target
+///   set.
+///
+/// # Accessors and updates
+///
+/// - [`FocusState::focused`](crate::focus::FocusState::focused) returns the current focused id.
+/// - [`FocusState::focus`](crate::focus::FocusState::focus) sets focus directly.
+/// - [`FocusState::clear`](crate::focus::FocusState::clear) removes focus.
+/// - [`FocusState::first`](crate::focus::FocusState::first) and
+///   [`FocusState::last`](crate::focus::FocusState::last) jump to traversal endpoints.
+/// - [`FocusState::next`](crate::focus::FocusState::next) and
+///   [`FocusState::previous`](crate::focus::FocusState::previous) move through enabled targets.
+/// - [`FocusState::focus_at`](crate::focus::FocusState::focus_at) moves focus to the enabled target
+///   under a position.
+/// - [`FocusState::ensure_visible`](crate::focus::FocusState::ensure_visible) repairs stale focus
+///   with an explicit [`FocusFallback`](crate::focus::FocusFallback).
+/// - [`FocusState::clamp_to`](crate::focus::FocusState::clamp_to) clears stale focus after
+///   filtering, scrolling, or disabling targets.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::focus::{FocusState, FocusTarget, FocusTargets};
+///
+/// let targets =
+///     FocusTargets::from_targets([FocusTarget::new("field", Rect::new(4, 2, 10, 1), 0)]);
+/// let mut focus = FocusState::default();
+///
+/// focus.focus_at(&targets, (6, 2));
+/// assert_eq!(focus.focused(), Some("field"));
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FocusState<Id = usize> {
+    focused: Option<Id>,
+}
+
+impl<Id> Default for FocusState<Id> {
+    fn default() -> Self {
+        Self { focused: None }
+    }
+}
+
+impl<Id> FocusState<Id> {
+    /// Returns the focused id.
+    ///
+    /// The id is app-owned; use it to decide which field receives keyboard input or which control
+    /// should draw a focused style.
+    ///
+    /// # Examples
+    ///
+    /// Read the focused id while deciding which input receives a key event:
+    ///
+    /// ```rust
+    /// use ratatui_layout::focus::FocusState;
+    ///
+    /// let mut focus = FocusState::default();
+    /// focus.focus(Some("search"));
+    ///
+    /// assert_eq!(focus.focused(), Some("search"));
+    /// ```
+    pub const fn focused(&self) -> Option<Id>
+    where
+        Id: Copy,
+    {
+        self.focused
+    }
+
+    /// Sets the focused id.
+    ///
+    /// This does not validate against a target set. Call
+    /// [`FocusState::clamp_to`](crate::focus::FocusState::clamp_to) after rendering
+    /// if the focused id may have become hidden or disabled.
+    ///
+    /// # Examples
+    ///
+    /// Restore focus from app state before the next frame clamps it:
+    ///
+    /// ```rust
+    /// use ratatui_layout::focus::FocusState;
+    ///
+    /// let mut focus = FocusState::default();
+    /// focus.focus(Some("email"));
+    ///
+    /// assert_eq!(focus.focused(), Some("email"));
+    /// ```
+    pub fn focus(&mut self, focused: Option<Id>) {
+        self.focused = focused;
+    }
+
+    /// Clears focus.
+    ///
+    /// Use this when closing a view or when keyboard input should stop targeting the current
+    /// control.
+    ///
+    /// # Examples
+    ///
+    /// Clear stale focus when a modal closes:
+    ///
+    /// ```rust
+    /// use ratatui_layout::focus::FocusState;
+    ///
+    /// let mut focus = FocusState::default();
+    /// focus.focus(Some("modal-field"));
+    /// focus.clear();
+    ///
+    /// assert_eq!(focus.focused(), None);
+    /// ```
+    pub fn clear(&mut self) {
+        self.focused = None;
+    }
+}
+
+impl<Id: Copy + Eq> FocusState<Id> {
+    /// Moves focus to the first enabled target.
+    ///
+    /// This is the typical initialization step when a dialog opens and nothing is focused yet.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusState, FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([FocusTarget::new("first", Rect::new(0, 0, 1, 1), 0)]);
+    /// let mut focus = FocusState::default();
+    /// focus.first(&plan);
+    ///
+    /// assert_eq!(focus.focused(), Some("first"));
+    /// ```
+    pub fn first(&mut self, plan: &FocusTargets<Id>) {
+        self.focused = plan.first_enabled().map(|target| target.id);
+    }
+
+    /// Moves focus to the last enabled target.
+    ///
+    /// This supports reverse traversal from an empty focus state.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusState, FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([
+    ///     FocusTarget::new("first", Rect::new(0, 0, 1, 1), 0),
+    ///     FocusTarget::new("last", Rect::new(1, 0, 1, 1), 1),
+    /// ]);
+    /// let mut focus = FocusState::default();
+    /// focus.last(&plan);
+    ///
+    /// assert_eq!(focus.focused(), Some("last"));
+    /// ```
+    pub fn last(&mut self, plan: &FocusTargets<Id>) {
+        self.focused = plan.last_enabled().map(|target| target.id);
+    }
+
+    /// Moves focus to the next enabled target, wrapping at the end.
+    ///
+    /// Use this for Tab, Down, or Right depending on the view's interaction model.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusState, FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([
+    ///     FocusTarget::new("a", Rect::new(0, 0, 1, 1), 0),
+    ///     FocusTarget::new("b", Rect::new(1, 0, 1, 1), 1),
+    /// ]);
+    /// let mut focus = FocusState::default();
+    /// focus.next(&plan);
+    /// focus.next(&plan);
+    ///
+    /// assert_eq!(focus.focused(), Some("b"));
+    /// ```
+    pub fn next(&mut self, plan: &FocusTargets<Id>) {
+        self.focused = match self.focused.and_then(|id| plan.target_index(id)) {
+            Some(index) => plan.next_after(index).map(|target| target.id),
+            None => plan.first_enabled().map(|target| target.id),
+        };
+    }
+
+    /// Moves focus to the previous enabled target, wrapping at the start.
+    ///
+    /// Use this for Shift-Tab, Up, or Left depending on the view's interaction model.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusState, FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([
+    ///     FocusTarget::new("a", Rect::new(0, 0, 1, 1), 0),
+    ///     FocusTarget::new("b", Rect::new(1, 0, 1, 1), 1),
+    /// ]);
+    /// let mut focus = FocusState::default();
+    /// focus.previous(&plan);
+    ///
+    /// assert_eq!(focus.focused(), Some("b"));
+    /// ```
+    pub fn previous(&mut self, plan: &FocusTargets<Id>) {
+        self.focused = match self.focused.and_then(|id| plan.target_index(id)) {
+            Some(index) => plan.previous_before(index).map(|target| target.id),
+            None => plan.last_enabled().map(|target| target.id),
+        };
+    }
+
+    /// Focuses the enabled target at a terminal position.
+    ///
+    /// This is useful after a mouse press when pointer routing and keyboard focus should converge
+    /// on the same control.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusState, FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([FocusTarget::new("field", Rect::new(2, 0, 10, 1), 0)]);
+    /// let mut focus = FocusState::default();
+    /// focus.focus_at(&plan, (3, 0));
+    ///
+    /// assert_eq!(focus.focused(), Some("field"));
+    /// ```
+    pub fn focus_at<P: Into<Position>>(&mut self, plan: &FocusTargets<Id>, position: P) {
+        self.focused = plan.target_at(position).map(|target| target.id);
+    }
+
+    /// Keeps valid focus or applies a fallback.
+    ///
+    /// Call this after a render pass builds the current
+    /// [`FocusTargets`](crate::focus::FocusTargets).
+    ///
+    /// # Examples
+    ///
+    /// Fall back to the first enabled command after the focused command becomes disabled:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusFallback, FocusState, FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([
+    ///     FocusTarget::new("run", Rect::new(0, 0, 5, 1), 0).disabled(true),
+    ///     FocusTarget::new("help", Rect::new(6, 0, 6, 1), 1),
+    /// ]);
+    /// let mut focus = FocusState::default();
+    /// focus.focus(Some("run"));
+    /// focus.ensure_visible(&plan, FocusFallback::First);
+    ///
+    /// assert_eq!(focus.focused(), Some("help"));
+    /// ```
+    pub fn ensure_visible(&mut self, plan: &FocusTargets<Id>, fallback: FocusFallback) {
+        if self.focused.and_then(|id| plan.target_index(id)).is_some() {
+            return;
+        }
+
+        self.focused = match fallback {
+            FocusFallback::Clear => None,
+            FocusFallback::First => plan.first_enabled().map(|target| target.id),
+            FocusFallback::Last => plan.last_enabled().map(|target| target.id),
+        };
+    }
+
+    /// Clears stale focus.
+    ///
+    /// This is shorthand for
+    /// [`FocusState::ensure_visible`](crate::focus::FocusState::ensure_visible) with
+    /// [`FocusFallback::Clear`](crate::focus::FocusFallback::Clear).
+    ///
+    /// # Examples
+    ///
+    /// Clear focus when filtering removes the focused row from the visible target set:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusState, FocusTarget, FocusTargets};
+    ///
+    /// let plan = FocusTargets::from_targets([FocusTarget::new("visible", Rect::new(0, 0, 1, 1), 0)]);
+    /// let mut focus = FocusState::default();
+    /// focus.focus(Some("hidden"));
+    /// focus.clamp_to(&plan);
+    ///
+    /// assert_eq!(focus.focused(), None);
+    /// ```
+    pub fn clamp_to(&mut self, plan: &FocusTargets<Id>) {
+        self.ensure_visible(plan, FocusFallback::Clear);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use ratatui_core::layout::Rect;
+
+    use super::*;
+
+    #[test]
+    fn traversal_skips_disabled_targets() {
+        let plan = FocusTargets::from_targets([
+            FocusTarget::new("first", Rect::new(0, 0, 1, 1), 0),
+            FocusTarget::new("disabled", Rect::new(1, 0, 1, 1), 1).disabled(true),
+            FocusTarget::new("last", Rect::new(2, 0, 1, 1), 2),
+        ]);
+        let mut state = FocusState::default();
+
+        state.next(&plan);
+        assert_eq!(state.focused(), Some("first"));
+
+        state.next(&plan);
+        assert_eq!(state.focused(), Some("last"));
+
+        state.next(&plan);
+        assert_eq!(state.focused(), Some("first"));
+    }
+
+    #[test]
+    fn focus_at_uses_enabled_target_under_position() {
+        let plan = FocusTargets::from_targets([
+            FocusTarget::new("disabled", Rect::new(0, 0, 4, 1), 0).disabled(true),
+            FocusTarget::new("enabled", Rect::new(0, 0, 4, 1), 1),
+        ]);
+        let mut state = FocusState::default();
+
+        state.focus_at(&plan, (1, 0));
+
+        assert_eq!(state.focused(), Some("enabled"));
+    }
+
+    #[test]
+    fn from_regions_uses_iterator_order() {
+        let plan = FocusTargets::from_regions([
+            Region::new("title", Rect::new(0, 0, 10, 1)),
+            Region::new("owner", Rect::new(0, 1, 10, 1)),
+        ]);
+
+        assert_eq!(plan.targets()[0].id, "title");
+        assert_eq!(plan.targets()[0].order, 0);
+        assert_eq!(plan.targets()[1].id, "owner");
+        assert_eq!(plan.targets()[1].order, 1);
+    }
+
+    #[test]
+    fn ensure_visible_keeps_valid_focus() {
+        let plan = FocusTargets::from_targets([
+            FocusTarget::new("first", Rect::new(0, 0, 1, 1), 0),
+            FocusTarget::new("second", Rect::new(1, 0, 1, 1), 1),
+        ]);
+        let mut state = FocusState::default();
+
+        state.focus(Some("second"));
+        state.ensure_visible(&plan, FocusFallback::First);
+
+        assert_eq!(state.focused(), Some("second"));
+    }
+
+    #[test]
+    fn ensure_visible_uses_declared_fallback_for_stale_focus() {
+        let plan = FocusTargets::from_targets([
+            FocusTarget::new("disabled", Rect::new(0, 0, 1, 1), 0).disabled(true),
+            FocusTarget::new("first", Rect::new(1, 0, 1, 1), 1),
+            FocusTarget::new("last", Rect::new(2, 0, 1, 1), 2),
+        ]);
+        let mut state = FocusState::default();
+
+        state.focus(Some("missing"));
+        state.ensure_visible(&plan, FocusFallback::First);
+        assert_eq!(state.focused(), Some("first"));
+
+        state.focus(Some("missing"));
+        state.ensure_visible(&plan, FocusFallback::Last);
+        assert_eq!(state.focused(), Some("last"));
+
+        state.focus(Some("missing"));
+        state.ensure_visible(&plan, FocusFallback::Clear);
+        assert_eq!(state.focused(), None);
+    }
+}

--- a/crates/ratatui-layout/src/frame.rs
+++ b/crates/ratatui-layout/src/frame.rs
@@ -1,0 +1,1674 @@
+//! Aggregate frame-local UI data.
+//!
+//! Immediate-mode apps usually handle input after the previous frame was drawn. That means a click,
+//! focus movement, or cursor decision often needs the data produced by the last render pass, not a
+//! retained widget tree. [`FrameSnapshot`](crate::frame::FrameSnapshot) is the value a component
+//! can return when it wants to expose that data as data.
+//!
+//! A [`FrameSnapshot`](crate::frame::FrameSnapshot) is the optional coordination layer above
+//! individual [`Regions`](crate::regions::Regions), [`FocusTargets`](crate::focus::FocusTargets),
+//! [`PointerTargets`](crate::pointer::PointerTargets), and
+//! [`CursorRequests`](crate::cursor::CursorRequests) values. A render pass builds it from visible
+//! UI data, the app stores it, and the next input event can route through the previous
+//! frame without requiring a retained widget tree.
+//!
+//! Use the smaller values directly when only one concern is needed.
+//! [`FrameSnapshot`](crate::frame::FrameSnapshot) is useful when a component boundary needs to
+//! return several concerns together.
+//!
+//! # Type
+//!
+//! - [`FrameSnapshot`](crate::frame::FrameSnapshot) aggregates the frame-local data produced by
+//!   rendering: geometry, keyboard focus targets, pointer targets, and cursor requests.
+//! - [`FrameTargets`](crate::frame::FrameTargets) builds a
+//!   [`FrameSnapshot`](crate::frame::FrameSnapshot) from visible regions when layout, pointer, and
+//!   focus target data should stay aligned.
+//! - [`RegionTargets`](crate::frame::RegionTargets) starts from an existing
+//!   [`Regions`](crate::regions::Regions) and adds focus, pointer, disabled, and z-order policy
+//!   before building a [`FrameSnapshot`](crate::frame::FrameSnapshot).
+//!
+//! # Common uses
+//!
+//! - Store a previous frame so the next pointer event can route through the regions that were
+//!   actually visible.
+//! - Return one value from a component that produced geometry, keyboard focus targets, pointer
+//!   targets, and cursor requests.
+//! - Compose child components by mapping local ids into parent ids, translating local coordinates,
+//!   clipping hidden regions, and merging the results.
+//! - Preserve render-order cursor behavior across children, where later visible cursor requests can
+//!   win.
+//!
+//! # Examples
+//!
+//! Store previous-frame-local data and route the next event through them:
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::frame::FrameSnapshot;
+//! use ratatui_layout::regions::{Region, Regions};
+//!
+//! let previous_frame = FrameSnapshot::from_layout(Regions::from_regions(
+//!     Rect::new(0, 0, 20, 1),
+//!     [Region::new("save", Rect::new(10, 0, 10, 1))],
+//! ));
+//!
+//! assert_eq!(previous_frame.route_position((12, 0)).unwrap().id, "save");
+//! ```
+//!
+//! Pointer-specific targets can override layout fallback, which is useful for disabled controls or
+//! pointer-only regions:
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::frame::FrameSnapshot;
+//! use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+//! use ratatui_layout::regions::{Region, Regions};
+//!
+//! let layout_regions = Regions::from_regions(
+//!     Rect::new(0, 0, 10, 1),
+//!     [Region::new("layout", Rect::new(0, 0, 10, 1))],
+//! );
+//! let pointer_targets =
+//!     PointerTargets::from_targets([PointerTarget::new("mouse", Rect::new(0, 0, 10, 1))]);
+//! let frame = FrameSnapshot::from_layout(layout_regions).mouse(pointer_targets);
+//!
+//! assert_eq!(frame.route_position((1, 0)).unwrap().id, "mouse");
+//! ```
+//!
+//! See [`crate::docs::frame_snapshots`] for the full render-then-route model and
+//! [`crate::docs::widget_contracts`] for the future component/action direction that this type is
+//! intended to leave room for.
+
+use alloc::vec::Vec;
+
+use ratatui_core::layout::{Position, Rect};
+
+use crate::cursor::CursorRequests;
+use crate::focus::{FocusTarget, FocusTargets};
+use crate::pointer::{PointerTarget, PointerTargets};
+use crate::regions::{Hit, Region, Regions};
+
+/// UI coordination data produced by one render pass.
+///
+/// [`FrameSnapshot`](crate::frame::FrameSnapshot) owns frame-local geometry, focus targets, pointer
+/// targets, and cursor requests. It does not own app data, widgets, event callbacks, selection, or
+/// retained children. Store it after rendering when the next event should use the previous frame's
+/// visible data.
+///
+/// The type is intentionally an aggregate, not a replacement for the smaller values. A component
+/// that only needs hit testing should return [`Regions`](crate::regions::Regions) or
+/// [`PointerTargets`](crate::pointer::PointerTargets) directly. Use
+/// [`FrameSnapshot`](crate::frame::FrameSnapshot) when a boundary would otherwise need to return
+/// several independent region and target values and the caller must keep their ids aligned.
+///
+/// # Constructors and setters
+///
+/// - [`FrameSnapshot::new`](crate::frame::FrameSnapshot::new) creates an empty aggregate for a
+///   solved area.
+/// - [`FrameSnapshot::from_layout`](crate::frame::FrameSnapshot::from_layout) starts from geometry
+///   and adds interaction data later.
+/// - [`FrameSnapshot::focus`](crate::frame::FrameSnapshot::focus) attaches a
+///   [`FocusTargets`](crate::focus::FocusTargets) produced by the same render pass.
+/// - [`FrameSnapshot::mouse`](crate::frame::FrameSnapshot::mouse) attaches a
+///   [`PointerTargets`](crate::pointer::PointerTargets) for pointer routing.
+/// - [`FrameSnapshot::mouse_target`](crate::frame::FrameSnapshot::mouse_target) adds one pointer
+///   target to an existing frame.
+/// - [`FrameSnapshot::scroll_region`](crate::frame::FrameSnapshot::scroll_region) adds a
+///   whole-region pointer target, commonly for wheel routing over blank pane space.
+/// - [`FrameSnapshot::cursor`](crate::frame::FrameSnapshot::cursor) attaches a
+///   [`CursorRequests`](crate::cursor::CursorRequests) for terminal cursor placement.
+///
+/// # Composition
+///
+/// - [`FrameSnapshot::merge`](crate::frame::FrameSnapshot::merge) appends a child frame's data to a
+///   parent frame.
+/// - [`FrameSnapshot::merge_child`](crate::frame::FrameSnapshot::merge_child) translates, clips,
+///   and merges a local child frame in one call.
+/// - [`FrameSnapshot::place_child`](crate::frame::FrameSnapshot::place_child) places a local child
+///   frame in an already solved screen area.
+/// - [`FrameSnapshot::translate`](crate::frame::FrameSnapshot::translate) moves child-local layout,
+///   focus, pointer, and cursor requests into parent coordinates.
+/// - [`FrameSnapshot::clip_to`](crate::frame::FrameSnapshot::clip_to) removes hidden child data
+///   before the snapshot is stored for input.
+/// - [`FrameSnapshot::map_id`](crate::frame::FrameSnapshot::map_id) converts child ids into
+///   application-level ids while preserving geometry and interaction behavior.
+///
+/// # Routing
+///
+/// - [`FrameSnapshot::route_position`](crate::frame::FrameSnapshot::route_position) routes broad
+///   position queries through pointer targets first and layout regions second, returning local
+///   coordinates in a [`crate::regions::Hit`].
+/// - [`FrameSnapshot::route_click`](crate::frame::FrameSnapshot::route_click),
+///   [`FrameSnapshot::route_hover`](crate::frame::FrameSnapshot::route_hover), and
+///   [`FrameSnapshot::route_scroll`](crate::frame::FrameSnapshot::route_scroll) are intent-named
+///   routes that use explicit pointer policy when a pointer target collection exists.
+///
+/// # Examples
+///
+/// Compose a child frame that solved local coordinates into a parent frame that uses app-level ids:
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::frame::FrameSnapshot;
+/// use ratatui_layout::regions::{Region, Regions};
+///
+/// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// enum AppRegion {
+///     Child(usize),
+///     Status,
+/// }
+///
+/// let child_regions = Regions::from_regions(
+///     Rect::new(0, 0, 8, 1),
+///     [Region::new(0, Rect::new(0, 0, 8, 1))],
+/// );
+/// let child_frame = FrameSnapshot::from_layout(child_regions)
+///     .map_id(AppRegion::Child)
+///     .translate(4, 2);
+/// let status = FrameSnapshot::from_layout(Regions::from_regions(
+///     Rect::new(0, 0, 20, 5),
+///     [Region::new(AppRegion::Status, Rect::new(0, 4, 20, 1))],
+/// ));
+///
+/// let frame = status.merge(child_frame);
+/// assert_eq!(
+///     frame.route_position((5, 2)).unwrap().id,
+///     AppRegion::Child(0)
+/// );
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct FrameSnapshot<Id = usize> {
+    /// Geometry data for visible regions.
+    ///
+    /// This is the broadest hit-test fallback and the source of renderable
+    /// [`crate::regions::Region`] values.
+    pub layout: Regions<Id>,
+    /// Keyboard traversal targets for visible controls.
+    ///
+    /// Persistent focused id remains in [`crate::focus::FocusState`]; this field records only the
+    /// targets visible in this frame.
+    pub focus: FocusTargets<Id>,
+    /// Pointer routing targets for visible controls.
+    ///
+    /// Persistent hover and pressed ids remain in [`crate::pointer::PointerState`]; this field
+    /// records only where pointer events can route for this frame.
+    pub mouse: PointerTargets<Id>,
+    /// Cursor requests emitted during rendering.
+    ///
+    /// The final cursor can be derived after all children have contributed requests.
+    pub cursor: CursorRequests,
+}
+
+/// Builder that turns visible regions into frame-local routing data.
+///
+/// Many components produce the same three data from the same solved rectangles: layout regions for
+/// geometry, pointer targets for pointer routing, and focus targets for keyboard traversal.
+/// [`FrameTargets`](crate::frame::FrameTargets) packages that pattern so component code can
+/// describe policy instead of manually keeping three values aligned.
+///
+/// The builder does not render and does not own application state. It consumes regions produced by
+/// a layout helper, maps local region ids into app ids, and records which regions are focusable or
+/// disabled for this frame. Use [`FrameSnapshot`](crate::frame::FrameSnapshot) directly when a
+/// component has only one or two ad-hoc targets; use [`FrameTargets`](crate::frame::FrameTargets)
+/// when a repeated list, grid, toolbar, or dialog field set would otherwise build
+/// [`Regions`](crate::regions::Regions), [`PointerTargets`](crate::pointer::PointerTargets), and
+/// [`FocusTargets`](crate::focus::FocusTargets) in parallel.
+///
+/// # Common Uses
+///
+/// - Turn virtual-list rows into layout, pointer, and focus targets.
+/// - Keep table header cells pointer-routable while making only body cells focusable.
+/// - Mark disabled toolbar buttons as visible layout regions while excluding them from focus and
+///   activation.
+/// - Assign higher z-order to overlay targets so hit testing follows render order.
+///
+/// # Examples
+///
+/// Build focus and pointer data for visible dialog fields:
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::frame::FrameTargets;
+/// use ratatui_layout::regions::Region;
+///
+/// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// enum Target {
+///     Field(&'static str),
+/// }
+///
+/// let regions = [
+///     Region::new("title", Rect::new(0, 0, 20, 1)),
+///     Region::new("owner", Rect::new(0, 1, 20, 1)),
+/// ];
+/// let frame =
+///     FrameTargets::new(Rect::new(0, 0, 20, 2), 10).build_focusable(regions, Target::Field);
+///
+/// assert_eq!(
+///     frame.route_click((1, 1)).unwrap().id,
+///     Target::Field("owner")
+/// );
+/// assert_eq!(frame.focus.targets()[0].order, 10);
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct FrameTargets<Id = usize> {
+    area: Rect,
+    z: u16,
+    focus_start: u16,
+    mouse_region: Option<(Id, Rect)>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+struct FrameTargetSlot<Id> {
+    region: Region<Id>,
+    focusable: bool,
+    mouseable: bool,
+    disabled: bool,
+}
+
+impl<Id> FrameTargets<Id> {
+    /// Starts a target builder for a component area.
+    ///
+    /// `focus_start` is the first focus order assigned to focusable regions. Parent components can
+    /// reserve ranges for children so traversal follows page order after values are merged.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    ///
+    /// let targets = FrameTargets::<&str>::new(Rect::new(0, 0, 10, 1), 20);
+    ///
+    /// assert_eq!(targets.focus_start(), 20);
+    /// ```
+    pub const fn new(area: Rect, focus_start: u16) -> Self {
+        Self {
+            area,
+            z: 0,
+            focus_start,
+            mouse_region: None,
+        }
+    }
+
+    /// Returns the component area used for the produced region set.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    ///
+    /// let area = Rect::new(0, 0, 10, 1);
+    /// let targets = FrameTargets::<()>::new(area, 0);
+    ///
+    /// assert_eq!(targets.area(), area);
+    /// ```
+    pub const fn area(&self) -> Rect {
+        self.area
+    }
+
+    /// Returns the first focus order assigned by this builder.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    ///
+    /// let targets = FrameTargets::<()>::new(Rect::new(0, 0, 1, 1), 7);
+    ///
+    /// assert_eq!(targets.focus_start(), 7);
+    /// ```
+    pub const fn focus_start(&self) -> u16 {
+        self.focus_start
+    }
+
+    /// Applies z-order to generated layout regions and pointer targets.
+    ///
+    /// Use this for overlays and dialogs that are rendered above the base page. Higher z values
+    /// win hit testing when areas overlap.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let frame = FrameTargets::new(Rect::new(0, 0, 4, 1), 0)
+    ///     .z(10)
+    ///     .build_focusable([Region::new("popup", Rect::new(0, 0, 4, 1))], |id| id);
+    ///
+    /// assert_eq!(frame.layout.regions()[0].z, 10);
+    /// ```
+    #[must_use = "method returns the modified builder"]
+    pub const fn z(mut self, z: u16) -> Self {
+        self.z = z;
+        self
+    }
+
+    /// Adds a whole-region pointer target before region-specific targets.
+    ///
+    /// Scrollable panes use this so wheel events route over blank viewport space as well as over
+    /// visible rows or cells.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    ///
+    /// let area = Rect::new(0, 0, 20, 5);
+    /// let frame = FrameTargets::new(area, 0).mouse_region("pane", area).build(
+    ///     core::iter::empty::<ratatui_layout::regions::Region<&str>>(),
+    ///     |id| id,
+    ///     |_| false,
+    ///     |_| false,
+    /// );
+    ///
+    /// assert_eq!(frame.route_scroll((1, 1)).unwrap().id, "pane");
+    /// ```
+    #[must_use = "method returns the modified builder"]
+    pub fn mouse_region(mut self, id: Id, area: Rect) -> Self {
+        self.mouse_region = Some((id, area));
+        self
+    }
+
+    /// Starts a target builder from a solved region set.
+    ///
+    /// Use this after [`Row`](crate::linear::Row), [`Column`](crate::linear::Column),
+    /// [`Grid`](crate::grid::Grid), [`Overlay`](crate::overlay::Overlay), a viewport, or a
+    /// custom component has already produced geometry. The returned
+    /// [`RegionTargets`](crate::frame::RegionTargets) adds policy that
+    /// [`Regions`](crate::regions::Regions) does not store: disabled, focusable, pointer routing,
+    /// whole-region pointer routing, and z-order.
+    ///
+    /// # Examples
+    ///
+    /// Derive frame-local data from a toolbar layout:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::focus::{FocusFallback, FocusState};
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum Command {
+    ///     Open,
+    ///     Save,
+    /// }
+    ///
+    /// let command_slots = [
+    ///     (Command::Open, Constraint::Length(6)),
+    ///     (Command::Save, Constraint::Length(6)),
+    /// ];
+    /// let plan = Row::named(command_slots)
+    ///     .spacing(1)
+    ///     .regions(Rect::new(0, 0, 13, 1));
+    /// let frame = FrameTargets::from_regions(plan, 0)
+    ///     .disabled(|command| command == Command::Save)
+    ///     .build();
+    /// let mut focus = FocusState::default();
+    ///
+    /// focus.ensure_visible(&frame.focus, FocusFallback::First);
+    ///
+    /// assert_eq!(focus.focused(), Some(Command::Open));
+    /// assert!(frame.route_click((8, 0)).is_none());
+    /// assert_eq!(frame.layout.hit_test((8, 0)).unwrap().id, Command::Save);
+    /// ```
+    pub fn from_regions(plan: Regions<Id>, focus_start: u16) -> RegionTargets<Id> {
+        RegionTargets::new(plan, focus_start)
+    }
+}
+
+/// Builder that derives frame-local targets from solved regions.
+///
+/// [`Regions`](crate::regions::Regions) stores visible ids and rectangles.
+/// [`RegionTargets`](crate::frame::RegionTargets) adds interaction policy while keeping layout,
+/// focus, and pointer targets aligned on the same ids.
+///
+/// Use this builder when rendering and routing share solved regions:
+///
+/// - a toolbar or command strip where disabled commands remain visible;
+/// - a table with mouseable headers but focusable body cells;
+/// - a segmented control that is mouseable but intentionally skipped by page-level focus;
+/// - a scrollable pane that needs a whole-region pointer target in addition to item regions.
+///
+/// Labels, styles, shortcuts, command effects, widget state, and app data stay outside this type.
+///
+/// # Methods
+///
+/// - [`RegionTargets::disabled`](crate::frame::RegionTargets::disabled) marks visible regions
+///   unavailable for focus traversal and pointer activation.
+/// - [`RegionTargets::focusable`](crate::frame::RegionTargets::focusable) chooses which regions
+///   join keyboard traversal.
+/// - [`RegionTargets::mouseable`](crate::frame::RegionTargets::mouseable) chooses which regions
+///   receive pointer routing.
+/// - [`RegionTargets::mouse_region`](crate::frame::RegionTargets::mouse_region) adds a whole-region
+///   pointer target for blank pane space or wheel routing.
+/// - [`RegionTargets::z`](crate::frame::RegionTargets::z) assigns one z-order to generated layout
+///   and pointer targets.
+/// - [`RegionTargets::build`](crate::frame::RegionTargets::build) produces the
+///   [`FrameSnapshot`](crate::frame::FrameSnapshot) stored after rendering.
+///
+/// # Examples
+///
+/// Build aligned frame-local data from a row of app-owned commands:
+///
+/// ```rust
+/// use ratatui_core::layout::{Constraint, Rect};
+/// use ratatui_layout::frame::FrameTargets;
+/// use ratatui_layout::linear::Row;
+///
+/// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// enum Command {
+///     Edit,
+///     Save,
+/// }
+///
+/// let command_slots = [
+///     (Command::Edit, Constraint::Length(6)),
+///     (Command::Save, Constraint::Length(6)),
+/// ];
+/// let row = Row::named(command_slots)
+///     .spacing(1)
+///     .regions(Rect::new(0, 0, 13, 1));
+/// let frame = FrameTargets::from_regions(row, 10)
+///     .disabled(|command| command == Command::Save)
+///     .build();
+///
+/// assert_eq!(frame.focus.targets()[0].id, Command::Edit);
+/// assert!(frame.focus.targets()[1].disabled);
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct RegionTargets<Id = usize> {
+    area: Rect,
+    focus_start: u16,
+    mouse_region: Option<(Id, Rect)>,
+    targets: Vec<FrameTargetSlot<Id>>,
+}
+
+impl<Id> RegionTargets<Id> {
+    fn new(plan: Regions<Id>, focus_start: u16) -> Self {
+        let area = plan.area();
+        let targets = plan
+            .into_iter()
+            .map(|region| FrameTargetSlot {
+                region,
+                focusable: true,
+                mouseable: true,
+                disabled: false,
+            })
+            .collect();
+        Self {
+            area,
+            focus_start,
+            mouse_region: None,
+            targets,
+        }
+    }
+
+    /// Marks regions disabled for focus traversal and pointer routing.
+    ///
+    /// Disabled regions remain renderable in the region set. Focus traversal and pointer hit
+    /// testing skip their generated targets.
+    ///
+    /// # Examples
+    ///
+    /// Keep a `Save` command visible while preventing activation when the document is clean:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum Command {
+    ///     Open,
+    ///     Save,
+    /// }
+    ///
+    /// let dirty = false;
+    /// let command_slots = [
+    ///     (Command::Open, Constraint::Length(6)),
+    ///     (Command::Save, Constraint::Length(6)),
+    /// ];
+    /// let plan = Row::named(command_slots).regions(Rect::new(0, 0, 12, 1));
+    /// let frame = FrameTargets::from_regions(plan, 0)
+    ///     .disabled(|command| command == Command::Save && !dirty)
+    ///     .build();
+    ///
+    /// assert!(frame.focus.targets()[1].disabled);
+    /// assert!(frame.route_click((7, 0)).is_none());
+    /// ```
+    #[must_use = "method returns the modified builder"]
+    pub fn disabled(mut self, disabled: impl Fn(Id) -> bool) -> Self
+    where
+        Id: Copy,
+    {
+        for target in &mut self.targets {
+            target.disabled = disabled(target.region.id);
+        }
+        self
+    }
+
+    /// Chooses which regions participate in keyboard traversal.
+    ///
+    /// Use this for headers, labels, pointer-only segments, or any region that should be visible
+    /// without becoming a page-level focus target.
+    ///
+    /// # Examples
+    ///
+    /// Make only body rows focusable while keeping the header in the layout:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let plan = Regions::from_regions(
+    ///     Rect::new(0, 0, 20, 2),
+    ///     [
+    ///         Region::new(None, Rect::new(0, 0, 20, 1)),
+    ///         Region::new(Some(0), Rect::new(0, 1, 20, 1)),
+    ///     ],
+    /// );
+    /// let frame = FrameTargets::from_regions(plan, 0)
+    ///     .focusable(|row| row.is_some())
+    ///     .build();
+    ///
+    /// assert_eq!(frame.layout.regions().len(), 2);
+    /// assert_eq!(frame.focus.targets().len(), 1);
+    /// ```
+    #[must_use = "method returns the modified builder"]
+    pub fn focusable(mut self, focusable: impl Fn(Id) -> bool) -> Self
+    where
+        Id: Copy,
+    {
+        for target in &mut self.targets {
+            target.focusable = focusable(target.region.id);
+        }
+        self
+    }
+
+    /// Chooses which regions receive pointer routing.
+    ///
+    /// Non-pointer-routable regions remain renderable and can still be found by broad
+    /// [`FrameSnapshot::route_position`](crate::frame::FrameSnapshot::route_position) geometry
+    /// queries.
+    ///
+    /// # Examples
+    ///
+    /// Keep a field focusable while routing clicks only to its explicit edit button:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let plan = Regions::from_regions(
+    ///     Rect::new(0, 0, 20, 1),
+    ///     [
+    ///         Region::new("field", Rect::new(0, 0, 12, 1)),
+    ///         Region::new("edit", Rect::new(13, 0, 6, 1)),
+    ///     ],
+    /// );
+    /// let frame = FrameTargets::from_regions(plan, 0)
+    ///     .mouseable(|id| id == "edit")
+    ///     .build();
+    ///
+    /// assert_eq!(frame.focus.targets().len(), 2);
+    /// assert_eq!(frame.route_click((14, 0)).unwrap().id, "edit");
+    /// ```
+    #[must_use = "method returns the modified builder"]
+    pub fn mouseable(mut self, mouseable: impl Fn(Id) -> bool) -> Self
+    where
+        Id: Copy,
+    {
+        for target in &mut self.targets {
+            target.mouseable = mouseable(target.region.id);
+        }
+        self
+    }
+
+    /// Adds a whole-region pointer target before region targets.
+    ///
+    /// Scrollable panes use this so wheel events route over blank viewport space.
+    ///
+    /// # Examples
+    ///
+    /// Route wheel events to a pane even when the pointer is below the last visible row:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::regions::Regions;
+    ///
+    /// let pane = Rect::new(0, 0, 20, 5);
+    /// let frame = FrameTargets::from_regions(Regions::new(pane), 0)
+    ///     .mouse_region("details", pane)
+    ///     .build();
+    ///
+    /// assert_eq!(frame.route_scroll((10, 4)).unwrap().id, "details");
+    /// ```
+    #[must_use = "method returns the modified builder"]
+    pub fn mouse_region(mut self, id: Id, area: Rect) -> Self {
+        self.mouse_region = Some((id, area));
+        self
+    }
+
+    /// Assigns one z-order to generated layout regions and pointer targets.
+    ///
+    /// Use this for dialogs, overlays, popups, and command palettes.
+    ///
+    /// # Examples
+    ///
+    /// Make a popup button route before base content at the same position:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let popup = Regions::from_regions(
+    ///     Rect::new(0, 0, 8, 1),
+    ///     [Region::new("close", Rect::new(0, 0, 8, 1))],
+    /// );
+    /// let frame = FrameTargets::from_regions(popup, 0).z(20).build();
+    ///
+    /// assert_eq!(frame.layout.regions()[0].z, 20);
+    /// assert_eq!(frame.mouse.targets()[0].z, 20);
+    /// ```
+    #[must_use = "method returns the modified builder"]
+    pub fn z(mut self, z: u16) -> Self {
+        for target in &mut self.targets {
+            target.region.z = z;
+        }
+        self
+    }
+
+    /// Builds a frame snapshot from the configured regions and policies.
+    ///
+    /// The layout keeps every region. Focus and pointer target collections include only regions
+    /// enabled by their policies, and disabled generated targets are skipped by traversal and
+    /// hit testing.
+    ///
+    /// # Examples
+    ///
+    /// Build a frame snapshot for a pointer-only segmented control:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// let segment_slots = [
+    ///     ("queued", Constraint::Length(8)),
+    ///     ("done", Constraint::Length(6)),
+    /// ];
+    /// let plan = Row::named(segment_slots).regions(Rect::new(0, 0, 14, 1));
+    /// let frame = FrameTargets::from_regions(plan, 0)
+    ///     .focusable(|_| false)
+    ///     .build();
+    ///
+    /// assert!(frame.focus.targets().is_empty());
+    /// assert_eq!(frame.route_click((1, 0)).unwrap().id, "queued");
+    /// ```
+    pub fn build(self) -> FrameSnapshot<Id>
+    where
+        Id: Copy,
+    {
+        let mut layout = Regions::new(self.area);
+        let mut mouse = if let Some((id, area)) = self.mouse_region {
+            PointerTargets::new().region(id, area)
+        } else {
+            PointerTargets::new()
+        };
+        let mut focus = FocusTargets::new();
+
+        for (order, target) in self.targets.into_iter().enumerate() {
+            let region = target.region;
+            layout.push(region);
+            if target.mouseable {
+                mouse = mouse.target(PointerTarget::from_region(region).disabled(target.disabled));
+            }
+            if target.focusable {
+                let order = self.focus_start + order as u16;
+                focus =
+                    focus.target(FocusTarget::from_region(region, order).disabled(target.disabled));
+            }
+        }
+
+        FrameSnapshot::from_layout(layout).mouse(mouse).focus(focus)
+    }
+}
+
+impl<Out> FrameTargets<Out>
+where
+    Out: Copy,
+{
+    /// Builds a frame snapshot for one focusable and mouseable region.
+    ///
+    /// This is useful for panes whose whole viewport is one target: keyboard focus scrolls the pane
+    /// and wheel events route over the same rectangle.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    ///
+    /// let frame =
+    ///     FrameTargets::new(Rect::new(0, 0, 10, 3), 0).region("details", Rect::new(0, 0, 10, 3));
+    ///
+    /// assert_eq!(frame.route_click((2, 2)).unwrap().id, "details");
+    /// ```
+    pub fn region(self, id: Out, area: Rect) -> FrameSnapshot<Out> {
+        self.build_focusable([Region::new(id, area)], |id| id)
+    }
+
+    /// Builds a frame snapshot when every region is enabled and focusable.
+    ///
+    /// Use this for dialog fields, menu rows, and ordinary button groups where every visible region
+    /// participates in keyboard traversal and pointer routing.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let frame = FrameTargets::new(Rect::new(0, 0, 8, 1), 0)
+    ///     .build_focusable([Region::new("save", Rect::new(0, 0, 8, 1))], |id| id);
+    ///
+    /// assert_eq!(frame.focus.targets()[0].id, "save");
+    /// ```
+    pub fn build_focusable<Id>(
+        self,
+        regions: impl IntoIterator<Item = Region<Id>>,
+        map_id: impl Fn(Id) -> Out,
+    ) -> FrameSnapshot<Out>
+    where
+        Id: Copy,
+    {
+        self.build(regions, map_id, |_| true, |_| false)
+    }
+
+    /// Builds a frame snapshot with a custom focus predicate and no disabled regions.
+    ///
+    /// Tables use this when header cells should remain pointer targets but body cells are the only
+    /// keyboard traversal targets.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let regions = [
+    ///     Region::new(None, Rect::new(0, 0, 10, 1)),
+    ///     Region::new(Some(0), Rect::new(0, 1, 10, 1)),
+    /// ];
+    /// let frame = FrameTargets::new(Rect::new(0, 0, 10, 2), 0).build_with_focus(
+    ///     regions,
+    ///     |row| row,
+    ///     |row| row.is_some(),
+    /// );
+    ///
+    /// assert_eq!(frame.mouse.targets().len(), 2);
+    /// assert_eq!(frame.focus.targets().len(), 1);
+    /// ```
+    pub fn build_with_focus<Id>(
+        self,
+        regions: impl IntoIterator<Item = Region<Id>>,
+        map_id: impl Fn(Id) -> Out,
+        focusable: impl Fn(Id) -> bool,
+    ) -> FrameSnapshot<Out>
+    where
+        Id: Copy,
+    {
+        self.build(regions, map_id, focusable, |_| false)
+    }
+
+    /// Builds a frame snapshot when every region is focusable but some regions are disabled.
+    ///
+    /// Disabled regions remain in the region set so they can still be rendered, but their pointer
+    /// and focus targets are marked disabled for routing and traversal.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let frame = FrameTargets::new(Rect::new(0, 0, 8, 1), 0).build_with_disabled(
+    ///     [Region::new("save", Rect::new(0, 0, 8, 1))],
+    ///     |id| id,
+    ///     |_| true,
+    /// );
+    ///
+    /// assert!(frame.focus.targets()[0].disabled);
+    /// assert!(frame.mouse.hit_test((1, 0)).is_none());
+    /// assert_eq!(frame.layout.hit_test((1, 0)).unwrap().id, "save");
+    /// ```
+    pub fn build_with_disabled<Id>(
+        self,
+        regions: impl IntoIterator<Item = Region<Id>>,
+        map_id: impl Fn(Id) -> Out,
+        disabled: impl Fn(Id) -> bool,
+    ) -> FrameSnapshot<Out>
+    where
+        Id: Copy,
+    {
+        self.build(regions, map_id, |_| true, disabled)
+    }
+
+    /// Builds a frame snapshot from local regions.
+    ///
+    /// `map_id` turns component-local region ids into app-level routing ids. `focusable` decides
+    /// whether the region joins keyboard traversal. `disabled` keeps disabled controls visible
+    /// while removing them from activation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameTargets;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let frame = FrameTargets::new(Rect::new(0, 0, 10, 2), 5).build(
+    ///     [
+    ///         Region::new(0, Rect::new(0, 0, 10, 1)),
+    ///         Region::new(1, Rect::new(0, 1, 10, 1)),
+    ///     ],
+    ///     |row| ("row", row),
+    ///     |row| row == 1,
+    ///     |_| false,
+    /// );
+    ///
+    /// assert_eq!(frame.layout.regions().len(), 2);
+    /// assert_eq!(frame.focus.targets()[0].id, ("row", 1));
+    /// ```
+    pub fn build<Id>(
+        self,
+        regions: impl IntoIterator<Item = Region<Id>>,
+        map_id: impl Fn(Id) -> Out,
+        focusable: impl Fn(Id) -> bool,
+        disabled: impl Fn(Id) -> bool,
+    ) -> FrameSnapshot<Out>
+    where
+        Id: Copy,
+    {
+        let mut layout = Regions::new(self.area);
+        let mut mouse = if let Some((id, area)) = self.mouse_region {
+            PointerTargets::new().region(id, area)
+        } else {
+            PointerTargets::new()
+        };
+        let mut focus = FocusTargets::new();
+
+        for (order, region) in regions.into_iter().enumerate() {
+            let id = map_id(region.id);
+            let disabled = disabled(region.id);
+            layout.push(Region::new(id, region.area).z(self.z));
+            mouse = mouse.target(
+                PointerTarget::new(id, region.area)
+                    .z(self.z)
+                    .disabled(disabled),
+            );
+            if focusable(region.id) {
+                let order = self.focus_start + order as u16;
+                focus = focus.target(FocusTarget::new(id, region.area, order).disabled(disabled));
+            }
+        }
+
+        FrameSnapshot::from_layout(layout).mouse(mouse).focus(focus)
+    }
+}
+
+impl<Id> FrameSnapshot<Id> {
+    /// Creates an empty frame snapshot for a solved area.
+    ///
+    /// Use this as a neutral previous-frame value before the first draw, or when a component has an
+    /// area but no visible children.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    ///
+    /// let frame = FrameSnapshot::<()>::new(Rect::new(0, 0, 80, 24));
+    /// assert!(frame.layout.is_empty());
+    /// assert!(frame.route_position((0, 0)).is_none());
+    /// ```
+    pub const fn new(area: Rect) -> Self {
+        Self {
+            layout: Regions::new(area),
+            focus: FocusTargets::new(),
+            mouse: PointerTargets::new(),
+            cursor: CursorRequests::new(),
+        }
+    }
+
+    /// Creates a frame snapshot from a region set.
+    ///
+    /// This is the common incremental path: start with geometry, then attach focus, pointer, or
+    /// cursor requests only when the component produces them.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let layout = Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 1),
+    ///     [Region::new("tab", Rect::new(0, 0, 10, 1))],
+    /// );
+    /// let frame = FrameSnapshot::from_layout(layout);
+    ///
+    /// assert_eq!(frame.route_position((1, 0)).unwrap().id, "tab");
+    /// ```
+    pub const fn from_layout(layout: Regions<Id>) -> Self {
+        Self {
+            layout,
+            focus: FocusTargets::new(),
+            mouse: PointerTargets::new(),
+            cursor: CursorRequests::new(),
+        }
+    }
+
+    /// Sets the focus target collection.
+    ///
+    /// This replaces the current focus target collection rather than merging. Use
+    /// [`FrameSnapshot::merge`](crate::frame::FrameSnapshot::merge) when a child frame should be
+    /// appended to existing data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::focus::{FocusTarget, FocusTargets};
+    /// use ratatui_layout::frame::FrameSnapshot;
+    ///
+    /// let frame = FrameSnapshot::new(Rect::new(0, 0, 10, 1)).focus(FocusTargets::from_targets([
+    ///     FocusTarget::new("field", Rect::new(0, 0, 10, 1), 0),
+    /// ]));
+    ///
+    /// assert_eq!(frame.focus.first_enabled().unwrap().id, "field");
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn focus(mut self, focus: FocusTargets<Id>) -> Self {
+        self.focus = focus;
+        self
+    }
+
+    /// Sets the pointer target collection.
+    ///
+    /// This replaces the current pointer target collection rather than deriving one from layout
+    /// regions. Keeping the two separate lets pointer routing skip disabled or non-interactive
+    /// regions.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let frame = FrameSnapshot::new(Rect::new(0, 0, 10, 1)).mouse(PointerTargets::from_targets([
+    ///     PointerTarget::new("button", Rect::new(0, 0, 10, 1)),
+    /// ]));
+    ///
+    /// assert_eq!(frame.route_position((1, 0)).unwrap().id, "button");
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn mouse(mut self, mouse: PointerTargets<Id>) -> Self {
+        self.mouse = mouse;
+        self
+    }
+
+    /// Sets the cursor request list.
+    ///
+    /// This replaces the current cursor request list. During composition,
+    /// [`FrameSnapshot::merge`](crate::frame::FrameSnapshot::merge) preserves render order so
+    /// later visible cursor requests can win.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Position, Rect};
+    /// use ratatui_layout::cursor::{CursorRequest, CursorRequests};
+    /// use ratatui_layout::frame::FrameSnapshot;
+    ///
+    /// let frame = FrameSnapshot::<()>::new(Rect::default())
+    ///     .cursor(CursorRequests::new().request(CursorRequest::visible(Position::new(4, 2))));
+    ///
+    /// assert_eq!(
+    ///     frame.cursor.final_cursor(),
+    ///     Some(CursorRequest::visible(Position::new(4, 2)))
+    /// );
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn cursor(mut self, cursor: CursorRequests) -> Self {
+        self.cursor = cursor;
+        self
+    }
+
+    /// Adds one pointer target to the frame's pointer target collection.
+    ///
+    /// This is the aggregate equivalent of
+    /// [`PointerTargets::target`](crate::pointer::PointerTargets::target). It is useful when a
+    /// component already has a [`FrameSnapshot`](crate::frame::FrameSnapshot) and wants to add a
+    /// pointer-only region without constructing a temporary pointer target collection.
+    ///
+    /// # Examples
+    ///
+    /// Add a pane-level target after building layout regions for visible rows:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    /// use ratatui_layout::pointer::PointerTarget;
+    ///
+    /// let frame = FrameSnapshot::new(Rect::new(0, 0, 20, 5))
+    ///     .mouse_target(PointerTarget::new("pane", Rect::new(0, 0, 20, 5)));
+    ///
+    /// assert_eq!(frame.route_position((2, 4)).unwrap().id, "pane");
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn mouse_target(mut self, target: PointerTarget<Id>) -> Self {
+        self.mouse = self.mouse.target(target);
+        self
+    }
+
+    /// Adds a whole-region pointer target to the frame.
+    ///
+    /// Use this for scrollable panes, blank viewport space, or any region where pointer input
+    /// belongs to the container rather than a visible child region. It records ordinary pointer
+    /// routing data; the app still decides whether a routed hit means scroll, click, hover, or
+    /// another semantic action.
+    ///
+    /// # Examples
+    ///
+    /// Register a scrollable list viewport before adding row targets:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    ///
+    /// let frame = FrameSnapshot::new(Rect::new(0, 0, 20, 5))
+    ///     .scroll_region("list-pane", Rect::new(0, 0, 20, 5));
+    ///
+    /// assert_eq!(frame.route_scroll((1, 4)).unwrap().id, "list-pane");
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn scroll_region(mut self, id: Id, area: Rect) -> Self {
+        self.mouse = self.mouse.region(id, area);
+        self
+    }
+
+    /// Merges another frame snapshot into this one.
+    ///
+    /// Later merged layout and pointer targets preserve normal z-order tie-breaking because their
+    /// regions and targets are appended after existing ones.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let base = FrameSnapshot::from_layout(Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 1),
+    ///     [Region::new("base", Rect::new(0, 0, 10, 1))],
+    /// ));
+    /// let overlay = FrameSnapshot::from_layout(Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 1),
+    ///     [Region::new("overlay", Rect::new(0, 0, 10, 1)).z(1)],
+    /// ));
+    ///
+    /// assert_eq!(
+    ///     base.merge(overlay).route_position((0, 0)).unwrap().id,
+    ///     "overlay"
+    /// );
+    /// ```
+    #[must_use = "method returns the merged plan"]
+    pub fn merge(mut self, other: Self) -> Self {
+        self.layout = self.layout.merge(other.layout);
+        self.focus = self.focus.merge(other.focus);
+        self.mouse = self.mouse.merge(other.mouse);
+        self.cursor = self.cursor.merge(other.cursor);
+        self
+    }
+
+    /// Places a child frame and merges its visible data into this frame.
+    ///
+    /// This is a convenience for the common parent/child composition sequence: a child solves local
+    /// coordinates, the parent translates those coordinates to the child's screen position, clips
+    /// them to a viewport, and then merges them into the parent aggregate. Use the lower-level
+    /// [`FrameSnapshot::translate`](crate::frame::FrameSnapshot::translate),
+    /// [`FrameSnapshot::clip_to`](crate::frame::FrameSnapshot::clip_to), and
+    /// [`FrameSnapshot::merge`](crate::frame::FrameSnapshot::merge) methods when each step
+    /// needs to be inspected separately.
+    ///
+    /// # Examples
+    ///
+    /// Place a child-local plan inside a parent viewport:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let child = FrameSnapshot::from_layout(Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 1),
+    ///     [Region::new("row", Rect::new(0, 0, 10, 1))],
+    /// ));
+    /// let frame =
+    ///     FrameSnapshot::new(Rect::new(0, 0, 20, 5)).merge_child(child, 4, 2, Rect::new(0, 0, 20, 5));
+    ///
+    /// assert_eq!(frame.route_position((5, 2)).unwrap().id, "row");
+    /// ```
+    #[must_use = "method returns the merged plan"]
+    pub fn merge_child(self, child: Self, dx: i16, dy: i16, clip: Rect) -> Self {
+        self.merge(child.translate(dx, dy).clip_to(clip))
+    }
+
+    /// Places a child frame in an absolute screen area and merges it into this frame.
+    ///
+    /// This is the common form of
+    /// [`FrameSnapshot::merge_child`](crate::frame::FrameSnapshot::merge_child) when the parent has
+    /// already solved the child area. The child is translated by `area.x` and `area.y`, then
+    /// clipped to `area`, so layout, focus, pointer, and cursor requests match the region the
+    /// child actually rendered into.
+    ///
+    /// # Examples
+    ///
+    /// Compose a local child plan after solving page areas:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let child_area = Rect::new(4, 2, 10, 1);
+    /// let child = FrameSnapshot::from_layout(Regions::from_regions(
+    ///     Rect::new(0, 0, child_area.width, child_area.height),
+    ///     [Region::new("field", Rect::new(0, 0, 10, 1))],
+    /// ));
+    /// let frame = FrameSnapshot::new(Rect::new(0, 0, 20, 5)).place_child(child, child_area);
+    ///
+    /// assert_eq!(frame.route_position((5, 2)).unwrap().id, "field");
+    /// ```
+    #[must_use = "method returns the merged plan"]
+    pub fn place_child(self, child: Self, area: Rect) -> Self {
+        self.merge_child(child, area.x as i16, area.y as i16, area)
+    }
+
+    /// Moves child-local frame-local data by a signed offset.
+    ///
+    /// Use this when a child solved layout, focus, pointer, and cursor requests in local
+    /// coordinates and the parent knows where that child was placed on the terminal. Cursor
+    /// requests move with the geometry data so focused child inputs can report local cursor
+    /// positions during render.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let frame = FrameSnapshot::from_layout(Regions::from_regions(
+    ///     Rect::new(0, 0, 5, 1),
+    ///     [Region::new("field", Rect::new(0, 0, 5, 1))],
+    /// ))
+    /// .translate(10, 3);
+    ///
+    /// assert_eq!(frame.route_position((11, 3)).unwrap().id, "field");
+    /// ```
+    #[must_use = "method returns the translated plan"]
+    pub fn translate(mut self, dx: i16, dy: i16) -> Self {
+        self.layout = self.layout.translate(dx, dy);
+        self.focus = self.focus.translate(dx, dy);
+        self.mouse = self.mouse.translate(dx, dy);
+        self.cursor = self.cursor.translate(dx, dy);
+        self
+    }
+
+    /// Clips frame-local data to a viewport.
+    ///
+    /// Use this when a child plan should expose only the regions visible through a parent
+    /// container or scroll viewport. Layout, focus, and pointer regions are clipped or removed.
+    /// Cursor requests outside the viewport are hidden so a scrolled-out input does not move the
+    /// terminal cursor.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let frame = FrameSnapshot::from_layout(Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 3),
+    ///     [Region::new("row", Rect::new(0, 0, 10, 3))],
+    /// ))
+    /// .clip_to(Rect::new(0, 1, 10, 1));
+    ///
+    /// assert_eq!(frame.layout.regions()[0].area, Rect::new(0, 1, 10, 1));
+    /// ```
+    #[must_use = "method returns the clipped plan"]
+    pub fn clip_to(mut self, viewport: Rect) -> Self {
+        self.layout = self.layout.clip_to(viewport);
+        self.focus = self.focus.clip_to(viewport);
+        self.mouse = self.mouse.clip_to(viewport);
+        self.cursor = self.cursor.clip_to(viewport);
+        self
+    }
+
+    /// Maps ids for layout, focus, and pointer target collections while preserving cursor requests.
+    ///
+    /// This is how a child component can use small local ids internally and then lift them into a
+    /// parent enum or stable app id before merging.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let frame = FrameSnapshot::from_layout(Regions::from_regions(
+    ///     Rect::new(0, 0, 5, 1),
+    ///     [Region::new(0, Rect::new(0, 0, 5, 1))],
+    /// ))
+    /// .map_id(|id| ("child", id));
+    ///
+    /// assert_eq!(frame.route_position((1, 0)).unwrap().id, ("child", 0));
+    /// ```
+    pub fn map_id<NextId, F>(self, mut map: F) -> FrameSnapshot<NextId>
+    where
+        F: FnMut(Id) -> NextId,
+    {
+        FrameSnapshot {
+            layout: self.layout.map_id(&mut map),
+            focus: self.focus.map_id(&mut map),
+            mouse: self.mouse.map_id(&mut map),
+            cursor: self.cursor,
+        }
+    }
+}
+
+impl<Id: Copy> FrameSnapshot<Id> {
+    /// Routes a position through the pointer target collection, falling back to layout hit testing.
+    ///
+    /// Pointer targets are the primary routing surface because they can represent disabled state
+    /// and pointer-specific z-order. The layout fallback keeps simple examples useful when no
+    /// explicit pointer target collection was built.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let frame = FrameSnapshot::from_layout(Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 1),
+    ///     [Region::new("fallback", Rect::new(0, 0, 10, 1))],
+    /// ))
+    /// .mouse(PointerTargets::from_targets([PointerTarget::new(
+    ///     "explicit",
+    ///     Rect::new(0, 0, 10, 1),
+    /// )]));
+    ///
+    /// assert_eq!(frame.route_position((1, 0)).unwrap().id, "explicit");
+    /// ```
+    pub fn route_position<P: Into<Position>>(&self, position: P) -> Option<Hit<Id>> {
+        let position = position.into();
+        self.mouse
+            .hit_test(position)
+            .or_else(|| self.layout.hit_test(position))
+    }
+
+    fn route_mouse_event<P: Into<Position>>(&self, position: P) -> Option<Hit<Id>> {
+        let position = position.into();
+        if self.mouse.targets().is_empty() {
+            self.layout.hit_test(position)
+        } else {
+            self.mouse.hit_test(position)
+        }
+    }
+
+    /// Routes a wheel position through the previous frame.
+    ///
+    /// When the frame has explicit pointer targets, wheel routing uses those targets so disabled or
+    /// non-pointer regions do not fall through to layout geometry. When the frame has no pointer
+    /// targets, it falls back to
+    /// [`FrameSnapshot::route_position`](crate::frame::FrameSnapshot::route_position) behavior and
+    /// routes through layout regions.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    ///
+    /// let frame =
+    ///     FrameSnapshot::new(Rect::new(0, 0, 20, 5)).scroll_region("details", Rect::new(0, 0, 20, 5));
+    ///
+    /// assert_eq!(frame.route_scroll((10, 4)).unwrap().id, "details");
+    /// ```
+    pub fn route_scroll<P: Into<Position>>(&self, position: P) -> Option<Hit<Id>> {
+        self.route_mouse_event(position)
+    }
+
+    /// Routes a click position through the previous frame.
+    ///
+    /// When the frame has explicit pointer targets, click routing uses those targets so disabled or
+    /// non-pointer regions do not fall through to layout geometry. When the frame has no pointer
+    /// targets, it falls back to
+    /// [`FrameSnapshot::route_position`](crate::frame::FrameSnapshot::route_position) behavior and
+    /// routes through layout regions.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let frame = FrameSnapshot::from_layout(Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 1),
+    ///     [Region::new("save", Rect::new(0, 0, 10, 1))],
+    /// ));
+    ///
+    /// assert_eq!(frame.route_click((4, 0)).unwrap().id, "save");
+    /// ```
+    pub fn route_click<P: Into<Position>>(&self, position: P) -> Option<Hit<Id>> {
+        self.route_mouse_event(position)
+    }
+
+    /// Routes a hover position through the previous frame.
+    ///
+    /// When the frame has explicit pointer targets, hover routing uses those targets so disabled or
+    /// non-pointer regions do not fall through to layout geometry. When the frame has no pointer
+    /// targets, it falls back to
+    /// [`FrameSnapshot::route_position`](crate::frame::FrameSnapshot::route_position) behavior and
+    /// routes through layout regions.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::frame::FrameSnapshot;
+    ///
+    /// let frame =
+    ///     FrameSnapshot::new(Rect::new(0, 0, 10, 3)).scroll_region("pane", Rect::new(0, 0, 10, 3));
+    ///
+    /// assert_eq!(frame.route_hover((5, 2)).unwrap().id, "pane");
+    /// ```
+    pub fn route_hover<P: Into<Position>>(&self, position: P) -> Option<Hit<Id>> {
+        self.route_mouse_event(position)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::cursor::CursorRequest;
+    use crate::focus::FocusTarget;
+    use crate::pointer::PointerTarget;
+    use crate::regions::Region;
+
+    #[test]
+    fn merge_child_plans_preserves_z_order() {
+        let parent = FrameSnapshot::from_layout(Regions::from_regions(
+            Rect::new(0, 0, 5, 1),
+            [Region::new("parent", Rect::new(0, 0, 5, 1)).z(1)],
+        ))
+        .mouse(PointerTargets::from_targets([PointerTarget::new(
+            "parent",
+            Rect::new(0, 0, 5, 1),
+        )
+        .z(1)]));
+        let child = FrameSnapshot::from_layout(Regions::from_regions(
+            Rect::new(0, 0, 5, 1),
+            [Region::new("child", Rect::new(0, 0, 5, 1)).z(2)],
+        ))
+        .mouse(PointerTargets::from_targets([PointerTarget::new(
+            "child",
+            Rect::new(0, 0, 5, 1),
+        )
+        .z(2)]));
+
+        let merged = parent.merge(child);
+
+        assert_eq!(
+            merged.route_position((0, 0)).map(|hit| hit.id),
+            Some("child")
+        );
+    }
+
+    #[test]
+    fn maps_translates_and_clips_child_regions() {
+        let frame = FrameSnapshot::from_layout(Regions::from_regions(
+            Rect::new(0, 0, 4, 2),
+            [Region::new(1, Rect::new(1, 0, 3, 2))],
+        ))
+        .focus(FocusTargets::from_targets([FocusTarget::new(
+            1,
+            Rect::new(1, 0, 3, 2),
+            0,
+        )]))
+        .mouse(PointerTargets::from_targets([PointerTarget::new(
+            1,
+            Rect::new(1, 0, 3, 2),
+        )]))
+        .translate(2, 1)
+        .clip_to(Rect::new(0, 0, 5, 3))
+        .map_id(|id| if id == 1 { "field" } else { "other" });
+
+        assert_eq!(frame.layout.regions()[0].id, "field");
+        assert_eq!(frame.layout.regions()[0].area, Rect::new(3, 1, 2, 2));
+        assert_eq!(frame.focus.targets()[0].area, Rect::new(3, 1, 2, 2));
+        assert_eq!(frame.mouse.targets()[0].area, Rect::new(3, 1, 2, 2));
+    }
+
+    #[test]
+    fn merged_cursor_requests_keep_last_visible() {
+        let first = FrameSnapshot::<()>::new(Rect::default())
+            .cursor(CursorRequests::new().request(CursorRequest::visible(Position::new(1, 1))));
+        let second = FrameSnapshot::<()>::new(Rect::default())
+            .cursor(CursorRequests::new().request(CursorRequest::visible(Position::new(2, 2))));
+
+        assert_eq!(
+            first.merge(second).cursor.final_cursor(),
+            Some(CursorRequest::visible(Position::new(2, 2)))
+        );
+    }
+
+    #[test]
+    fn translated_frame_moves_cursor_requests() {
+        let frame = FrameSnapshot::<()>::new(Rect::default())
+            .cursor(CursorRequests::new().request(CursorRequest::visible(Position::new(2, 1))))
+            .translate(10, 3);
+
+        assert_eq!(
+            frame.cursor.final_cursor(),
+            Some(CursorRequest::visible(Position::new(12, 4)))
+        );
+    }
+
+    #[test]
+    fn clipped_frame_hides_cursor_requests_outside_viewport() {
+        let frame = FrameSnapshot::<()>::new(Rect::default())
+            .cursor(CursorRequests::new().request(CursorRequest::visible(Position::new(8, 1))))
+            .clip_to(Rect::new(0, 0, 5, 3));
+
+        assert_eq!(frame.cursor.final_cursor(), None);
+    }
+
+    #[test]
+    fn place_child_uses_area_offset_and_clip() {
+        let child = FrameSnapshot::from_layout(Regions::from_regions(
+            Rect::new(0, 0, 10, 3),
+            [Region::new("row", Rect::new(0, 0, 10, 3))],
+        ))
+        .cursor(CursorRequests::new().request(CursorRequest::visible(Position::new(2, 1))));
+
+        let frame =
+            FrameSnapshot::new(Rect::new(0, 0, 20, 5)).place_child(child, Rect::new(4, 2, 10, 2));
+
+        assert_eq!(frame.route_position((5, 2)).map(|hit| hit.id), Some("row"));
+        assert_eq!(
+            frame.cursor.final_cursor(),
+            Some(CursorRequest::visible(Position::new(6, 3)))
+        );
+    }
+
+    #[test]
+    fn scroll_region_routes_blank_pane_space() {
+        let frame = FrameSnapshot::new(Rect::new(0, 0, 20, 5))
+            .scroll_region("details", Rect::new(0, 0, 20, 5));
+
+        assert_eq!(
+            frame.route_scroll((10, 4)).map(|hit| hit.id),
+            Some("details")
+        );
+    }
+
+    #[test]
+    fn frame_targets_build_layout_mouse_and_focus_from_regions() {
+        let frame = FrameTargets::new(Rect::new(0, 0, 10, 2), 40).build_with_focus(
+            [
+                Region::new(None, Rect::new(0, 0, 10, 1)),
+                Region::new(Some(0), Rect::new(0, 1, 10, 1)),
+            ],
+            |row| row,
+            |row| row.is_some(),
+        );
+
+        assert_eq!(frame.layout.regions().len(), 2);
+        assert_eq!(frame.mouse.targets().len(), 2);
+        assert_eq!(frame.focus.targets().len(), 1);
+        assert_eq!(frame.focus.targets()[0].order, 41);
+    }
+
+    #[test]
+    fn frame_targets_preserve_disabled_visual_regions() {
+        let frame = FrameTargets::new(Rect::new(0, 0, 10, 1), 0).build_with_disabled(
+            [Region::new("save", Rect::new(0, 0, 10, 1))],
+            |id| id,
+            |_| true,
+        );
+
+        assert_eq!(
+            frame.layout.hit_test((1, 0)).map(|hit| hit.id),
+            Some("save")
+        );
+        assert!(frame.mouse.hit_test((1, 0)).is_none());
+        assert!(frame.focus.first_enabled().is_none());
+    }
+
+    #[test]
+    fn frame_target_plan_builds_from_layout_plan() {
+        let plan = Regions::from_regions(
+            Rect::new(0, 0, 12, 1),
+            [
+                Region::new("open", Rect::new(0, 0, 6, 1)),
+                Region::new("save", Rect::new(6, 0, 6, 1)),
+            ],
+        );
+
+        let frame = FrameTargets::from_regions(plan, 20)
+            .disabled(|id| id == "save")
+            .build();
+
+        assert_eq!(
+            frame.layout.hit_test((7, 0)).map(|hit| hit.id),
+            Some("save")
+        );
+        assert_eq!(frame.focus.targets()[0].id, "open");
+        assert_eq!(frame.focus.targets()[0].order, 20);
+        assert!(frame.focus.targets()[1].disabled);
+        assert!(frame.mouse.hit_test((7, 0)).is_none());
+    }
+
+    #[test]
+    fn frame_target_plan_separates_focusable_and_mouseable_policy() {
+        let plan = Regions::from_regions(
+            Rect::new(0, 0, 20, 2),
+            [
+                Region::new("header", Rect::new(0, 0, 20, 1)),
+                Region::new("row", Rect::new(0, 1, 20, 1)),
+            ],
+        );
+
+        let frame = FrameTargets::from_regions(plan, 0)
+            .focusable(|id| id == "row")
+            .mouseable(|id| id == "header")
+            .build();
+
+        assert_eq!(frame.focus.targets().len(), 1);
+        assert_eq!(frame.focus.targets()[0].id, "row");
+        assert_eq!(frame.route_click((1, 0)).map(|hit| hit.id), Some("header"));
+        assert_eq!(frame.route_click((1, 1)).map(|hit| hit.id), None);
+        assert_eq!(frame.route_position((1, 1)).map(|hit| hit.id), Some("row"));
+        assert!(frame.mouse.hit_test((1, 1)).is_none());
+    }
+
+    #[test]
+    fn frame_target_plan_applies_z_and_mouse_region() {
+        let pane = Rect::new(0, 0, 20, 5);
+        let plan = Regions::from_regions(pane, [Region::new("button", Rect::new(0, 0, 6, 1))]);
+
+        let frame = FrameTargets::from_regions(plan, 0)
+            .mouse_region("pane", pane)
+            .z(10)
+            .build();
+
+        assert_eq!(frame.layout.regions()[0].z, 10);
+        assert_eq!(frame.mouse.targets()[1].z, 10);
+        assert_eq!(frame.route_scroll((10, 4)).map(|hit| hit.id), Some("pane"));
+        assert_eq!(frame.route_click((1, 0)).map(|hit| hit.id), Some("button"));
+    }
+
+    #[test]
+    fn merge_child_places_and_clips_local_plan() {
+        let child = FrameSnapshot::from_layout(Regions::from_regions(
+            Rect::new(0, 0, 10, 3),
+            [Region::new("row", Rect::new(0, 0, 10, 3))],
+        ));
+
+        let frame = FrameSnapshot::new(Rect::new(0, 0, 20, 5)).merge_child(
+            child,
+            4,
+            2,
+            Rect::new(0, 0, 20, 4),
+        );
+
+        assert_eq!(
+            frame.layout.regions(),
+            &[
+                Region::new("row", Rect::new(4, 2, 10, 2)).clip(crate::regions::Clip {
+                    bottom: 1,
+                    ..crate::regions::Clip::default()
+                })
+            ]
+        );
+    }
+}

--- a/crates/ratatui-layout/src/grid.rs
+++ b/crates/ratatui-layout/src/grid.rs
@@ -1,0 +1,533 @@
+//! Grid regions and typed cell coordinates.
+//!
+//! A [`Grid`](crate::grid::Grid) composes Ratatui row and column constraints into a row-major
+//! [`Regions`](crate::regions::Regions). It is a geometry helper, not a table widget: it does not
+//! own rows, cells, headers, styles, or selection. Callers use the resulting regions to render
+//! their own content.
+//!
+//! For a static grid that is rendered immediately, nested Ratatui [`Layout`] calls are usually
+//! enough. `Grid` is useful when cells need row-major ids, hit testing, or one
+//! [`Regions`](crate::regions::Regions) value that can be inspected before rendering.
+//! Use Ratatui's built-in table widget when the content is genuinely tabular data with row/column
+//! styling handled by the widget; this module solves cell regions for app-owned content.
+//!
+//! # Common uses
+//!
+//! - Render a palette, dashboard, or toolbar where each cell is app-owned content.
+//! - Use row-major [`Grid::regions`](crate::grid::Grid::regions) when simple indexed ids are
+//!   enough.
+//! - Use typed [`Grid::layout`](crate::grid::Grid::layout) when focus, pointer, or selection state
+//!   should talk in [`GridPosition`](crate::grid::GridPosition) values instead of encoded indexes.
+//! - Inspect row and column areas for decorations that span an entire row or column.
+//!
+//! # Types
+//!
+//! - [`GridPosition`](crate::grid::GridPosition) is a typed `{ row, column }` cell id for focus,
+//!   pointer, and selection state.
+//! - [`GridLayout`](crate::grid::GridLayout) is the solved typed-grid layout with row areas, column
+//!   areas, and cell regions.
+//! - [`Grid`](crate::grid::Grid) stores row and column constraints and can solve either indexed or
+//!   typed cell values.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use ratatui_core::layout::{Constraint, Rect};
+//! use ratatui_layout::grid::{Grid, GridPosition};
+//! use ratatui_layout::selection::{SelectionMode, SelectionState};
+//!
+//! let row_heights = [Constraint::Length(1), Constraint::Length(1)];
+//! let column_widths = [Constraint::Length(4), Constraint::Length(4)];
+//! let layout = Grid::new(row_heights, column_widths).layout(Rect::new(0, 0, 8, 2));
+//! let visible_cells = layout
+//!     .cells()
+//!     .regions()
+//!     .iter()
+//!     .map(|region| region.id)
+//!     .collect::<Vec<_>>();
+//! let mut selection = SelectionState::new(SelectionMode::Single);
+//!
+//! selection.select_next(&visible_cells);
+//! assert_eq!(selection.primary(), Some(GridPosition::new(0, 0)));
+//! ```
+//!
+//! See [`crate::docs::containers`] for how grids fit with rows, columns, overlays, and nested
+//! composition. See [`crate::docs::interaction`] for examples of pairing typed grid cells with
+//! focus, pointer, and selection state.
+//!
+//! [`Layout`]: ratatui_core::layout::Layout
+//! [`Regions`](crate::regions::Regions): crate::regions::Regions
+
+use alloc::vec::Vec;
+
+use ratatui_core::layout::{Constraint, Layout, Position, Rect};
+
+use crate::regions::{Region, Regions};
+
+/// Typed row-column identity for a grid cell.
+///
+/// [`GridPosition`](crate::grid::GridPosition) exists when a cell id should say what it means
+/// instead of encoding row-major math in a `usize`. It owns no cell data; it is only the
+/// frame-local identity used by [`GridLayout`](crate::grid::GridLayout).
+///
+/// # Common uses
+///
+/// - Store selected or focused palette cells without decoding `usize` math.
+/// - Route pointer hits from [`GridLayout::cell_at`](crate::grid::GridLayout::cell_at) to app state
+///   using row and column fields.
+/// - Use the same id type across [`crate::focus::FocusTargets`],
+///   [`crate::pointer::PointerTargets`], and [`crate::selection::SelectionState`].
+///
+/// # Constructor
+///
+/// - [`GridPosition::new`](crate::grid::GridPosition::new) creates a typed cell id from zero-based
+///   row and column indexes.
+///
+/// # Examples
+///
+/// Use typed cell ids with selection and pointer routing instead of encoding row-major indexes:
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::grid::GridPosition;
+/// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+/// use ratatui_layout::selection::{SelectionMode, SelectionState};
+///
+/// let cell = GridPosition::new(1, 2);
+/// let mouse = PointerTargets::new().target(PointerTarget::new(cell, Rect::new(8, 1, 4, 1)));
+/// let mut selection = SelectionState::new(SelectionMode::Single);
+///
+/// selection.select(mouse.hit_test((9, 1)).unwrap().id);
+///
+/// assert_eq!(
+///     selection.primary(),
+///     Some(GridPosition { row: 1, column: 2 })
+/// );
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GridPosition {
+    /// Zero-based row index.
+    ///
+    /// This indexes the row constraints passed to [`Grid::new`](crate::grid::Grid::new).
+    pub row: usize,
+    /// Zero-based column index.
+    ///
+    /// This indexes the column constraints passed to [`Grid::new`](crate::grid::Grid::new).
+    pub column: usize,
+}
+
+impl GridPosition {
+    /// Creates a grid position from a zero-based row and column.
+    ///
+    /// Use this when tests or app code need to name a typed cell explicitly.
+    ///
+    /// # Examples
+    ///
+    /// Store selection using a typed cell identity instead of row-major math:
+    ///
+    /// ```rust
+    /// use ratatui_layout::grid::GridPosition;
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let mut selection = SelectionState::new(SelectionMode::Single);
+    /// selection.select(GridPosition::new(1, 2));
+    ///
+    /// assert_eq!(
+    ///     selection.primary(),
+    ///     Some(GridPosition { row: 1, column: 2 })
+    /// );
+    /// ```
+    pub const fn new(row: usize, column: usize) -> Self {
+        Self { row, column }
+    }
+}
+
+/// Solved grid geometry for one frame.
+///
+/// [`GridLayout`](crate::grid::GridLayout) owns row areas, column areas, and a typed cell
+/// [`Regions`](crate::regions::Regions). It does not own table data, headers, selection, or
+/// rendering state. Use it when app logic wants to talk about cells as `{ row, column }` rather
+/// than row-major indexes.
+///
+/// # Common uses
+///
+/// - Build a [`crate::focus::FocusTargets`] or [`crate::pointer::PointerTargets`] from
+///   [`GridLayout::cells`](crate::grid::GridLayout::cells).
+/// - Draw row or column decorations using
+///   [`GridLayout::row_areas`](crate::grid::GridLayout::row_areas) and
+///   [`GridLayout::column_areas`](crate::grid::GridLayout::column_areas).
+/// - Hit test cells with [`GridLayout::cell_at`](crate::grid::GridLayout::cell_at) and update
+///   app-owned selection.
+///
+/// # Inspection and routing
+///
+/// - [`GridLayout::area`](crate::grid::GridLayout::area) returns the area the grid was solved
+///   against.
+/// - [`GridLayout::row_areas`](crate::grid::GridLayout::row_areas) returns row-spanning rectangles.
+/// - [`GridLayout::column_areas`](crate::grid::GridLayout::column_areas) returns column-spanning
+///   rectangles.
+/// - [`GridLayout::cells`](crate::grid::GridLayout::cells) returns the typed
+///   [`Regions`](crate::regions::Regions) of cell regions.
+/// - [`GridLayout::cell_at`](crate::grid::GridLayout::cell_at) hit-tests a terminal position and
+///   returns a [`GridPosition`](crate::grid::GridPosition).
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::{Constraint, Rect};
+/// use ratatui_layout::grid::{Grid, GridPosition};
+///
+/// let row_heights = [Constraint::Length(1), Constraint::Length(1)];
+/// let column_widths = [Constraint::Length(3), Constraint::Length(3)];
+/// let layout = Grid::new(row_heights, column_widths).layout(Rect::new(0, 0, 6, 2));
+///
+/// assert_eq!(layout.cell_at((4, 1)), Some(GridPosition::new(1, 1)));
+/// assert_eq!(layout.row_areas()[1], Rect::new(0, 1, 6, 1));
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct GridLayout {
+    area: Rect,
+    row_areas: Vec<Rect>,
+    column_areas: Vec<Rect>,
+    cells: Regions<GridPosition>,
+}
+
+impl GridLayout {
+    /// Returns the area the grid was solved for.
+    ///
+    /// This is the parent area, not the union of visible cells.
+    ///
+    /// # Examples
+    ///
+    /// Keep the full grid area for drawing a shared background:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::grid::Grid;
+    ///
+    /// let layout =
+    ///     Grid::new([Constraint::Length(1)], [Constraint::Length(4)]).layout(Rect::new(2, 3, 10, 4));
+    ///
+    /// assert_eq!(layout.area(), Rect::new(2, 3, 10, 4));
+    /// ```
+    pub const fn area(&self) -> Rect {
+        self.area
+    }
+
+    /// Returns the solved row areas.
+    ///
+    /// These are useful for row backgrounds, row separators, or diagnostics that span all columns.
+    ///
+    /// # Examples
+    ///
+    /// Draw row-spanning selection or separator regions:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::grid::Grid;
+    ///
+    /// let row_heights = [Constraint::Length(1), Constraint::Length(2)];
+    /// let column_widths = [Constraint::Fill(1)];
+    /// let layout = Grid::new(row_heights, column_widths).layout(Rect::new(0, 0, 10, 3));
+    ///
+    /// assert_eq!(layout.row_areas()[1], Rect::new(0, 1, 10, 2));
+    /// ```
+    pub fn row_areas(&self) -> &[Rect] {
+        &self.row_areas
+    }
+
+    /// Returns the solved column areas.
+    ///
+    /// These are useful for column headers, guides, or pointer affordances that span all rows.
+    ///
+    /// # Examples
+    ///
+    /// Use column areas for column-wide hover guides or headers:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::grid::Grid;
+    ///
+    /// let row_heights = [Constraint::Fill(1)];
+    /// let column_widths = [Constraint::Length(3), Constraint::Length(5)];
+    /// let layout = Grid::new(row_heights, column_widths).layout(Rect::new(0, 0, 8, 4));
+    ///
+    /// assert_eq!(layout.column_areas()[1], Rect::new(3, 0, 5, 4));
+    /// ```
+    pub fn column_areas(&self) -> &[Rect] {
+        &self.column_areas
+    }
+
+    /// Returns the typed cell regions.
+    ///
+    /// Iterate these regions to render app-owned cell content or derive focus and pointer targets.
+    ///
+    /// # Examples
+    ///
+    /// Build visible ids for selection traversal from the typed cell regions:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::grid::{Grid, GridPosition};
+    ///
+    /// let row_heights = [Constraint::Length(1)];
+    /// let column_widths = [Constraint::Length(2), Constraint::Length(2)];
+    /// let layout = Grid::new(row_heights, column_widths).layout(Rect::new(0, 0, 4, 1));
+    /// let ids: Vec<_> = layout
+    ///     .cells()
+    ///     .regions()
+    ///     .iter()
+    ///     .map(|region| region.id)
+    ///     .collect();
+    ///
+    /// assert_eq!(ids, [GridPosition::new(0, 0), GridPosition::new(0, 1)]);
+    /// ```
+    pub const fn cells(&self) -> &Regions<GridPosition> {
+        &self.cells
+    }
+
+    /// Returns the topmost cell at a terminal position.
+    ///
+    /// This is a convenience wrapper around
+    /// [`Regions::hit_test`](crate::regions::Regions::hit_test) for callers that only need the
+    /// typed cell id.
+    ///
+    /// # Examples
+    ///
+    /// Route a pointer position to the typed grid cell under the pointer:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::grid::{Grid, GridPosition};
+    ///
+    /// let row_heights = [Constraint::Length(1), Constraint::Length(1)];
+    /// let column_widths = [Constraint::Length(4), Constraint::Length(4)];
+    /// let layout = Grid::new(row_heights, column_widths).layout(Rect::new(0, 0, 8, 2));
+    ///
+    /// assert_eq!(layout.cell_at((5, 1)), Some(GridPosition::new(1, 1)));
+    /// ```
+    pub fn cell_at<P: Into<Position>>(&self, position: P) -> Option<GridPosition> {
+        self.cells.hit_test(position).map(|hit| hit.id)
+    }
+}
+
+/// Grid configuration that assigns one region for each row-column cell.
+///
+/// Use [`Grid`](crate::grid::Grid) when a cell layout needs ids and hit testing but not a full
+/// table widget. For example, a dashboard of app-owned tiles can use `Grid` to assign one region
+/// per tile, then render each tile from application data.
+///
+/// Grid regions are assigned in row-major order. For `r` rows and `c` columns, the id for
+/// `(row, column)` is `row * c + column`.
+///
+/// Use [`Grid::layout`](crate::grid::Grid::layout) instead when the caller would otherwise need to
+/// repeatedly encode and decode row/column pairs.
+///
+/// # Constructors and solving
+///
+/// - [`Grid::new`](crate::grid::Grid::new) stores row and column constraints.
+/// - [`Grid::regions`](crate::grid::Grid::regions) returns a row-major
+///   [`Regions`](crate::regions::Regions) with integer ids.
+/// - [`Grid::layout`](crate::grid::Grid::layout) returns [`GridLayout`](crate::grid::GridLayout)
+///   with typed [`GridPosition`](crate::grid::GridPosition) ids plus row/column areas.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::{Constraint, Rect};
+/// use ratatui_layout::grid::Grid;
+///
+/// let row_heights = [Constraint::Length(1), Constraint::Length(1)];
+/// let column_widths = [Constraint::Length(4), Constraint::Fill(1)];
+/// let grid = Grid::new(row_heights, column_widths);
+/// let cell_regions = grid.regions(Rect::new(0, 0, 10, 2));
+///
+/// assert_eq!(cell_regions.regions()[0].id, 0);
+/// assert_eq!(cell_regions.regions()[1].id, 1);
+/// assert_eq!(cell_regions.regions()[2].id, 2);
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Grid {
+    rows: Vec<Constraint>,
+    columns: Vec<Constraint>,
+}
+
+impl Grid {
+    /// Creates a grid from row and column constraints.
+    ///
+    /// The row constraints are solved vertically first. Each solved row is then split horizontally
+    /// with the column constraints.
+    ///
+    /// # Examples
+    ///
+    /// Create a dashboard grid from ordinary Ratatui constraints:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::grid::Grid;
+    ///
+    /// let row_heights = [Constraint::Length(1)];
+    /// let column_widths = [Constraint::Length(4), Constraint::Fill(1)];
+    /// let grid = Grid::new(row_heights, column_widths);
+    /// let plan = grid.regions(Rect::new(0, 0, 10, 1));
+    ///
+    /// assert_eq!(plan.regions()[0].area.width, 4);
+    /// ```
+    pub fn new<R, C>(rows: R, columns: C) -> Self
+    where
+        R: IntoIterator,
+        R::Item: Into<Constraint>,
+        C: IntoIterator,
+        C::Item: Into<Constraint>,
+    {
+        Self {
+            rows: rows.into_iter().map(Into::into).collect(),
+            columns: columns.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    /// Solves the grid into row-major regions.
+    ///
+    /// Empty row or column constraint lists produce empty regions.
+    ///
+    /// Use this when simple index ids are enough and row/column metadata is not needed.
+    ///
+    /// # Examples
+    ///
+    /// Use row-major integer ids for a simple generated grid:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::grid::Grid;
+    ///
+    /// let row_heights = [Constraint::Length(1), Constraint::Length(1)];
+    /// let column_widths = [Constraint::Length(3), Constraint::Length(3)];
+    /// let plan = Grid::new(row_heights, column_widths).regions(Rect::new(0, 0, 6, 2));
+    ///
+    /// assert_eq!(plan.hit_test((4, 1)).unwrap().id, 3);
+    /// ```
+    pub fn regions(&self, area: Rect) -> Regions {
+        let row_areas = Layout::vertical(self.rows.clone()).split(area);
+        let mut regions = Vec::with_capacity(row_areas.len().saturating_mul(self.columns.len()));
+
+        for (row_index, row_area) in row_areas.iter().copied().enumerate() {
+            for (column_index, cell_area) in Layout::horizontal(self.columns.clone())
+                .split(row_area)
+                .iter()
+                .copied()
+                .enumerate()
+            {
+                let id = row_index * self.columns.len() + column_index;
+                regions.push(Region::new(id, cell_area));
+            }
+        }
+
+        Regions::from_regions(area, regions)
+    }
+
+    /// Solves the grid into row areas, column areas, and typed cell ids.
+    ///
+    /// Empty row or column constraint lists produce empty cell regions. Column areas are solved
+    /// against the full grid height so callers can render column affordances that span all rows.
+    ///
+    /// # Examples
+    ///
+    /// Use typed cell ids when focus, mouse, and selection should share one coordinate type:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::grid::{Grid, GridPosition};
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let row_heights = [Constraint::Length(1), Constraint::Length(1)];
+    /// let column_widths = [Constraint::Length(2), Constraint::Length(2)];
+    /// let layout = Grid::new(row_heights, column_widths).layout(Rect::new(0, 0, 4, 2));
+    /// let visible: Vec<_> = layout
+    ///     .cells()
+    ///     .regions()
+    ///     .iter()
+    ///     .map(|region| region.id)
+    ///     .collect();
+    /// let mut selection = SelectionState::new(SelectionMode::Single);
+    /// selection.select_next(&visible);
+    ///
+    /// assert_eq!(selection.primary(), Some(GridPosition::new(0, 0)));
+    /// ```
+    pub fn layout(&self, area: Rect) -> GridLayout {
+        let row_areas = Layout::vertical(self.rows.clone()).split(area).to_vec();
+        let column_areas = Layout::horizontal(self.columns.clone())
+            .split(area)
+            .to_vec();
+        let mut regions = Vec::with_capacity(row_areas.len().saturating_mul(self.columns.len()));
+
+        for (row_index, row_area) in row_areas.iter().copied().enumerate() {
+            for (column_index, cell_area) in Layout::horizontal(self.columns.clone())
+                .split(row_area)
+                .iter()
+                .copied()
+                .enumerate()
+            {
+                regions.push(Region::new(
+                    GridPosition::new(row_index, column_index),
+                    cell_area,
+                ));
+            }
+        }
+
+        GridLayout {
+            area,
+            row_areas,
+            column_areas,
+            cells: Regions::from_regions(area, regions),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use ratatui_core::layout::{Constraint, Rect};
+
+    use super::*;
+
+    #[test]
+    fn grid_uses_row_major_ids() {
+        let row_heights = [Constraint::Length(1), Constraint::Length(1)];
+        let column_widths = [Constraint::Length(2), Constraint::Length(3)];
+        let plan = Grid::new(row_heights, column_widths).regions(Rect::new(0, 0, 5, 2));
+
+        assert_eq!(plan.regions()[0].area, Rect::new(0, 0, 2, 1));
+        assert_eq!(plan.regions()[1].area, Rect::new(2, 0, 3, 1));
+        assert_eq!(plan.regions()[2].area, Rect::new(0, 1, 2, 1));
+        assert_eq!(plan.regions()[3].area, Rect::new(2, 1, 3, 1));
+    }
+
+    #[test]
+    fn grid_layout_uses_typed_cell_ids() {
+        let row_heights = [Constraint::Length(1), Constraint::Length(1)];
+        let column_widths = [Constraint::Length(2), Constraint::Length(3)];
+        let layout = Grid::new(row_heights, column_widths).layout(Rect::new(0, 0, 5, 2));
+
+        assert_eq!(
+            layout.row_areas(),
+            &[Rect::new(0, 0, 5, 1), Rect::new(0, 1, 5, 1)]
+        );
+        assert_eq!(
+            layout.column_areas(),
+            &[Rect::new(0, 0, 2, 2), Rect::new(2, 0, 3, 2)]
+        );
+        assert_eq!(layout.cells().regions()[3].id, GridPosition::new(1, 1));
+        assert_eq!(layout.cell_at((3, 1)), Some(GridPosition::new(1, 1)));
+    }
+
+    #[test]
+    fn empty_grid_has_no_cells() {
+        let rows: [Constraint; 0] = [];
+        let layout = Grid::new(rows, [Constraint::Length(1)]).layout(Rect::new(0, 0, 5, 2));
+
+        assert!(layout.row_areas().is_empty());
+        assert!(layout.cells().is_empty());
+    }
+}

--- a/crates/ratatui-layout/src/input.rs
+++ b/crates/ratatui-layout/src/input.rs
@@ -1,0 +1,825 @@
+//! Rendering-agnostic state helpers for simple controls.
+//!
+//! `ratatui-layout` mostly deals in frame-local geometry and routing data, but real applications
+//! also need a small amount of persistent state behind common controls. This module contains
+//! helpers for the mechanical parts that should not be reimplemented in every example: text-field
+//! cursor editing and button-row focus movement.
+//!
+//! These types deliberately do not render. They do not know about styles, labels, borders, or key
+//! bindings. A Ratatui app can render a field or button however it wants, then use these helpers to
+//! keep the state transitions predictable.
+//!
+//! # Types
+//!
+//! - [`TextFieldState`](crate::input::TextFieldState) stores a character cursor and edits an
+//!   externally owned [`String`](alloc::string::String).
+//! - [`ButtonRowState`](crate::input::ButtonRowState) stores the focused button position for a row
+//!   of app-owned ids.
+//! - [`ButtonRow`](crate::input::ButtonRow) stores a fixed row of button ids with its
+//!   [`ButtonRowState`](crate::input::ButtonRowState).
+//!
+//! Use full widgets or application-specific state when the control owns validation, completion,
+//! history, undo, or other domain behavior. Use these helpers when the problem is just editing a
+//! temporary string or moving focus across a small row of buttons.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use ratatui_core::layout::{Position, Rect};
+
+use crate::cursor::CursorRequest;
+
+/// Cursor and edit state for an externally owned text value.
+///
+/// [`TextFieldState`](crate::input::TextFieldState) owns only the cursor position. The text itself
+/// stays in application state, so cancel/save flows can copy values into a temporary dialog struct
+/// and apply them later. Cursor positions are measured in characters rather than bytes, which keeps
+/// insertion and deletion from splitting a UTF-8 code point.
+///
+/// # Common uses
+///
+/// - Store one `TextFieldState` beside each editable field in a modal dialog.
+/// - Move the cursor with left/right/home/end keys while keeping the text in a domain edit buffer.
+/// - Insert, backspace, or delete characters without duplicating byte-index conversion at every
+///   call site.
+///
+/// # Methods
+///
+/// - [`TextFieldState::new`](crate::input::TextFieldState::new) starts with the cursor at the
+///   beginning.
+/// - [`TextFieldState::at_end`](crate::input::TextFieldState::at_end) starts with the cursor after
+///   the current value.
+/// - [`TextFieldState::cursor`](crate::input::TextFieldState::cursor) reads the character cursor.
+/// - [`TextFieldState::set_cursor`](crate::input::TextFieldState::set_cursor) stores a cursor
+///   clamped to a value.
+/// - [`TextFieldState::clamp_to`](crate::input::TextFieldState::clamp_to) clamps the cursor after a
+///   value changed externally.
+/// - [`TextFieldState::move_left`](crate::input::TextFieldState::move_left),
+///   [`TextFieldState::move_right`](crate::input::TextFieldState::move_right),
+///   [`TextFieldState::move_home`](crate::input::TextFieldState::move_home), and
+///   [`TextFieldState::move_end`](crate::input::TextFieldState::move_end) implement ordinary cursor
+///   navigation.
+/// - [`TextFieldState::cursor_request_after_prefix`](crate::input::TextFieldState::cursor_request_after_prefix) converts the text cursor into a terminal
+///   cursor request for a rendered field.
+/// - [`TextFieldState::insert_char`](crate::input::TextFieldState::insert_char),
+///   [`TextFieldState::backspace`](crate::input::TextFieldState::backspace), and
+///   [`TextFieldState::delete`](crate::input::TextFieldState::delete) implement canonical
+///   single-character editing.
+///
+/// # Examples
+///
+/// Edit a temporary dialog value without storing the text inside the field state:
+///
+/// ```rust
+/// use std::string::String;
+///
+/// use ratatui_layout::input::TextFieldState;
+///
+/// let mut value = String::from("abcd");
+/// let mut field = TextFieldState::new();
+///
+/// field.set_cursor(2, &value);
+/// field.insert_char(&mut value, 'X');
+/// field.backspace(&mut value);
+/// field.move_right(&value);
+/// field.delete(&mut value);
+///
+/// assert_eq!(value, "abc");
+/// assert_eq!(field.cursor(), 3);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TextFieldState {
+    cursor: usize,
+}
+
+impl TextFieldState {
+    /// Creates field state with the cursor at the start.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let field = TextFieldState::new();
+    ///
+    /// assert_eq!(field.cursor(), 0);
+    /// ```
+    pub const fn new() -> Self {
+        Self { cursor: 0 }
+    }
+
+    /// Creates field state with the cursor at the end of a value.
+    ///
+    /// Use this when opening an edit dialog from an existing record. The user can immediately
+    /// append text, while left/right navigation still works in character coordinates.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let field = TextFieldState::at_end("owner");
+    ///
+    /// assert_eq!(field.cursor(), 5);
+    /// ```
+    pub fn at_end(value: &str) -> Self {
+        Self {
+            cursor: value.chars().count(),
+        }
+    }
+
+    /// Returns the character cursor.
+    ///
+    /// The cursor is a character index, not a byte index. Use it for terminal cursor placement
+    /// after accounting for the field label width.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let field = TextFieldState::at_end("ab");
+    ///
+    /// assert_eq!(field.cursor(), 2);
+    /// ```
+    pub const fn cursor(self) -> usize {
+        self.cursor
+    }
+
+    /// Sets the cursor, clamped to the current value length.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let mut field = TextFieldState::new();
+    /// field.set_cursor(10, "abc");
+    ///
+    /// assert_eq!(field.cursor(), 3);
+    /// ```
+    pub fn set_cursor(&mut self, cursor: usize, value: &str) {
+        self.cursor = cursor.min(value.chars().count());
+    }
+
+    /// Clamps the cursor after the value was changed outside this state.
+    ///
+    /// This is useful after replacing a field value from autocomplete, paste handling, or a domain
+    /// refresh.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let mut field = TextFieldState::at_end("abcdef");
+    /// field.clamp_to("ab");
+    ///
+    /// assert_eq!(field.cursor(), 2);
+    /// ```
+    pub fn clamp_to(&mut self, value: &str) {
+        self.set_cursor(self.cursor, value);
+    }
+
+    /// Moves the cursor one character left.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let mut field = TextFieldState::at_end("ab");
+    /// field.move_left();
+    ///
+    /// assert_eq!(field.cursor(), 1);
+    /// ```
+    pub const fn move_left(&mut self) {
+        self.cursor = self.cursor.saturating_sub(1);
+    }
+
+    /// Moves the cursor one character right, clamped to the value length.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let mut field = TextFieldState::new();
+    /// field.move_right("ab");
+    ///
+    /// assert_eq!(field.cursor(), 1);
+    /// ```
+    pub fn move_right(&mut self, value: &str) {
+        self.cursor = self.cursor.saturating_add(1).min(value.chars().count());
+    }
+
+    /// Moves the cursor to the beginning.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let mut field = TextFieldState::at_end("ab");
+    /// field.move_home();
+    ///
+    /// assert_eq!(field.cursor(), 0);
+    /// ```
+    pub const fn move_home(&mut self) {
+        self.cursor = 0;
+    }
+
+    /// Moves the cursor to the end of the value.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let mut field = TextFieldState::new();
+    /// field.move_end("abc");
+    ///
+    /// assert_eq!(field.cursor(), 3);
+    /// ```
+    pub fn move_end(&mut self, value: &str) {
+        self.cursor = value.chars().count();
+    }
+
+    /// Returns a cursor request for a field with a fixed prefix.
+    ///
+    /// `prefix_width` is the rendered width before editable text, such as `"title: "`. The cursor
+    /// is clamped to the field area so an overlong value does not request a position outside the
+    /// visible row.
+    ///
+    /// # Examples
+    ///
+    /// Place the terminal cursor after a rendered label prefix:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Position, Rect};
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let field = TextFieldState::at_end("abc");
+    /// let request = field.cursor_request_after_prefix(Rect::new(10, 2, 20, 1), 7);
+    ///
+    /// assert_eq!(request.position, Position::new(20, 2));
+    /// ```
+    pub fn cursor_request_after_prefix(self, area: Rect, prefix_width: u16) -> CursorRequest {
+        let x = area
+            .x
+            .saturating_add(prefix_width)
+            .saturating_add(self.cursor as u16)
+            .min(area.right().saturating_sub(1));
+        CursorRequest::visible(Position::new(x, area.y))
+    }
+
+    /// Inserts a character at the cursor and moves the cursor after it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::string::String;
+    ///
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let mut value = String::from("ac");
+    /// let mut field = TextFieldState::new();
+    /// field.set_cursor(1, &value);
+    /// field.insert_char(&mut value, 'b');
+    ///
+    /// assert_eq!(value, "abc");
+    /// assert_eq!(field.cursor(), 2);
+    /// ```
+    pub fn insert_char(&mut self, value: &mut String, ch: char) {
+        let index = byte_index(value, self.cursor);
+        value.insert(index, ch);
+        self.cursor += 1;
+    }
+
+    /// Removes the character before the cursor and moves left.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::string::String;
+    ///
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let mut value = String::from("abc");
+    /// let mut field = TextFieldState::at_end(&value);
+    /// field.backspace(&mut value);
+    ///
+    /// assert_eq!(value, "ab");
+    /// assert_eq!(field.cursor(), 2);
+    /// ```
+    pub fn backspace(&mut self, value: &mut String) {
+        if self.cursor == 0 {
+            return;
+        }
+        let start = byte_index(value, self.cursor - 1);
+        let end = byte_index(value, self.cursor);
+        value.replace_range(start..end, "");
+        self.cursor -= 1;
+    }
+
+    /// Removes the character at the cursor.
+    ///
+    /// Delete leaves the cursor in place. It is a no-op at the end of the value.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::string::String;
+    ///
+    /// use ratatui_layout::input::TextFieldState;
+    ///
+    /// let mut value = String::from("abc");
+    /// let mut field = TextFieldState::new();
+    /// field.set_cursor(1, &value);
+    /// field.delete(&mut value);
+    ///
+    /// assert_eq!(value, "ac");
+    /// assert_eq!(field.cursor(), 1);
+    /// ```
+    pub fn delete(self, value: &mut String) {
+        if self.cursor >= value.chars().count() {
+            return;
+        }
+        let start = byte_index(value, self.cursor);
+        let end = byte_index(value, self.cursor + 1);
+        value.replace_range(start..end, "");
+    }
+}
+
+/// Focus state for a horizontal row of buttons.
+///
+/// [`ButtonRowState`](crate::input::ButtonRowState) owns the focused position inside a row, while
+/// the application owns the button ids and actions. This is the small state helper behind a common
+/// modal pattern: left and right keys move between `Cancel` and `Save`, while Enter or Space
+/// activates the focused id.
+///
+/// The helper is intentionally index-based internally. Callers pass the current visible button ids
+/// when reading or changing focus, which keeps it useful for enum ids, integer ids, and filtered or
+/// disabled button sets.
+///
+/// # Methods
+///
+/// - [`ButtonRowState::new`](crate::input::ButtonRowState::new) starts at the first button.
+/// - [`ButtonRowState::focused_index`](crate::input::ButtonRowState::focused_index) reads the
+///   current position.
+/// - [`ButtonRowState::focused_id`](crate::input::ButtonRowState::focused_id) maps the current
+///   position to the caller's id slice.
+/// - [`ButtonRowState::focus_index`](crate::input::ButtonRowState::focus_index) stores a clamped
+///   position.
+/// - [`ButtonRowState::focus_id`](crate::input::ButtonRowState::focus_id) stores the position of a
+///   specific id.
+/// - [`ButtonRowState::move_next`](crate::input::ButtonRowState::move_next) and
+///   [`ButtonRowState::move_previous`](crate::input::ButtonRowState::move_previous) move
+///   horizontally with wrapping.
+///
+/// # Examples
+///
+/// Keep a dialog button row aligned with enum ids:
+///
+/// ```rust
+/// use ratatui_layout::input::ButtonRowState;
+///
+/// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// enum Action {
+///     Cancel,
+///     Save,
+/// }
+///
+/// let buttons = [Action::Cancel, Action::Save];
+/// let mut row = ButtonRowState::new();
+///
+/// row.move_next(buttons.len());
+/// assert_eq!(row.focused_id(&buttons), Some(Action::Save));
+/// row.focus_id(&buttons, &Action::Cancel);
+/// assert_eq!(row.focused_index(), 0);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ButtonRowState {
+    focused: usize,
+}
+
+impl ButtonRowState {
+    /// Creates button-row state focused on the first position.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRowState;
+    ///
+    /// let row = ButtonRowState::new();
+    ///
+    /// assert_eq!(row.focused_index(), 0);
+    /// ```
+    pub const fn new() -> Self {
+        Self { focused: 0 }
+    }
+
+    /// Returns the focused button position.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRowState;
+    ///
+    /// let row = ButtonRowState::new();
+    ///
+    /// assert_eq!(row.focused_index(), 0);
+    /// ```
+    pub const fn focused_index(self) -> usize {
+        self.focused
+    }
+
+    /// Returns the id at the focused position.
+    ///
+    /// Passing the current id slice keeps the state independent from the application's id type and
+    /// from any buttons that may be hidden or disabled this frame.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRowState;
+    ///
+    /// let row = ButtonRowState::new();
+    ///
+    /// assert_eq!(row.focused_id(&["cancel", "save"]), Some("cancel"));
+    /// ```
+    pub fn focused_id<Id: Copy>(self, ids: &[Id]) -> Option<Id> {
+        ids.get(self.focused).copied()
+    }
+
+    /// Stores a focused index clamped to the visible button count.
+    ///
+    /// Empty rows always store zero so later non-empty rows start from the first button.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRowState;
+    ///
+    /// let mut row = ButtonRowState::new();
+    /// row.focus_index(10, 2);
+    ///
+    /// assert_eq!(row.focused_index(), 1);
+    /// ```
+    pub const fn focus_index(&mut self, index: usize, len: usize) {
+        self.focused = if len == 0 {
+            0
+        } else if index >= len {
+            len - 1
+        } else {
+            index
+        };
+    }
+
+    /// Focuses the first matching id in the current visible button slice.
+    ///
+    /// Use this when focus is stored globally as an application enum and the button row needs to
+    /// synchronize its local index before handling left/right movement.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRowState;
+    ///
+    /// let mut row = ButtonRowState::new();
+    /// row.focus_id(&["cancel", "save"], &"save");
+    ///
+    /// assert_eq!(row.focused_index(), 1);
+    /// ```
+    pub fn focus_id<Id: Eq>(&mut self, ids: &[Id], id: &Id) {
+        if let Some(index) = ids.iter().position(|button| button == id) {
+            self.focused = index;
+        }
+    }
+
+    /// Moves focus to the next button, wrapping at the end.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRowState;
+    ///
+    /// let mut row = ButtonRowState::new();
+    /// row.move_next(2);
+    /// row.move_next(2);
+    ///
+    /// assert_eq!(row.focused_index(), 0);
+    /// ```
+    pub const fn move_next(&mut self, len: usize) {
+        if len == 0 {
+            self.focused = 0;
+        } else {
+            self.focused = (self.focused + 1) % len;
+        }
+    }
+
+    /// Moves focus to the previous button, wrapping at the start.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRowState;
+    ///
+    /// let mut row = ButtonRowState::new();
+    /// row.move_previous(2);
+    ///
+    /// assert_eq!(row.focused_index(), 1);
+    /// ```
+    pub const fn move_previous(&mut self, len: usize) {
+        if len == 0 {
+            self.focused = 0;
+        } else {
+            self.focused = (self.focused + len - 1) % len;
+        }
+    }
+}
+
+/// Button-row focus state that owns the row's ids.
+///
+/// [`ButtonRowState`](crate::input::ButtonRowState) is intentionally minimal: callers pass the
+/// current visible id slice every time they move or read focus.
+/// [`ButtonRow`](crate::input::ButtonRow) is the convenience wrapper for fixed or mostly fixed rows
+/// where the same ids are used repeatedly. Dialogs with `Cancel` and `Save` buttons are the
+/// canonical case: rendering owns labels and styles, while this helper owns only the row ids and
+/// horizontal focus position.
+///
+/// Use [`ButtonRowState`](crate::input::ButtonRowState) directly when the visible id slice is
+/// produced fresh each frame, filtered by permissions, or borrowed from another component. Use
+/// [`ButtonRow`](crate::input::ButtonRow) when a component would otherwise have to rebuild the same
+/// id vector for every left/right movement.
+///
+/// # Methods
+///
+/// - [`ButtonRow::new`](crate::input::ButtonRow::new) stores ids and starts focused on the first
+///   id.
+/// - [`ButtonRow::ids`](crate::input::ButtonRow::ids) exposes the owned ids for rendering or
+///   frame-snapshot construction.
+/// - [`ButtonRow::focused_id`](crate::input::ButtonRow::focused_id) returns the currently focused
+///   id.
+/// - [`ButtonRow::focus_id`](crate::input::ButtonRow::focus_id) synchronizes local button focus
+///   with global app focus.
+/// - [`ButtonRow::move_next`](crate::input::ButtonRow::move_next) and
+///   [`ButtonRow::move_previous`](crate::input::ButtonRow::move_previous) move horizontally with
+///   wrapping.
+/// - [`ButtonRow::state`](crate::input::ButtonRow::state) and
+///   [`ButtonRow::state_mut`](crate::input::ButtonRow::state_mut) expose the inner
+///   [`ButtonRowState`](crate::input::ButtonRowState) when a caller needs index-level control.
+///
+/// # Examples
+///
+/// Store fixed dialog button ids once and move through them with left/right keys:
+///
+/// ```rust
+/// use ratatui_layout::input::ButtonRow;
+///
+/// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// enum DialogButton {
+///     Cancel,
+///     Save,
+/// }
+///
+/// let mut buttons = ButtonRow::new([DialogButton::Cancel, DialogButton::Save]);
+///
+/// buttons.move_next();
+/// assert_eq!(buttons.focused_id(), Some(DialogButton::Save));
+/// buttons.focus_id(&DialogButton::Cancel);
+/// assert_eq!(buttons.focused_id(), Some(DialogButton::Cancel));
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ButtonRow<Id = usize> {
+    ids: Vec<Id>,
+    state: ButtonRowState,
+}
+
+impl<Id> ButtonRow<Id> {
+    /// Creates a button row from ids in left-to-right order.
+    ///
+    /// The row starts focused on the first id. Empty rows are allowed so a component can keep a
+    /// single field even when no actions are currently visible.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRow;
+    ///
+    /// let row = ButtonRow::new(["cancel", "save"]);
+    ///
+    /// assert_eq!(row.ids(), &["cancel", "save"]);
+    /// ```
+    pub fn new(ids: impl IntoIterator<Item = Id>) -> Self {
+        Self {
+            ids: ids.into_iter().collect(),
+            state: ButtonRowState::new(),
+        }
+    }
+
+    /// Returns the ids in left-to-right visual order.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRow;
+    ///
+    /// let row = ButtonRow::new([1, 2]);
+    ///
+    /// assert_eq!(row.ids(), &[1, 2]);
+    /// ```
+    pub fn ids(&self) -> &[Id] {
+        &self.ids
+    }
+
+    /// Returns the inner position-based state.
+    ///
+    /// This is useful for diagnostics or for code that still needs the focused index.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRow;
+    ///
+    /// let row = ButtonRow::new(["cancel", "save"]);
+    ///
+    /// assert_eq!(row.state().focused_index(), 0);
+    /// ```
+    pub const fn state(&self) -> ButtonRowState {
+        self.state
+    }
+
+    /// Returns mutable access to the inner position-based state.
+    ///
+    /// Use this when a caller has a reason to set the focused index directly while still keeping
+    /// the ids owned by [`ButtonRow`](crate::input::ButtonRow).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRow;
+    ///
+    /// let mut row = ButtonRow::new(["cancel", "save"]);
+    /// row.state_mut().focus_index(1, 2);
+    ///
+    /// assert_eq!(row.focused_id(), Some("save"));
+    /// ```
+    pub const fn state_mut(&mut self) -> &mut ButtonRowState {
+        &mut self.state
+    }
+
+    /// Moves focus to the next id, wrapping at the end.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRow;
+    ///
+    /// let mut row = ButtonRow::new(["cancel", "save"]);
+    /// row.move_next();
+    ///
+    /// assert_eq!(row.focused_id(), Some("save"));
+    /// ```
+    pub const fn move_next(&mut self) {
+        self.state.move_next(self.ids.len());
+    }
+
+    /// Moves focus to the previous id, wrapping at the start.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRow;
+    ///
+    /// let mut row = ButtonRow::new(["cancel", "save"]);
+    /// row.move_previous();
+    ///
+    /// assert_eq!(row.focused_id(), Some("save"));
+    /// ```
+    pub const fn move_previous(&mut self) {
+        self.state.move_previous(self.ids.len());
+    }
+}
+
+impl<Id: Copy> ButtonRow<Id> {
+    /// Returns the currently focused id.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRow;
+    ///
+    /// let row = ButtonRow::new(["cancel", "save"]);
+    ///
+    /// assert_eq!(row.focused_id(), Some("cancel"));
+    /// ```
+    pub fn focused_id(&self) -> Option<Id> {
+        self.state.focused_id(&self.ids)
+    }
+}
+
+impl<Id: Eq> ButtonRow<Id> {
+    /// Focuses the first matching id.
+    ///
+    /// This synchronizes row-local focus with app-level focus before handling left/right movement.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::input::ButtonRow;
+    ///
+    /// let mut row = ButtonRow::new(["cancel", "save"]);
+    /// row.focus_id(&"save");
+    ///
+    /// assert_eq!(row.state().focused_index(), 1);
+    /// ```
+    pub fn focus_id(&mut self, id: &Id) {
+        self.state.focus_id(&self.ids, id);
+    }
+}
+
+fn byte_index(value: &str, cursor: usize) -> usize {
+    value
+        .char_indices()
+        .nth(cursor)
+        .map_or(value.len(), |(index, _)| index)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+
+    use super::*;
+
+    #[test]
+    fn text_field_edits_at_character_cursor() {
+        let mut value = String::from("aé");
+        let mut field = TextFieldState::at_end(&value);
+
+        field.move_left();
+        field.insert_char(&mut value, 'X');
+        field.delete(&mut value);
+        field.backspace(&mut value);
+
+        assert_eq!(value, "a");
+        assert_eq!(field.cursor(), 1);
+    }
+
+    #[test]
+    fn text_field_clamps_cursor_to_value() {
+        let mut field = TextFieldState::new();
+
+        field.set_cursor(99, "abc");
+        field.move_right("abc");
+        field.clamp_to("a");
+
+        assert_eq!(field.cursor(), 1);
+    }
+
+    #[test]
+    fn text_field_builds_cursor_request_after_prefix() {
+        let field = TextFieldState::at_end("abcdef");
+
+        let request = field.cursor_request_after_prefix(Rect::new(10, 2, 12, 1), 7);
+
+        assert_eq!(request.position, Position::new(21, 2));
+    }
+
+    #[test]
+    fn button_row_moves_and_resolves_ids() {
+        #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+        enum Button {
+            Cancel,
+            Save,
+        }
+
+        let buttons = [Button::Cancel, Button::Save];
+        let mut row = ButtonRowState::new();
+
+        row.move_previous(buttons.len());
+        assert_eq!(row.focused_id(&buttons), Some(Button::Save));
+        row.focus_id(&buttons, &Button::Cancel);
+        assert_eq!(row.focused_id(&buttons), Some(Button::Cancel));
+    }
+
+    #[test]
+    fn owned_button_row_moves_and_resolves_ids() {
+        #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+        enum Button {
+            Cancel,
+            Save,
+        }
+
+        let mut row = ButtonRow::new([Button::Cancel, Button::Save]);
+
+        row.move_previous();
+        assert_eq!(row.focused_id(), Some(Button::Save));
+        row.focus_id(&Button::Cancel);
+        assert_eq!(row.focused_id(), Some(Button::Cancel));
+        assert_eq!(row.ids(), &[Button::Cancel, Button::Save]);
+    }
+}

--- a/crates/ratatui-layout/src/lib.rs
+++ b/crates/ratatui-layout/src/lib.rs
@@ -1,0 +1,296 @@
+#![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/ratatui/ratatui/main/assets/logo.png",
+    html_favicon_url = "https://raw.githubusercontent.com/ratatui/ratatui/main/assets/favicon.ico"
+)]
+#![warn(missing_docs)]
+// Explicit module targets keep prose links aligned with the owning modules now that the crate root
+// no longer re-exports every public type.
+#![allow(rustdoc::redundant_explicit_links)]
+//! Experimental frame-local UI coordination primitives for Ratatui.
+//!
+//! This is a `0.0.1-alpha.0` experiment. The crate exists to validate ideas, examples, and API
+//! pressure around immediate-mode UI coordination. Names, module boundaries, responsibilities, and
+//! even the crate shape may change substantially; the properly baked version is likely to look
+//! different from this alpha.
+//!
+//! `ratatui-layout` explores immediate-mode UI coordination for applications that need more than a
+//! one-pass render call. A render pass can compute visible data such as regions, focus targets,
+//! pointer targets, cursor requests, viewport metrics, and selected ids. The application can store
+//! that output after drawing and use it to route the next input event.
+//!
+//! The crate does not introduce a retained widget tree and does not make containers store child
+//! widgets. Application code keeps ownership of domain data, widget state, focus state, selection
+//! state, and event handling. These primitives only make the output produced by a frame explicit.
+//!
+//! [`Rect`]: ratatui_core::layout::Rect
+//!
+//! # Relationship to Ratatui layout
+//!
+//! Use Ratatui's built-in [`Layout`] directly when the rectangles are only an implementation detail
+//! of the current render function. The normal `Layout::areas` and `Layout::split` APIs are still
+//! the right tool for ordinary page structure:
+//!
+//! ```rust
+//! use ratatui_core::layout::{Constraint, Layout, Rect};
+//!
+//! let area = Rect::new(0, 0, 80, 24);
+//! let columns = [Constraint::Length(20), Constraint::Fill(1)];
+//! let [sidebar, content] = Layout::horizontal(columns).areas(area);
+//! ```
+//!
+//! Use this crate when the solved layout needs to be observed or reused after the split:
+//!
+//! - pointer hit testing needs to map a position back to an item;
+//! - a scrollable viewport needs clamped content-space coordinates;
+//! - rows or cells are rendered by external application state instead of child widgets;
+//! - selection, clipping, z-order, or stable ids need to travel with a rectangle;
+//! - tests or diagnostics need to inspect the visible regions directly.
+//!
+//! [`Layout`]: ratatui_core::layout::Layout
+//!
+//! # Areas and regions
+//!
+//! Ratatui already uses the word "area" for a [`Rect`]: a rectangle in terminal coordinates. An
+//! area is geometry only. It is the right word when code is about drawing into a rectangle or
+//! splitting a page into rectangles.
+//!
+//! This crate uses "region" for a rectangle that has become part of frame-local coordination. A
+//! [`Region`](crate::regions::Region) contains an area plus an app-owned id, clipping metadata, and
+//! z-order. A [`Regions`](crate::regions::Regions) value stores those records together so a later
+//! input event can route back to the thing that was visible. Put another way: render into areas,
+//! store regions when those areas need identity or behavior after rendering.
+//!
+//! # Choosing what to store
+//!
+//! The crate has several kinds of values because an immediate-mode app should store only the data
+//! it needs for the next event, not a retained widget tree.
+//!
+//! Frame-local data is produced by rendering or layout and describes what was visible in one frame.
+//! It is safe to rebuild every draw and store for the next input event.
+//! [`Regions`](crate::regions::Regions), [`FocusTargets`](crate::focus::FocusTargets),
+//! [`PointerTargets`](crate::pointer::PointerTargets),
+//! [`CursorRequests`](crate::cursor::CursorRequests), and
+//! [`FrameSnapshot`](crate::frame::FrameSnapshot) are frame-local outputs. Rich layout outputs such
+//! as [`ContainerLayout`](crate::container::ContainerLayout),
+//! [`GridLayout`](crate::grid::GridLayout), [`list::ListLayout`], [`table::TableLayout`], and
+//! [`ViewportLayout`](crate::viewport::ViewportLayout) are also frame-local data.
+//!
+//! Persistent state belongs to the app or to small app-owned helpers.
+//! [`FocusState`](crate::focus::FocusState), [`PointerState`](crate::pointer::PointerState),
+//! [`SelectionState`](crate::selection::SelectionState),
+//! [`VisibleSelection`](crate::selection::VisibleSelection),
+//! [`TextFieldState`](crate::input::TextFieldState),
+//! [`ButtonRowState`](crate::input::ButtonRowState),
+//! [`ViewportState`](crate::viewport::ViewportState), [`list::VirtualListState`], and
+//! [`table::VirtualTableState`] survive across frames and feed the next render pass.
+//!
+//! Render and measure contexts are callback inputs, not frame outputs.
+//! [`MeasureContext`](crate::participant::MeasureContext),
+//! [`RenderContext`](crate::participant::RenderContext), [`list::ListItemContext`], and
+//! [`table::TableCellContext`] describe the current item or cell while external application content
+//! is being measured or drawn.
+//!
+//! Use [`FrameSnapshot`](crate::frame::FrameSnapshot) when a component boundary needs regions,
+//! focus targets, pointer targets, and cursor requests to travel together. Use the smaller values
+//! directly when a surface only needs one concern, such as a pointer-only scroll region or a
+//! focus-only field set.
+//!
+//! # Frame-local model
+//!
+//! Ratatui widgets are usually immediate-mode render commands. That works well for simple widgets,
+//! but container-like widgets often need more than a final render call. A list, table, menu, or
+//! toolbar may need to know where each child ended up so the app can perform hit testing, scroll a
+//! viewport, draw a selection, or render custom row content.
+//!
+//! This crate makes those intermediate results explicit:
+//!
+//! - [`Regions`](crate::regions::Regions) stores solved [`Region`](crate::regions::Region) values
+//!   for geometry.
+//! - [`FocusTargets`](crate::focus::FocusTargets), [`FocusState`](crate::focus::FocusState), and
+//!   [`FocusFallback`](crate::focus::FocusFallback) expose focus traversal over visible regions and
+//!   repair stale focus after a frame changes.
+//! - [`PointerTargets`](crate::pointer::PointerTargets),
+//!   [`PointerState`](crate::pointer::PointerState), and
+//!   [`PointerPhase`](crate::pointer::PointerPhase) route pointer positions through visible
+//!   targets.
+//! - [`FrameTargets`](crate::frame::FrameTargets) turns visible regions into aligned regions,
+//!   pointer targets, and focus target data.
+//! - [`RegionTargets`](crate::frame::RegionTargets) starts from an existing
+//!   [`Regions`](crate::regions::Regions) and adds disabled, focusable, mouseable, and z-order
+//!   policy.
+//! - [`SelectionState`](crate::selection::SelectionState) stores app-owned selection independently
+//!   from geometry.
+//! - [`VisibleSelection`](crate::selection::VisibleSelection) bridges durable selected ids to
+//!   visible positions in virtualized views.
+//! - [`CursorRequests`](crate::cursor::CursorRequests) records cursor placement requests produced
+//!   during rendering.
+//! - [`FrameSnapshot`](crate::frame::FrameSnapshot) optionally aggregates one frame's coordination
+//!   data.
+//! - [`Row`](crate::linear::Row), [`Column`](crate::linear::Column), [`Grid`](crate::grid::Grid),
+//!   and [`Overlay`](crate::overlay::Overlay) produce region sets for common arrangements.
+//! - [`Container`](crate::container::Container) computes outer, inner, clipping, and child-region
+//!   geometry.
+//! - [`Viewport`](crate::viewport::Viewport) computes clamped scroll metadata for rectangular
+//!   content.
+//! - [`list::VirtualList`] measures and renders externally owned list items by index.
+//! - [`table::VirtualTable`] lays out app-owned cells with pinned headers and two-axis scrolling.
+//! - [`TextFieldState`](crate::input::TextFieldState),
+//!   [`ButtonRowState`](crate::input::ButtonRowState), and [`ButtonRow`](crate::input::ButtonRow)
+//!   handle small rendering-agnostic control state.
+//! - [`ActionSurface`](crate::action::ActionSurface), [`CommandRow`](crate::action::CommandRow),
+//!   [`TextInput`](crate::text_input::TextInput), [`ModalShell`](crate::modal::ModalShell),
+//!   [`ScrollablePane`](crate::pane::ScrollablePane), and
+//!   [`VirtualRecordList`](crate::record_list::VirtualRecordList) package common app-level patterns
+//!   on top of the lower-level primitives.
+//!
+//! The application still owns its data, row state, and widget state. The layout primitive owns only
+//! the geometry calculation and the state needed to keep that geometry stable.
+//! [`Row`](crate::linear::Row) and [`Column`](crate::linear::Column) are intentionally thin
+//! adapters over the existing Ratatui [`Layout`] solver; their value is the returned
+//! [`Regions`](crate::regions::Regions), not different split behavior.
+//!
+//! # Choosing id types
+//!
+//! Most routing and geometry types are generic over `Id` because the frame-local output should
+//! route back to application data without owning that data. Pick the id type that matches how
+//! stable the identity must be:
+//!
+//! - Use integers for generated positions where order is the contract, such as
+//!   [`Row`](crate::linear::Row) regions, [`Column`](crate::linear::Column) regions, simple indexed
+//!   lists, or row-major [`Grid::regions`](crate::grid::Grid::regions) cells.
+//! - Use string names in examples, tests, diagnostics, and small prototypes where readable output
+//!   matters more than exhaustively modeling app state.
+//! - Use enums for most application controls. An enum makes routing explicit, gives the compiler a
+//!   closed set of cases, and avoids mixing unrelated ids that happen to have the same string or
+//!   number.
+//! - Use stable record keys when rows can be filtered, sorted, or moved but input should still
+//!   route to the same underlying application item.
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::regions::{Region, Regions};
+//!
+//! #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+//! enum Command {
+//!     Open,
+//!     Save,
+//! }
+//!
+//! let command_regions = Regions::from_regions(
+//!     Rect::new(0, 0, 20, 1),
+//!     [
+//!         Region::new(Command::Open, Rect::new(0, 0, 10, 1)),
+//!         Region::new(Command::Save, Rect::new(10, 0, 10, 1)),
+//!     ],
+//! );
+//!
+//! assert_eq!(command_regions.hit_test((12, 0)).unwrap().id, Command::Save);
+//! ```
+//!
+//! # First example
+//!
+//! A small use is to solve a row and render externally owned content into the assigned regions:
+//!
+//! ```rust
+//! use ratatui_core::buffer::Buffer;
+//! use ratatui_core::layout::{Constraint, Rect};
+//! use ratatui_core::text::Line;
+//! use ratatui_core::widgets::Widget;
+//! use ratatui_layout::linear::Row;
+//!
+//! let mut buffer = Buffer::empty(Rect::new(0, 0, 20, 1));
+//! let row_regions = Row::new([Constraint::Min(0), Constraint::Length(5)]).regions(buffer.area);
+//!
+//! Line::from("download").render(row_regions.regions()[0].area, &mut buffer);
+//! Line::from("done")
+//!     .right_aligned()
+//!     .render(row_regions.regions()[1].area, &mut buffer);
+//! ```
+//!
+//! For a runnable example that combines region sets, frame snapshots, focus, pointer routing,
+//! selection, cursor placement, containers, overlays, viewports, virtual lists, virtual tables, and
+//! ordinary Ratatui widgets, run:
+//!
+//! ```text
+//! cargo run -p ratatui-layout --example frame_snapshot
+//! ```
+//!
+//! # Reader paths
+//!
+//! - App authors: start with [`docs::frame_snapshots`], [`docs::interaction`], and
+//!   [`docs::virtualization`] when input routing or scrolling needs previous-frame data.
+//! - API reviewers: read the repository `ratatui-layout/use-cases/` catalog to check proposed
+//!   helpers against real app shapes before adding broader abstractions.
+//! - Widget authors: start with [`docs::regions`], [`docs::containers`], and
+//!   [`docs::widget_contracts`] when experimenting with app-owned children.
+//! - Maintainers: read [`docs::frame_snapshots`] and [`docs::widget_contracts`] for the split
+//!   between current API and future component/action direction, then use
+//!   [`docs::documentation_review`] when reviewing new docs.
+//!
+//! # Crate status
+//!
+//! This crate is intentionally separate from `ratatui-core` and `ratatui-widgets`. It is a proving
+//! ground for reusable coordination APIs. Existing Ratatui widgets continue to work normally; this
+//! crate gives widget authors and applications a place to experiment with visible layout state
+//! before any of these ideas become core Ratatui contracts.
+//!
+//! The APIs are interop-first. They also document design pressure around future widget contracts:
+//! measured participants, render outcomes, focus targets, cursor requests, and app-owned children
+//! can be represented explicitly without requiring a parent container to retain child widgets.
+
+#![warn(clippy::std_instead_of_core)]
+#![warn(clippy::std_instead_of_alloc)]
+#![warn(clippy::alloc_instead_of_core)]
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+/// Action surfaces for command rows, toolbars, tabs, and menus.
+pub mod action;
+/// Container geometry without retained child widgets.
+pub mod container;
+/// Cursor placement metadata.
+pub mod cursor;
+/// Documentation guide pages for the coordination model.
+pub mod docs;
+/// Focus targets and persistent focus state.
+pub mod focus;
+/// Aggregate frame-local UI data.
+pub mod frame;
+/// Grid regions and typed cell coordinates.
+pub mod grid;
+/// Rendering-agnostic input state helpers.
+pub mod input;
+/// Linear row and column regions.
+pub mod linear;
+/// Virtual list layout and external row rendering.
+pub mod list;
+/// Measurement types for externally owned content.
+pub mod measure;
+/// Modal-shell geometry and outside-click routing.
+pub mod modal;
+/// Overlay regions for overlapping UI.
+pub mod overlay;
+/// Scrollable pane coordination.
+pub mod pane;
+/// External layout participant traits and adapters.
+pub mod participant;
+/// Pointer target routing and pointer state.
+pub mod pointer;
+/// Durable-id adapter for virtual lists.
+pub mod record_list;
+/// Region, clipping, and hit-test types.
+pub mod regions;
+/// Scroll metrics.
+pub mod scroll;
+/// App-owned selection state.
+pub mod selection;
+/// Virtual table layout and rendering.
+pub mod table;
+/// Text-input coordination without choosing a text widget.
+pub mod text_input;
+/// Generic viewport layout.
+pub mod viewport;

--- a/crates/ratatui-layout/src/linear.rs
+++ b/crates/ratatui-layout/src/linear.rs
@@ -1,0 +1,852 @@
+//! Linear row and column regions.
+//!
+//! This module adapts Ratatui's existing [`Layout`] solver into inspectable
+//! [`Regions`](crate::regions::Regions) values. It does not replace [`Layout`]. Instead, it keeps
+//! the same constraint behavior and adds region identifiers, render-order metadata, and hit testing
+//! through the returned region set.
+//!
+//! If the solved rectangles are consumed immediately and never inspected again, use [`Layout`]
+//! directly. Use this module when the result needs to be passed around as data, hit tested, or
+//! associated with external ids.
+//! Ordinary `Layout::areas` remains the better tool for local render-only splits because it avoids
+//! introducing ids and stored regions where no later coordination is needed.
+//!
+//! # Types
+//!
+//! - [`RegionsExt`](crate::linear::RegionsExt) adds
+//!   [`RegionsExt::regions`](crate::linear::RegionsExt::regions) to Ratatui [`Layout`] for
+//!   incremental adoption.
+//! - [`Row`](crate::linear::Row) is a horizontal wrapper that can return indexed or named
+//!   left-to-right regions.
+//! - [`Column`](crate::linear::Column) is a vertical wrapper that can return indexed or named
+//!   top-to-bottom regions.
+//!
+//! See [`crate::docs::regions`] for the frame-local geometry model and
+//! [`crate::docs::containers`] for how rows and columns fit into larger container composition.
+//!
+//! [`Layout`]: ratatui_core::layout::Layout
+//! [`Regions`](crate::regions::Regions): crate::regions::Regions
+//!
+//! # Examples
+//!
+//! Pair ids with constraints when the split is page structure. This keeps the region name beside
+//! the sizing rule and avoids later numeric indexing:
+//!
+//! ```rust
+//! use ratatui_core::layout::{Constraint, Rect};
+//! use ratatui_layout::linear::{Column, Row};
+//!
+//! #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+//! enum PageSlot {
+//!     Header,
+//!     Body,
+//! }
+//!
+//! #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+//! enum BodySlot {
+//!     Sidebar,
+//!     Content,
+//! }
+//!
+//! let page_slots = [
+//!     (PageSlot::Header, Constraint::Length(1)),
+//!     (PageSlot::Body, Constraint::Fill(1)),
+//! ];
+//! let page = Column::named(page_slots).regions(Rect::new(0, 0, 20, 5));
+//!
+//! let body_slots = [
+//!     (BodySlot::Sidebar, Constraint::Length(6)),
+//!     (BodySlot::Content, Constraint::Fill(1)),
+//! ];
+//! let body_area = page.area_for(PageSlot::Body).unwrap();
+//! let body = Row::named(body_slots).regions(body_area);
+//!
+//! assert_eq!(body.hit_test((8, 1)).unwrap().id, BodySlot::Content);
+//! ```
+
+use alloc::vec::Vec;
+
+use ratatui_core::layout::{Constraint, Direction, Flex, Layout, Rect, Spacing};
+
+use crate::regions::{Region, Regions};
+
+/// Extension methods for producing inspectable region sets from Ratatui layouts.
+///
+/// This trait is the lowest-friction bridge from existing Ratatui code. Any [`Layout`] can still be
+/// used normally with `split` or `areas`; calling
+/// [`RegionsExt::regions`](crate::linear::RegionsExt::regions) returns the same solved rectangles
+/// wrapped in a [`Regions`](crate::regions::Regions) with `usize` region ids.
+///
+/// This is useful for incremental adoption: start with the layout you already have, then switch the
+/// call from `areas` or `split` to [`RegionsExt::regions`](crate::linear::RegionsExt::regions) only
+/// where the solved rectangles need hit testing or metadata.
+///
+/// # Method
+///
+/// - [`RegionsExt::regions`](crate::linear::RegionsExt::regions) solves a Ratatui [`Layout`] and
+///   wraps the rectangles in a [`Regions`](crate::regions::Regions) with region ids assigned by
+///   split order.
+///
+/// # Examples
+///
+/// Convert an existing layout call site into a region set without changing its constraints:
+///
+/// ```rust
+/// use ratatui_core::layout::{Constraint, Layout, Rect};
+/// use ratatui_layout::linear::RegionsExt;
+///
+/// let layout = Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]);
+/// let regions = layout.regions(Rect::new(0, 0, 20, 5));
+///
+/// assert_eq!(regions.regions()[0].area.height, 1);
+/// assert_eq!(regions.regions()[1].id, 1);
+/// ```
+pub trait RegionsExt {
+    /// Splits an area and returns the result as a [`Regions`](crate::regions::Regions).
+    ///
+    /// Region ids are assigned by split order starting at zero.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Layout, Rect};
+    /// use ratatui_layout::linear::RegionsExt;
+    ///
+    /// let layout = Layout::horizontal([Constraint::Length(4), Constraint::Fill(1)]);
+    /// let plan = layout.regions(Rect::new(0, 0, 10, 1));
+    ///
+    /// assert_eq!(plan.regions()[0].area.width, 4);
+    /// assert_eq!(plan.regions()[1].id, 1);
+    /// ```
+    fn regions(&self, area: Rect) -> Regions;
+}
+
+impl RegionsExt for Layout {
+    fn regions(&self, area: Rect) -> Regions {
+        let regions: Vec<_> = self
+            .split(area)
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(id, area)| Region::new(id, area))
+            .collect();
+        Regions::from_regions(area, regions)
+    }
+}
+
+/// Horizontal region builder that produces [`Regions`](crate::regions::Regions) values.
+///
+/// Use [`Row`](crate::linear::Row) when a horizontal split needs to become inspectable regions. A
+/// common case is a row with left content and a right status label: normal [`Layout`] can split the
+/// row, while [`Row`](crate::linear::Row) returns those split rectangles as regions that can be
+/// rendered, tested, or hit-tested.
+///
+/// `Row` is a small convenience wrapper around a horizontal Ratatui [`Layout`]. It is useful when
+/// code wants to speak in terms of row regions instead of generic direction-based layout.
+///
+/// # Constructors and setters
+///
+/// - [`Row::new`](crate::linear::Row::new) creates horizontal regions from Ratatui constraints and
+///   assigns `usize` ids.
+/// - [`Row::named`](crate::linear::Row::named) creates horizontal regions from `(id, constraint)`
+///   pairs.
+/// - [`Row::margin`](crate::linear::Row::margin),
+///   [`Row::horizontal_margin`](crate::linear::Row::horizontal_margin), and
+///   [`Row::vertical_margin`](crate::linear::Row::vertical_margin) delegate to the wrapped
+///   [`Layout`] margin behavior.
+/// - [`Row::flex`](crate::linear::Row::flex) delegates excess-space placement to Ratatui's solver.
+/// - [`Row::spacing`](crate::linear::Row::spacing) delegates fixed spacing or overlap between
+///   cells.
+///
+/// # Inspection and solving
+///
+/// - [`Row::layout`](crate::linear::Row::layout) returns the wrapped Ratatui [`Layout`] for APIs
+///   not mirrored here.
+/// - [`Row::regions`](crate::linear::Row::regions) solves the row and returns a
+///   [`Regions`](crate::regions::Regions) with left-to-right ids.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::{Constraint, Rect};
+/// use ratatui_layout::linear::Row;
+///
+/// let row = Row::new([Constraint::Length(8), Constraint::Fill(1)]).spacing(1);
+/// let regions = row.regions(Rect::new(0, 0, 20, 1));
+///
+/// assert_eq!(regions.hit_test((2, 0)).unwrap().id, 0);
+/// assert_eq!(regions.hit_test((12, 0)).unwrap().id, 1);
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Row<Id = usize> {
+    layout: Layout,
+    ids: Vec<Id>,
+}
+
+impl Row {
+    /// Creates a row from horizontal constraints.
+    ///
+    /// The constraints use the same semantics as [`ratatui_core::layout::Layout::horizontal`].
+    ///
+    /// # Examples
+    ///
+    /// Split a status row into app-owned left and right regions:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// let plan = Row::new([Constraint::Fill(1), Constraint::Length(6)])
+    ///     .spacing(1)
+    ///     .regions(Rect::new(0, 0, 20, 1));
+    ///
+    /// assert_eq!(plan.regions()[1].id, 1);
+    /// assert_eq!(plan.regions()[1].area.width, 6);
+    /// ```
+    pub fn new<I>(constraints: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<Constraint>,
+    {
+        let constraints = constraints.into_iter().map(Into::into).collect::<Vec<_>>();
+        let ids = (0..constraints.len()).collect();
+        Self {
+            layout: Layout::new(Direction::Horizontal, constraints),
+            ids,
+        }
+    }
+}
+
+impl<Id> Row<Id> {
+    /// Creates a row from `(id, constraint)` pairs.
+    ///
+    /// Use this for structural layouts where each region already has a meaning at the point where
+    /// its constraint is declared. Pairing the id with the constraint keeps the layout
+    /// vocabulary local and avoids fragile numeric indexing such as `regions()[1]`.
+    ///
+    /// For repeated generated regions, [`Row::new`](crate::linear::Row::new) is still a good fit
+    /// because numeric ids often line up naturally with item indexes.
+    ///
+    /// # Examples
+    ///
+    /// Name page body regions at the same time their widths are declared:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum BodySlot {
+    ///     Sidebar,
+    ///     Content,
+    /// }
+    ///
+    /// let body_slots = [
+    ///     (BodySlot::Sidebar, Constraint::Length(20)),
+    ///     (BodySlot::Content, Constraint::Fill(1)),
+    /// ];
+    /// let body = Row::named(body_slots)
+    ///     .spacing(1)
+    ///     .regions(Rect::new(0, 0, 50, 1));
+    ///
+    /// assert_eq!(body.area_for(BodySlot::Content).unwrap().x, 21);
+    /// ```
+    pub fn named<I, C>(regions: I) -> Self
+    where
+        I: IntoIterator<Item = (Id, C)>,
+        C: Into<Constraint>,
+    {
+        let (ids, constraints): (Vec<_>, Vec<_>) = regions
+            .into_iter()
+            .map(|(id, constraint)| (id, constraint.into()))
+            .unzip();
+        Self {
+            layout: Layout::new(Direction::Horizontal, constraints),
+            ids,
+        }
+    }
+
+    /// Returns the inner Ratatui layout.
+    ///
+    /// Use this when a caller needs access to existing `Layout` configuration or methods that are
+    /// not mirrored by `Row`.
+    ///
+    /// # Examples
+    ///
+    /// Inspect the wrapped layout when interoperating with existing Ratatui code:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// let row = Row::new([Constraint::Length(4), Constraint::Fill(1)]);
+    /// let areas = row.layout().split(Rect::new(0, 0, 10, 1));
+    ///
+    /// assert_eq!(areas[0].width, 4);
+    /// ```
+    pub const fn layout(&self) -> &Layout {
+        &self.layout
+    }
+
+    /// Sets the row margin on all edges before solving constraints.
+    ///
+    /// # Examples
+    ///
+    /// Keep planned regions away from the border area of a one-line toolbar:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// let plan = Row::new([Constraint::Fill(1)])
+    ///     .margin(1)
+    ///     .regions(Rect::new(0, 0, 10, 3));
+    ///
+    /// assert_eq!(plan.regions()[0].area, Rect::new(1, 1, 8, 1));
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn margin(mut self, margin: u16) -> Self {
+        self.layout = self.layout.margin(margin);
+        self
+    }
+
+    /// Sets the row horizontal margin before solving constraints.
+    ///
+    /// # Examples
+    ///
+    /// Inset row items horizontally while preserving the full row height:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// let plan = Row::new([Constraint::Fill(1)])
+    ///     .horizontal_margin(2)
+    ///     .regions(Rect::new(0, 0, 12, 2));
+    ///
+    /// assert_eq!(plan.regions()[0].area, Rect::new(2, 0, 8, 2));
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn horizontal_margin(mut self, horizontal: u16) -> Self {
+        self.layout = self.layout.horizontal_margin(horizontal);
+        self
+    }
+
+    /// Sets the row vertical margin before solving constraints.
+    ///
+    /// # Examples
+    ///
+    /// Reserve top and bottom space for surrounding chrome:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// let plan = Row::new([Constraint::Fill(1)])
+    ///     .vertical_margin(1)
+    ///     .regions(Rect::new(0, 0, 12, 3));
+    ///
+    /// assert_eq!(plan.regions()[0].area, Rect::new(0, 1, 12, 1));
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn vertical_margin(mut self, vertical: u16) -> Self {
+        self.layout = self.layout.vertical_margin(vertical);
+        self
+    }
+
+    /// Sets how excess horizontal space is distributed.
+    ///
+    /// # Examples
+    ///
+    /// Center fixed-width command regions in the available row:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Flex, Rect};
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// let plan = Row::new([Constraint::Length(4), Constraint::Length(4)])
+    ///     .flex(Flex::Center)
+    ///     .regions(Rect::new(0, 0, 12, 1));
+    ///
+    /// assert_eq!(plan.regions()[0].area.x, 2);
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn flex(mut self, flex: Flex) -> Self {
+        self.layout = self.layout.flex(flex);
+        self
+    }
+
+    /// Sets spacing or overlap between row items.
+    ///
+    /// # Examples
+    ///
+    /// Separate adjacent toolbar commands with one cell of spacing:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// let plan = Row::new([Constraint::Length(4), Constraint::Length(4)])
+    ///     .spacing(1)
+    ///     .regions(Rect::new(0, 0, 10, 1));
+    ///
+    /// assert_eq!(plan.regions()[1].area.x, 5);
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn spacing<T>(mut self, spacing: T) -> Self
+    where
+        T: Into<Spacing>,
+    {
+        self.layout = self.layout.spacing(spacing);
+        self
+    }
+
+    /// Solves the row into regions.
+    ///
+    /// The returned regions use ids in left-to-right order.
+    ///
+    /// # Examples
+    ///
+    /// Store the solved row for later hit testing:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Row;
+    ///
+    /// let previous_frame =
+    ///     Row::new([Constraint::Length(6), Constraint::Length(6)]).regions(Rect::new(0, 0, 12, 1));
+    ///
+    /// assert_eq!(previous_frame.hit_test((8, 0)).unwrap().id, 1);
+    /// ```
+    pub fn regions(&self, area: Rect) -> Regions<Id>
+    where
+        Id: Clone,
+    {
+        let regions = self
+            .layout
+            .split(area)
+            .iter()
+            .copied()
+            .zip(self.ids.iter().cloned())
+            .map(|(area, id)| Region::new(id, area))
+            .collect::<Vec<_>>();
+        Regions::from_regions(area, regions)
+    }
+}
+
+/// Vertical region builder that produces [`Regions`](crate::regions::Regions) values.
+///
+/// Use [`Column`](crate::linear::Column) when a vertical stack of app-owned items needs stable
+/// region ids. For ordinary page structure,
+/// [`Layout::vertical`](ratatui_core::layout::Layout::vertical) followed by `areas(area)` is
+/// simpler. [`Column`](crate::linear::Column) is useful when each visible row is handed to an
+/// external participant or later hit tested.
+///
+/// `Column` is the vertical counterpart to [`Row`](crate::linear::Row). It assigns region ids from
+/// top to bottom.
+///
+/// # Constructors and setters
+///
+/// - [`Column::new`](crate::linear::Column::new) creates vertical regions from Ratatui constraints
+///   and assigns `usize` ids.
+/// - [`Column::named`](crate::linear::Column::named) creates vertical regions from `(id,
+///   constraint)` pairs.
+/// - [`Column::margin`](crate::linear::Column::margin),
+///   [`Column::horizontal_margin`](crate::linear::Column::horizontal_margin), and
+///   [`Column::vertical_margin`](crate::linear::Column::vertical_margin) delegate to the wrapped
+///   [`Layout`] margin behavior.
+/// - [`Column::flex`](crate::linear::Column::flex) delegates excess-space placement to Ratatui's
+///   solver.
+/// - [`Column::spacing`](crate::linear::Column::spacing) delegates fixed spacing or overlap between
+///   cells.
+///
+/// # Inspection and solving
+///
+/// - [`Column::layout`](crate::linear::Column::layout) returns the wrapped Ratatui [`Layout`].
+/// - [`Column::regions`](crate::linear::Column::regions) solves the column and returns a
+///   [`Regions`](crate::regions::Regions) with top-to-bottom ids.
+///
+/// # Examples
+///
+/// Plan a named vertical stack and pass the body region to a nested row:
+///
+/// ```rust
+/// use ratatui_core::layout::{Constraint, Rect};
+/// use ratatui_layout::linear::{Column, Row};
+///
+/// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// enum PageSlot {
+///     Header,
+///     Body,
+///     Footer,
+/// }
+///
+/// let page_slots = [
+///     (PageSlot::Header, Constraint::Length(1)),
+///     (PageSlot::Body, Constraint::Fill(1)),
+///     (PageSlot::Footer, Constraint::Length(1)),
+/// ];
+/// let column = Column::named(page_slots);
+/// let page = column.regions(Rect::new(0, 0, 30, 10));
+/// let body_area = page.area_for(PageSlot::Body).unwrap();
+/// let body_row = Row::new([Constraint::Length(10), Constraint::Fill(1)]).regions(body_area);
+///
+/// assert_eq!(body_row.regions()[0].area.width, 10);
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Column<Id = usize> {
+    layout: Layout,
+    ids: Vec<Id>,
+}
+
+impl Column {
+    /// Creates a column from vertical constraints.
+    ///
+    /// The constraints use the same semantics as [`ratatui_core::layout::Layout::vertical`].
+    ///
+    /// # Examples
+    ///
+    /// Split a panel into header, body, and footer regions:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Column;
+    ///
+    /// let rows = [
+    ///     Constraint::Length(1),
+    ///     Constraint::Fill(1),
+    ///     Constraint::Length(1),
+    /// ];
+    /// let plan = Column::new(rows).regions(Rect::new(0, 0, 20, 5));
+    ///
+    /// assert_eq!(plan.regions()[1].area, Rect::new(0, 1, 20, 3));
+    /// ```
+    pub fn new<I>(constraints: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<Constraint>,
+    {
+        let constraints = constraints.into_iter().map(Into::into).collect::<Vec<_>>();
+        let ids = (0..constraints.len()).collect();
+        Self {
+            layout: Layout::new(Direction::Vertical, constraints),
+            ids,
+        }
+    }
+}
+
+impl<Id> Column<Id> {
+    /// Creates a column from `(id, constraint)` pairs.
+    ///
+    /// Use this for page structure, dialogs, and other vertical layouts where each row has a stable
+    /// role. The id travels with the constraint, so later code can ask for
+    /// [`Regions::area_for`](crate::regions::Regions::area_for) by enum value instead of relying on
+    /// numeric region positions.
+    ///
+    /// Keep using [`Column::new`](crate::linear::Column::new) for repeated generated rows where an
+    /// index is already the natural identity.
+    ///
+    /// # Examples
+    ///
+    /// Name page rows at the same time their heights are declared:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Column;
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum PageSlot {
+    ///     Header,
+    ///     Body,
+    ///     Footer,
+    /// }
+    ///
+    /// let page_slots = [
+    ///     (PageSlot::Header, Constraint::Length(1)),
+    ///     (PageSlot::Body, Constraint::Fill(1)),
+    ///     (PageSlot::Footer, Constraint::Length(1)),
+    /// ];
+    /// let page = Column::named(page_slots).regions(Rect::new(0, 0, 20, 5));
+    ///
+    /// assert_eq!(
+    ///     page.area_for(PageSlot::Body).unwrap(),
+    ///     Rect::new(0, 1, 20, 3)
+    /// );
+    /// ```
+    pub fn named<I, C>(regions: I) -> Self
+    where
+        I: IntoIterator<Item = (Id, C)>,
+        C: Into<Constraint>,
+    {
+        let (ids, constraints): (Vec<_>, Vec<_>) = regions
+            .into_iter()
+            .map(|(id, constraint)| (id, constraint.into()))
+            .unzip();
+        Self {
+            layout: Layout::new(Direction::Vertical, constraints),
+            ids,
+        }
+    }
+
+    /// Returns the inner Ratatui layout.
+    ///
+    /// Use this when code needs Ratatui's full [`Layout`] API while still using
+    /// [`Column`](crate::linear::Column) in the places that need
+    /// [`Regions`](crate::regions::Regions) output.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Column;
+    ///
+    /// let column = Column::new([Constraint::Length(1), Constraint::Fill(1)]);
+    /// let areas = column.layout().split(Rect::new(0, 0, 10, 4));
+    ///
+    /// assert_eq!(areas[0].height, 1);
+    /// ```
+    pub const fn layout(&self) -> &Layout {
+        &self.layout
+    }
+
+    /// Sets the column margin on all edges before solving constraints.
+    ///
+    /// # Examples
+    ///
+    /// Inset a vertical stack inside surrounding chrome:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Column;
+    ///
+    /// let plan = Column::new([Constraint::Fill(1)])
+    ///     .margin(1)
+    ///     .regions(Rect::new(0, 0, 10, 5));
+    ///
+    /// assert_eq!(plan.regions()[0].area, Rect::new(1, 1, 8, 3));
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn margin(mut self, margin: u16) -> Self {
+        self.layout = self.layout.margin(margin);
+        self
+    }
+
+    /// Sets the column horizontal margin before solving constraints.
+    ///
+    /// # Examples
+    ///
+    /// Keep rows aligned with content while using the full vertical area:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Column;
+    ///
+    /// let plan = Column::new([Constraint::Fill(1)])
+    ///     .horizontal_margin(2)
+    ///     .regions(Rect::new(0, 0, 12, 4));
+    ///
+    /// assert_eq!(plan.regions()[0].area, Rect::new(2, 0, 8, 4));
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn horizontal_margin(mut self, horizontal: u16) -> Self {
+        self.layout = self.layout.horizontal_margin(horizontal);
+        self
+    }
+
+    /// Sets the column vertical margin before solving constraints.
+    ///
+    /// # Examples
+    ///
+    /// Reserve top and bottom space while planning the middle stack:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Column;
+    ///
+    /// let plan = Column::new([Constraint::Fill(1)])
+    ///     .vertical_margin(1)
+    ///     .regions(Rect::new(0, 0, 12, 5));
+    ///
+    /// assert_eq!(plan.regions()[0].area, Rect::new(0, 1, 12, 3));
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn vertical_margin(mut self, vertical: u16) -> Self {
+        self.layout = self.layout.vertical_margin(vertical);
+        self
+    }
+
+    /// Sets how excess vertical space is distributed.
+    ///
+    /// # Examples
+    ///
+    /// Center fixed-height rows in a taller available area:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Flex, Rect};
+    /// use ratatui_layout::linear::Column;
+    ///
+    /// let plan = Column::new([Constraint::Length(1), Constraint::Length(1)])
+    ///     .flex(Flex::Center)
+    ///     .regions(Rect::new(0, 0, 10, 4));
+    ///
+    /// assert_eq!(plan.regions()[0].area.y, 1);
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn flex(mut self, flex: Flex) -> Self {
+        self.layout = self.layout.flex(flex);
+        self
+    }
+
+    /// Sets spacing or overlap between column items.
+    ///
+    /// # Examples
+    ///
+    /// Separate stacked form fields with one blank row:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Column;
+    ///
+    /// let plan = Column::new([Constraint::Length(1), Constraint::Length(1)])
+    ///     .spacing(1)
+    ///     .regions(Rect::new(0, 0, 10, 3));
+    ///
+    /// assert_eq!(plan.regions()[1].area.y, 2);
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn spacing<T>(mut self, spacing: T) -> Self
+    where
+        T: Into<Spacing>,
+    {
+        self.layout = self.layout.spacing(spacing);
+        self
+    }
+
+    /// Solves the column into regions.
+    ///
+    /// The returned regions use ids in top-to-bottom order.
+    ///
+    /// # Examples
+    ///
+    /// Store vertical menu regions so the next pointer event can hit-test a row:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Column;
+    ///
+    /// let previous_frame =
+    ///     Column::new([Constraint::Length(1), Constraint::Length(1)]).regions(Rect::new(0, 0, 10, 2));
+    ///
+    /// assert_eq!(previous_frame.hit_test((3, 1)).unwrap().id, 1);
+    /// ```
+    pub fn regions(&self, area: Rect) -> Regions<Id>
+    where
+        Id: Clone,
+    {
+        let regions = self
+            .layout
+            .split(area)
+            .iter()
+            .copied()
+            .zip(self.ids.iter().cloned())
+            .map(|(area, id)| Region::new(id, area))
+            .collect::<Vec<_>>();
+        Regions::from_regions(area, regions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use ratatui_core::layout::{Constraint, Rect};
+
+    use super::*;
+
+    #[test]
+    fn row_creates_indexed_regions() {
+        let plan =
+            Row::new([Constraint::Length(2), Constraint::Fill(1)]).regions(Rect::new(0, 0, 5, 1));
+
+        assert_eq!(plan.regions()[0].area, Rect::new(0, 0, 2, 1));
+        assert_eq!(plan.regions()[1].area, Rect::new(2, 0, 3, 1));
+    }
+
+    #[test]
+    fn row_creates_named_regions() {
+        #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+        enum SlotId {
+            Left,
+            Right,
+        }
+
+        let regions = [
+            (SlotId::Left, Constraint::Length(2)),
+            (SlotId::Right, Constraint::Fill(1)),
+        ];
+        let plan = Row::named(regions).regions(Rect::new(0, 0, 5, 1));
+
+        assert_eq!(plan.area_for(SlotId::Left), Some(Rect::new(0, 0, 2, 1)));
+        assert_eq!(plan.area_for(SlotId::Right), Some(Rect::new(2, 0, 3, 1)));
+    }
+
+    #[test]
+    fn row_builder_matches_equivalent_layout() {
+        let area = Rect::new(0, 0, 20, 3);
+        let constraints = [Constraint::Length(4), Constraint::Length(4)];
+        let plan = Row::new(constraints)
+            .margin(1)
+            .spacing(2)
+            .flex(Flex::Start)
+            .regions(area);
+        let expected = Layout::horizontal(constraints)
+            .margin(1)
+            .spacing(2)
+            .flex(Flex::Start)
+            .split(area);
+
+        assert_eq!(plan.regions()[0].area, expected[0]);
+        assert_eq!(plan.regions()[1].area, expected[1]);
+    }
+
+    #[test]
+    fn column_builder_matches_equivalent_layout() {
+        let area = Rect::new(0, 0, 10, 12);
+        let constraints = [Constraint::Length(2), Constraint::Length(3)];
+        let plan = Column::new(constraints)
+            .horizontal_margin(1)
+            .vertical_margin(2)
+            .spacing(1)
+            .flex(Flex::Center)
+            .regions(area);
+        let expected = Layout::vertical(constraints)
+            .horizontal_margin(1)
+            .vertical_margin(2)
+            .spacing(1)
+            .flex(Flex::Center)
+            .split(area);
+
+        assert_eq!(plan.regions()[0].area, expected[0]);
+        assert_eq!(plan.regions()[1].area, expected[1]);
+    }
+
+    #[test]
+    fn column_creates_named_regions() {
+        #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+        enum SlotId {
+            Header,
+            Body,
+            Footer,
+        }
+
+        let regions = [
+            (SlotId::Header, Constraint::Length(1)),
+            (SlotId::Body, Constraint::Fill(1)),
+            (SlotId::Footer, Constraint::Length(1)),
+        ];
+        let plan = Column::named(regions).regions(Rect::new(0, 0, 10, 5));
+
+        assert_eq!(plan.area_for(SlotId::Header), Some(Rect::new(0, 0, 10, 1)));
+        assert_eq!(plan.area_for(SlotId::Body), Some(Rect::new(0, 1, 10, 3)));
+        assert_eq!(plan.area_for(SlotId::Footer), Some(Rect::new(0, 4, 10, 1)));
+    }
+}

--- a/crates/ratatui-layout/src/list.rs
+++ b/crates/ratatui-layout/src/list.rs
@@ -1,0 +1,2173 @@
+//! Virtual list layout and external row rendering.
+//!
+//! [`VirtualList`](crate::list::VirtualList) is a vertical viewport over externally owned items. It
+//! does not store row widgets, row data, or row state. Instead, it asks a
+//! [`ListItems`](crate::list::ListItems) implementation how many items exist, how tall each item is
+//! at the final width, and how to render a visible item into an assigned
+//! [`Rect`](ratatui_core::layout::Rect).
+//!
+//! Use Ratatui's built-in list widget for ordinary text lists. `VirtualList` is for cases where the
+//! list behavior is the problem: large collections, variable-height rows, custom row rendering,
+//! externally owned row state, hit testing, or line-aware scrolling through multiline items.
+//!
+//! See [`crate::docs::virtualization`] for how virtual lists relate to viewports, virtual tables,
+//! visible rows, and scroll metrics.
+//!
+//! This design keeps application ownership visible:
+//!
+//! - the app owns the collection and any per-row state;
+//! - [`VirtualListState`](crate::list::VirtualListState) owns selection and scroll state between
+//!   frames;
+//! - [`VirtualList`](crate::list::VirtualList) owns the viewport policy for one layout or render
+//!   call;
+//! - [`ListLayout`](crate::list::ListLayout) exposes the computed visible rows, clipping, and
+//!   hit-test data.
+//!
+//! # Types and traits
+//!
+//! - [`ScrollPosition`](crate::list::ScrollPosition) stores an item index plus an in-item line
+//!   offset for line-aware scrolling.
+//! - [`VirtualListState`](crate::list::VirtualListState) stores persistent selection and scroll
+//!   state between frames.
+//! - [`ListItems`](crate::list::ListItems) is the trait for app-owned row data that can measure and
+//!   render visible rows.
+//! - [`ListItemsFn`](crate::list::ListItemsFn) adapts simple closures into
+//!   [`ListItems`](crate::list::ListItems) for tests, examples, and small apps.
+//! - [`ListItemContext`](crate::list::ListItemContext) is passed to row renderers with selection,
+//!   visible-index, and clipping metadata.
+//! - [`VisibleItem`](crate::list::VisibleItem) describes one row slice visible in the current
+//!   frame.
+//! - [`ListLayout`](crate::list::ListLayout) is the solved frame-local layout for visible rows, hit
+//!   testing, and scrollbars.
+//! - [`VirtualList`](crate::list::VirtualList) is the reusable list configuration that computes or
+//!   renders a [`ListLayout`](crate::list::ListLayout).
+//! - [`ListHeightCache`](crate::list::ListHeightCache) stores measured row heights when measurement
+//!   is expensive.
+//!
+//! # Measurement and rendering
+//!
+//! Measurement happens before rendering.
+//! [`ListItems::height_for_width`](crate::list::ListItems::height_for_width) receives the final
+//! list width and returns the full logical height of the item. The list then computes which item
+//! slices are visible and calls [`ListItems::render_item`](crate::list::ListItems::render_item)
+//! only for those items.
+//!
+//! Partially visible items are allowed. A renderer receives
+//! [`ListItemContext::y_offset`](crate::list::ListItemContext::y_offset) and clipping flags so it
+//! can decide whether to skip lines, draw a continuation marker, or render a simplified clipped
+//! representation.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use ratatui_core::buffer::Buffer;
+//! use ratatui_core::layout::Rect;
+//! use ratatui_core::text::Line;
+//! use ratatui_core::widgets::Widget;
+//! use ratatui_layout::list::{ListItemContext, ListItems, VirtualList, VirtualListState};
+//! use ratatui_layout::participant::MeasureContext;
+//!
+//! struct Rows(&'static [&'static str]);
+//!
+//! impl ListItems for Rows {
+//!     fn len(&self) -> usize {
+//!         self.0.len()
+//!     }
+//!
+//!     fn height_for_width(&self, index: usize, width: u16, _: MeasureContext) -> u16 {
+//!         let width = width.max(1) as usize;
+//!         self.0[index].len().div_ceil(width).max(1) as u16
+//!     }
+//!
+//!     fn render_item(
+//!         &mut self,
+//!         index: usize,
+//!         area: Rect,
+//!         buf: &mut Buffer,
+//!         ctx: ListItemContext,
+//!     ) {
+//!         let marker = if ctx.render.state.selected {
+//!             "> "
+//!         } else {
+//!             "  "
+//!         };
+//!         Line::from(format!("{marker}{}", self.0[index])).render(area, buf);
+//!     }
+//! }
+//!
+//! let mut rows = Rows(&["short", "a longer row"]);
+//! let mut state = VirtualListState::default();
+//! state.select(Some(1));
+//!
+//! let mut buffer = Buffer::empty(Rect::new(0, 0, 20, 2));
+//! let layout = VirtualList::new().render(buffer.area, &mut buffer, &mut state, &mut rows);
+//!
+//! assert_eq!(layout.selected.unwrap().index, 1);
+//! ```
+
+use alloc::vec::Vec;
+
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::{Position, Rect};
+
+use crate::participant::{MeasureContext, RenderContext, RenderState};
+use crate::regions::{Clip, Hit, Region, Regions};
+use crate::selection::VisibleSelection;
+
+/// Line-aware scroll position for a virtual list.
+///
+/// Use [`ScrollPosition`] when rows can be taller than one terminal line. An item-only offset can
+/// say "start at item 10", but it cannot say "start on the fourth line of item 10." That
+/// distinction matters for smooth scrolling, page scrolling, and selected rows that are taller than
+/// the viewport.
+///
+/// [`ScrollPosition`] identifies the first logical line shown in the viewport as an item index plus
+/// a line offset inside that item.
+///
+/// # Constructor
+///
+/// - [`ScrollPosition::new`] creates a desired item/line offset. [`VirtualList::layout`] clamps it
+///   against the current rows and measured heights.
+///
+/// # Examples
+///
+/// Keep smooth scrolling state beside the selected row:
+///
+/// ```rust
+/// use ratatui_layout::list::{ScrollPosition, VirtualListState};
+///
+/// let mut state = VirtualListState::default();
+/// state.select(Some(10));
+/// state.set_scroll(ScrollPosition::new(8, 2));
+///
+/// assert_eq!(state.selected(), Some(10));
+/// assert_eq!(
+///     state.scroll(),
+///     ScrollPosition {
+///         index: 8,
+///         y_offset: 2
+///     }
+/// );
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ScrollPosition {
+    /// The item index where the viewport starts.
+    pub index: usize,
+    /// The number of lines skipped from the top of `index`.
+    pub y_offset: u16,
+}
+
+impl ScrollPosition {
+    /// Creates a scroll position.
+    ///
+    /// The value is clamped during [`VirtualList::layout`] and [`VirtualList::render`].
+    /// Constructing a position with an out-of-bounds index or offset is allowed so applications
+    /// can restore stale state before the current item count is known.
+    ///
+    /// # Examples
+    ///
+    /// Restore a line-aware scroll position before the next layout clamps it:
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::{ScrollPosition, VirtualListState};
+    ///
+    /// let mut state = VirtualListState::default();
+    /// state.set_scroll(ScrollPosition::new(5, 2));
+    ///
+    /// assert_eq!(
+    ///     state.scroll(),
+    ///     ScrollPosition {
+    ///         index: 5,
+    ///         y_offset: 2
+    ///     }
+    /// );
+    /// ```
+    pub const fn new(index: usize, y_offset: u16) -> Self {
+        Self { index, y_offset }
+    }
+}
+
+/// State for [`VirtualList`].
+///
+/// Use [`VirtualListState`] as the persistent UI state for a [`VirtualList`]. Store it in the
+/// application next to the data being listed. The list will update it when selection or scroll
+/// positions need to be clamped to the current content.
+///
+/// The state stores only scroll and selection. It does not store item count, measured heights,
+/// visible rows, or child widget state. Those values are either owned by the application or exposed
+/// in the [`ListLayout`] returned by each layout pass.
+///
+/// # Selection
+///
+/// - [`VirtualListState::selected`] reads the selected source item index.
+/// - [`VirtualListState::select`] sets or clears the selected source item index and asks layout to
+///   reveal it.
+/// - [`VirtualListState::select_relative`] moves selection by a signed row delta and asks layout to
+///   reveal the new row.
+/// - [`VirtualListState::select_without_scrolling`] sets selection for styling or commands without
+///   moving the viewport back to it.
+/// - [`VirtualListState::scroll_to_selected`] asks the next layout to reveal the current selected
+///   item.
+/// - [`VirtualListState::scrolls_selected_into_view`] reports which selection policy the next
+///   layout pass will use.
+///
+/// # Scrolling
+///
+/// - [`VirtualListState::scroll`] reads the current line-aware scroll position.
+/// - [`VirtualListState::set_scroll`] stores a desired line-aware scroll position for the next
+///   layout pass to clamp.
+/// - [`VirtualListState::scroll_viewport_by`] moves the viewport by item indexes without changing
+///   selection.
+///
+/// # Examples
+///
+/// Store selection and scroll between frames while rebuilding the list layout as needed:
+///
+/// ```rust
+/// use ratatui_layout::list::{ScrollPosition, VirtualListState};
+///
+/// let mut state = VirtualListState::default();
+/// state.select(Some(3));
+/// state.set_scroll(ScrollPosition::new(2, 0));
+///
+/// assert_eq!(state.selected(), Some(3));
+/// assert_eq!(state.scroll().index, 2);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct VirtualListState {
+    selected: Option<usize>,
+    scroll: ScrollPosition,
+    #[cfg_attr(feature = "serde", serde(default))]
+    scroll_selected_into_view: bool,
+}
+
+impl VirtualListState {
+    /// Returns the selected item index.
+    ///
+    /// # Examples
+    ///
+    /// Read the selected source row after input updates list state:
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::VirtualListState;
+    ///
+    /// let mut state = VirtualListState::default();
+    /// state.select(Some(3));
+    ///
+    /// assert_eq!(state.selected(), Some(3));
+    /// ```
+    pub const fn selected(&self) -> Option<usize> {
+        self.selected
+    }
+
+    /// Returns whether layout should keep the selected item visible.
+    ///
+    /// This flag separates two common intents that otherwise look the same in state: keyboard
+    /// selection should usually move the viewport so the selected row can be seen, while
+    /// mouse-wheel scrolling should usually move the viewport without snapping back to the
+    /// selected row. Calling [`VirtualListState::select`] turns this on. Calling
+    /// [`VirtualListState::scroll_viewport_by`] turns it off.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::VirtualListState;
+    ///
+    /// let mut state = VirtualListState::default();
+    /// state.select(Some(4));
+    /// assert!(state.scrolls_selected_into_view());
+    ///
+    /// state.scroll_viewport_by(1);
+    /// assert!(!state.scrolls_selected_into_view());
+    /// ```
+    pub const fn scrolls_selected_into_view(&self) -> bool {
+        self.scroll_selected_into_view
+    }
+
+    /// Sets the selected item index.
+    ///
+    /// The selected index is clamped to the last available item during layout. Passing `None`
+    /// clears selection without changing scroll until the next layout pass decides whether the
+    /// scroll position also needs clamping.
+    ///
+    /// Selecting an item also asks the next layout pass to keep that item visible. Use
+    /// [`VirtualListState::select_without_scrolling`] when a caller wants selected styling for a
+    /// row that may or may not currently be in the viewport.
+    ///
+    /// # Examples
+    ///
+    /// Select a source row before rendering so the row renderer receives selected state:
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::VirtualListState;
+    ///
+    /// let mut state = VirtualListState::default();
+    /// state.select(Some(1));
+    ///
+    /// assert_eq!(state.selected(), Some(1));
+    /// ```
+    pub const fn select(&mut self, selected: Option<usize>) {
+        self.selected = selected;
+        self.scroll_selected_into_view = selected.is_some();
+    }
+
+    /// Moves selection by a signed row delta.
+    ///
+    /// Use this for keyboard row movement in source-index lists. The caller passes the current item
+    /// count because the list state intentionally does not own the app's collection. Empty lists
+    /// clear selection. If nothing is selected yet, the first movement selects the first item. When
+    /// a row is already selected, movement is clamped to the first and last item and the next
+    /// layout pass will reveal the selected row.
+    ///
+    /// This changes selection. Use [`VirtualListState::scroll_viewport_by`] for mouse-wheel or page
+    /// scrolling that should move the viewport without changing the selected row.
+    ///
+    /// # Examples
+    ///
+    /// Move selected rows without hand-writing index clamping in the app:
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::VirtualListState;
+    ///
+    /// let mut state = VirtualListState::default();
+    ///
+    /// assert_eq!(state.select_relative(1, 3), Some(0));
+    /// assert_eq!(state.select_relative(1, 3), Some(1));
+    /// assert_eq!(state.select_relative(99, 3), Some(2));
+    /// assert_eq!(state.select_relative(-99, 3), Some(0));
+    /// ```
+    pub const fn select_relative(&mut self, delta: isize, item_count: usize) -> Option<usize> {
+        if item_count == 0 {
+            self.select(None);
+            return None;
+        }
+
+        let index = match self.selected {
+            Some(selected) => {
+                let index = offset_index(selected, delta);
+                if index >= item_count {
+                    item_count - 1
+                } else {
+                    index
+                }
+            }
+            None => 0,
+        };
+        self.select(Some(index));
+        Some(index)
+    }
+
+    /// Sets selection without asking layout to move the viewport.
+    ///
+    /// Use this when selection is stable app state but the current input changed only the viewport.
+    /// For example, a mouse wheel over a list should usually scroll rows while leaving the selected
+    /// record unchanged. If that record is still visible, row renderers will still receive selected
+    /// state; if it is off-screen, the viewport is left alone.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::VirtualListState;
+    ///
+    /// let mut state = VirtualListState::default();
+    /// state.select_without_scrolling(Some(8));
+    ///
+    /// assert_eq!(state.selected(), Some(8));
+    /// assert!(!state.scrolls_selected_into_view());
+    /// ```
+    pub const fn select_without_scrolling(&mut self, selected: Option<usize>) {
+        self.selected = selected;
+        self.scroll_selected_into_view = false;
+    }
+
+    /// Asks the next layout pass to bring the current selection into view.
+    ///
+    /// This is useful when selection is restored from app state with
+    /// [`VirtualListState::select_without_scrolling`] and a later keyboard command should reveal
+    /// that selected row. The actual scroll offset still depends on the measured item heights and
+    /// is computed by [`VirtualList::layout`] or [`VirtualList::render`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::VirtualListState;
+    ///
+    /// let mut state = VirtualListState::default();
+    /// state.select_without_scrolling(Some(12));
+    /// state.scroll_to_selected();
+    ///
+    /// assert!(state.scrolls_selected_into_view());
+    /// ```
+    pub const fn scroll_to_selected(&mut self) {
+        self.scroll_selected_into_view = self.selected.is_some();
+    }
+
+    /// Returns the current scroll position.
+    ///
+    /// # Examples
+    ///
+    /// Read the clamped line-aware scroll position after layout:
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::{ScrollPosition, VirtualListState};
+    ///
+    /// let mut state = VirtualListState::default();
+    /// state.set_scroll(ScrollPosition::new(2, 1));
+    ///
+    /// assert_eq!(state.scroll().index, 2);
+    /// assert_eq!(state.scroll().y_offset, 1);
+    /// ```
+    pub const fn scroll(&self) -> ScrollPosition {
+        self.scroll
+    }
+
+    /// Sets the current scroll position.
+    ///
+    /// The position is clamped during layout. This lets applications apply input deltas before
+    /// measuring the current content.
+    ///
+    /// # Examples
+    ///
+    /// Apply a scroll command before the list knows current row heights:
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::{ScrollPosition, VirtualListState};
+    ///
+    /// let mut state = VirtualListState::default();
+    /// state.set_scroll(ScrollPosition::new(10, 0));
+    ///
+    /// assert_eq!(state.scroll(), ScrollPosition::new(10, 0));
+    /// ```
+    pub const fn set_scroll(&mut self, scroll: ScrollPosition) {
+        self.scroll = scroll;
+    }
+
+    /// Scrolls the viewport by item indexes without changing selection.
+    ///
+    /// This is the canonical mouse-wheel helper for fixed-height rows and simple tree/list
+    /// navigation. It updates the desired starting item and lets the next layout pass clamp the
+    /// value to the current item count. It also disables automatic selection reveal so wheel input
+    /// does not snap back to the selected row.
+    ///
+    /// For variable-height rows, this remains item-based rather than line-based. Call
+    /// [`VirtualListState::set_scroll`] with an explicit [`ScrollPosition`] when an app needs
+    /// smooth line-aware scrolling within a tall row.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::{ScrollPosition, VirtualListState};
+    ///
+    /// let mut state = VirtualListState::default();
+    /// state.select(Some(10));
+    /// state.set_scroll(ScrollPosition::new(3, 0));
+    /// state.scroll_viewport_by(2);
+    ///
+    /// assert_eq!(state.selected(), Some(10));
+    /// assert_eq!(state.scroll(), ScrollPosition::new(5, 0));
+    /// assert!(!state.scrolls_selected_into_view());
+    /// ```
+    pub const fn scroll_viewport_by(&mut self, delta: isize) {
+        let index = offset_index(self.scroll.index, delta);
+        self.scroll = ScrollPosition::new(index, 0);
+        self.scroll_selected_into_view = false;
+    }
+}
+
+/// Externally owned items rendered by a [`VirtualList`].
+///
+/// Implement this trait for the application object or a small adapter that can look up rows by
+/// index. The list calls [`ListItems::height_for_width`] for measurement and
+/// [`ListItems::render_item`] for visible rows only.
+///
+/// Returning zero height is treated as one line. This prevents invisible items from causing
+/// non-terminating viewport calculations.
+///
+/// # Required methods
+///
+/// - [`ListItems::len`] returns the current source item count.
+/// - [`ListItems::height_for_width`] measures one source item at the final list width.
+/// - [`ListItems::render_item`] renders one visible item slice into its assigned rectangle.
+///
+/// # Provided methods
+///
+/// - [`ListItems::is_empty`] derives empty-state behavior from [`ListItems::len`].
+///
+/// # Examples
+///
+/// Implement the trait on app-owned data so [`VirtualList`] can measure and render only visible
+/// rows:
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::Rect;
+/// use ratatui_core::text::Line;
+/// use ratatui_core::widgets::Widget;
+/// use ratatui_layout::list::{ListItemContext, ListItems};
+/// use ratatui_layout::participant::MeasureContext;
+///
+/// struct Rows(&'static [&'static str]);
+///
+/// impl ListItems for Rows {
+///     fn len(&self) -> usize {
+///         self.0.len()
+///     }
+///
+///     fn height_for_width(&self, index: usize, width: u16, _: MeasureContext) -> u16 {
+///         self.0[index].len().div_ceil(width.max(1) as usize).max(1) as u16
+///     }
+///
+///     fn render_item(&mut self, index: usize, area: Rect, buf: &mut Buffer, _: ListItemContext) {
+///         Line::from(self.0[index]).render(area, buf);
+///     }
+/// }
+/// ```
+pub trait ListItems {
+    /// Returns the number of items.
+    ///
+    /// The list may call this before measurement and rendering in each frame.
+    ///
+    /// # Examples
+    ///
+    /// Back a virtual list with app-owned row data:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListItemContext, ListItems};
+    /// use ratatui_layout::participant::MeasureContext;
+    ///
+    /// struct Rows(&'static [&'static str]);
+    ///
+    /// impl ListItems for Rows {
+    ///     fn len(&self) -> usize {
+    ///         self.0.len()
+    ///     }
+    ///     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+    ///         1
+    ///     }
+    ///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+    /// }
+    ///
+    /// assert_eq!(Rows(&["a", "b"]).len(), 2);
+    /// ```
+    fn len(&self) -> usize;
+
+    /// Returns true when there are no items.
+    ///
+    /// # Examples
+    ///
+    /// Use the provided empty check before deciding whether to render an empty state:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListItemContext, ListItems};
+    /// use ratatui_layout::participant::MeasureContext;
+    ///
+    /// struct Rows;
+    ///
+    /// impl ListItems for Rows {
+    ///     fn len(&self) -> usize {
+    ///         0
+    ///     }
+    ///     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+    ///         1
+    ///     }
+    ///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+    /// }
+    ///
+    /// assert!(Rows.is_empty());
+    /// ```
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the item height for the final width.
+    ///
+    /// The returned height is the full logical height, not just the visible height. It should be
+    /// stable for the same item and width during a single layout pass.
+    ///
+    /// # Examples
+    ///
+    /// Measure wrapped text rows from the final list width:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListItemContext, ListItems};
+    /// use ratatui_layout::participant::MeasureContext;
+    ///
+    /// struct Rows(&'static [&'static str]);
+    ///
+    /// impl ListItems for Rows {
+    ///     fn len(&self) -> usize {
+    ///         self.0.len()
+    ///     }
+    ///     fn height_for_width(&self, index: usize, width: u16, _: MeasureContext) -> u16 {
+    ///         self.0[index].len().div_ceil(width.max(1) as usize).max(1) as u16
+    ///     }
+    ///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+    /// }
+    ///
+    /// assert_eq!(Rows(&["abcdef"]).height_for_width(0, 3, MeasureContext), 2);
+    /// ```
+    fn height_for_width(&self, index: usize, width: u16, ctx: MeasureContext) -> u16;
+
+    /// Renders an item into the assigned area.
+    ///
+    /// The area may be shorter than the full measured item height when the item is partially
+    /// clipped. Use [`ListItemContext::y_offset`] and the clipping flags to decide which logical
+    /// lines to draw.
+    ///
+    /// # Examples
+    ///
+    /// Render only rows that [`VirtualList::render`] reports as visible:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_core::text::Line;
+    /// use ratatui_core::widgets::Widget;
+    /// use ratatui_layout::list::{ListItemContext, ListItems};
+    /// use ratatui_layout::participant::MeasureContext;
+    ///
+    /// struct Rows(&'static [&'static str]);
+    ///
+    /// impl ListItems for Rows {
+    ///     fn len(&self) -> usize {
+    ///         self.0.len()
+    ///     }
+    ///     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+    ///         1
+    ///     }
+    ///     fn render_item(
+    ///         &mut self,
+    ///         index: usize,
+    ///         area: Rect,
+    ///         buf: &mut Buffer,
+    ///         ctx: ListItemContext,
+    ///     ) {
+    ///         let marker = if ctx.render.state.selected {
+    ///             "> "
+    ///         } else {
+    ///             "  "
+    ///         };
+    ///         Line::from(format!("{marker}{}", self.0[index])).render(area, buf);
+    ///     }
+    /// }
+    /// ```
+    fn render_item(&mut self, index: usize, area: Rect, buf: &mut Buffer, ctx: ListItemContext);
+}
+
+/// Closure adapter for [`ListItems`].
+///
+/// Use [`ListItemsFn`] when a list is backed by simple local closures instead of a reusable row
+/// source type. It is useful in examples, tests, and small applications where a named adapter would
+/// obscure the relationship between the data, measurement, and rendering.
+///
+/// Larger apps should usually implement [`ListItems`] directly so the ownership and measurement
+/// contracts are documented near the data.
+///
+/// # Constructor
+///
+/// - [`ListItemsFn::new`] stores len, height, and render closures behind the [`ListItems`] trait.
+///
+/// # Examples
+///
+/// Build a local row source without naming a new adapter type:
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::list::{ListItems, ListItemsFn, VirtualList, VirtualListState};
+/// use ratatui_layout::participant::MeasureContext;
+///
+/// let rows = ["open", "save", "close"];
+/// let mut items = ListItemsFn::new(
+///     || rows.len(),
+///     |index: usize, width: u16, _: MeasureContext| {
+///         rows[index].len().div_ceil(width.max(1) as usize) as u16
+///     },
+///     |_, _: Rect, _: &mut Buffer, _| {},
+/// );
+///
+/// let mut state = VirtualListState::default();
+/// let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 2));
+/// let layout = VirtualList::new().render(buffer.area, &mut buffer, &mut state, &mut items);
+///
+/// assert_eq!(layout.visible_items.len(), 2);
+/// ```
+#[derive(Debug, Clone)]
+pub struct ListItemsFn<L, H, R> {
+    len: L,
+    height: H,
+    render: R,
+}
+
+impl<L, H, R> ListItemsFn<L, H, R> {
+    /// Creates list items from len, height, and render closures.
+    ///
+    /// # Examples
+    ///
+    /// Adapt local closures into [`ListItems`] for a small list:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListItems, ListItemsFn};
+    /// use ratatui_layout::participant::MeasureContext;
+    ///
+    /// let rows = ["open", "save"];
+    /// let items = ListItemsFn::new(
+    ///     || rows.len(),
+    ///     |_, _, _: MeasureContext| 1,
+    ///     |_, _: Rect, _: &mut Buffer, _| {},
+    /// );
+    ///
+    /// assert_eq!(items.len(), 2);
+    /// ```
+    pub const fn new(len: L, height: H, render: R) -> Self {
+        Self {
+            len,
+            height,
+            render,
+        }
+    }
+}
+
+impl<L, H, R> ListItems for ListItemsFn<L, H, R>
+where
+    L: Fn() -> usize,
+    H: Fn(usize, u16, MeasureContext) -> u16,
+    R: FnMut(usize, Rect, &mut Buffer, ListItemContext),
+{
+    fn len(&self) -> usize {
+        (self.len)()
+    }
+
+    fn height_for_width(&self, index: usize, width: u16, ctx: MeasureContext) -> u16 {
+        (self.height)(index, width, ctx)
+    }
+
+    fn render_item(&mut self, index: usize, area: Rect, buf: &mut Buffer, ctx: ListItemContext) {
+        (self.render)(index, area, buf, ctx);
+    }
+}
+
+/// Render context for a visible list item.
+///
+/// Use `ListItemContext` inside [`ListItems::render_item`] to decide how a row should look in its
+/// assigned area. It tells the row whether it is selected, which visible row it is, and whether it
+/// was clipped by the viewport.
+///
+/// [`ListItemContext`] combines common [`RenderContext`](crate::participant::RenderContext) state
+/// with list-specific metadata. It is passed only to visible items during rendering.
+///
+/// # Fields
+///
+/// - [`ListItemContext::render`] carries shared interaction flags such as selection.
+/// - [`ListItemContext::index`] is the source item index being rendered.
+/// - [`ListItemContext::visible_index`] is the item position among visible rows.
+/// - [`ListItemContext::y_offset`] tells how many logical lines were clipped from the top.
+/// - [`ListItemContext::clipped_top`] and [`ListItemContext::clipped_bottom`] describe whether the
+///   assigned area is a partial slice of a taller item.
+///
+/// # Examples
+///
+/// Use context fields together to render selected and clipped rows differently:
+///
+/// ```rust
+/// use ratatui_layout::list::ListItemContext;
+/// use ratatui_layout::participant::RenderContext;
+///
+/// let context = ListItemContext {
+///     render: RenderContext::selected(true),
+///     index: 4,
+///     visible_index: 0,
+///     y_offset: 2,
+///     clipped_top: true,
+///     clipped_bottom: false,
+/// };
+///
+/// let marker = if context.render.state.selected {
+///     "> "
+/// } else {
+///     "  "
+/// };
+/// assert_eq!(marker, "> ");
+/// assert!(context.clipped_top);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ListItemContext {
+    /// Common render context.
+    ///
+    /// Selection is set when this item is the state's selected index.
+    pub render: RenderContext,
+    /// The item index in the source list.
+    pub index: usize,
+    /// The item index among visible items.
+    pub visible_index: usize,
+    /// Lines skipped from the top of the item.
+    ///
+    /// A non-zero value means the item begins above the viewport and the renderer is receiving
+    /// only the visible tail of the item.
+    pub y_offset: u16,
+    /// Whether the top of the item is clipped.
+    pub clipped_top: bool,
+    /// Whether the bottom of the item is clipped.
+    pub clipped_bottom: bool,
+}
+
+/// Metadata for a visible list item.
+///
+/// Use [`VisibleItem`] when code outside the row renderer needs to inspect what the list did. A
+/// pointer handler can map a click to a visible item. A debug line can show visible indexes. A
+/// custom scrollbar can compare visible rows with total content height.
+///
+/// [`VisibleItem`] is returned in [`ListLayout::visible_items`]. It is the list's public render
+/// layout output: each value says which source item is visible, where it should be rendered, how
+/// tall the full item is, and whether the assigned area is clipped.
+///
+/// # Fields
+///
+/// - [`VisibleItem::index`] is the source item id for rendering and hit testing.
+/// - [`VisibleItem::area`] is the terminal-space visible rectangle.
+/// - [`VisibleItem::full_height`] is the measured logical item height.
+/// - [`VisibleItem::y_offset`] is the number of hidden logical lines above [`VisibleItem::area`].
+/// - [`VisibleItem::clipped_top`] and [`VisibleItem::clipped_bottom`] tell whether the item
+///   continues beyond the viewport.
+///
+/// # Examples
+///
+/// Combine visible item metadata with hit testing to recover the logical row line:
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::list::{ListLayout, ScrollPosition, VisibleItem};
+///
+/// let item = VisibleItem {
+///     index: 10,
+///     area: Rect::new(0, 0, 20, 2),
+///     full_height: 4,
+///     y_offset: 1,
+///     clipped_top: true,
+///     clipped_bottom: true,
+/// };
+/// let layout = ListLayout {
+///     viewport: Rect::new(0, 0, 20, 2),
+///     item_count: 20,
+///     content_height: 40,
+///     scroll_offset: 21,
+///     scroll: ScrollPosition::new(10, 1),
+///     visible_items: vec![item],
+///     selected: Some(item),
+/// };
+///
+/// let hit = layout.hit_test((3, 1)).unwrap();
+/// let logical_y = item.y_offset + hit.relative_y;
+/// assert_eq!((hit.id, logical_y), (10, 2));
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct VisibleItem {
+    /// The item index in the source list.
+    pub index: usize,
+    /// The visible area assigned to this item.
+    pub area: Rect,
+    /// The full measured item height.
+    pub full_height: u16,
+    /// Lines skipped from the top of the item.
+    pub y_offset: u16,
+    /// Whether the top of the item is clipped.
+    pub clipped_top: bool,
+    /// Whether the bottom of the item is clipped.
+    pub clipped_bottom: bool,
+}
+
+impl VisibleItem {
+    fn context(self, visible_index: usize, selected: bool) -> ListItemContext {
+        ListItemContext {
+            render: RenderContext {
+                state: RenderState {
+                    selected,
+                    ..RenderState::default()
+                },
+            },
+            index: self.index,
+            visible_index,
+            y_offset: self.y_offset,
+            clipped_top: self.clipped_top,
+            clipped_bottom: self.clipped_bottom,
+        }
+    }
+}
+
+/// Solved virtual-list layout.
+///
+/// Use [`ListLayout`] when list rendering needs to be observable. The high-level
+/// [`VirtualList::render`] method still returns this value so callers can render normally and then
+/// use the same frame's layout for hit testing, diagnostics, scrollbars, or status text.
+///
+/// [`ListLayout`] is returned from both [`VirtualList::layout`] and [`VirtualList::render`]. Keep
+/// it around for the current frame when routing pointer input or displaying scroll diagnostics.
+///
+/// # Fields and methods
+///
+/// - [`ListLayout::viewport`] is the terminal area assigned to the list.
+/// - [`ListLayout::item_count`] is the source collection length.
+/// - [`ListLayout::content_height`] is the total measured height in logical lines.
+/// - [`ListLayout::scroll_offset`] is the clamped offset in logical content lines.
+/// - [`ListLayout::scroll`] is the clamped [`ScrollPosition`].
+/// - [`ListLayout::visible_items`] is the ordered list of visible row slices.
+/// - [`ListLayout::selected`] is the selected row when it is visible.
+/// - [`ListLayout::visible_indices`] returns only the visible source row indexes.
+/// - [`ListLayout::row_regions`] converts visible rows into a generic
+///   [`Regions`](crate::regions::Regions).
+/// - [`ListLayout::hit_test`] maps a terminal position to the visible source item index.
+/// - [`ListLayout::hit_index`] returns only the source item index for common click handling.
+/// - [`ListLayout::select_hit`] selects a durable id through
+///   [`VisibleSelection`](crate::selection::VisibleSelection) after a click.
+///
+/// # Examples
+///
+/// Keep the layout returned by rendering so the next pointer event can route to a source row:
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::list::{ListItemContext, ListItems, VirtualList, VirtualListState};
+/// use ratatui_layout::participant::MeasureContext;
+///
+/// struct Rows;
+/// impl ListItems for Rows {
+///     fn len(&self) -> usize {
+///         5
+///     }
+///     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+///         1
+///     }
+///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+/// }
+///
+/// let mut rows = Rows;
+/// let mut state = VirtualListState::default();
+/// let mut buffer = Buffer::empty(Rect::new(0, 0, 12, 3));
+/// let layout = VirtualList::new().render(buffer.area, &mut buffer, &mut state, &mut rows);
+///
+/// assert_eq!(layout.hit_test((1, 2)).unwrap().id, 2);
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ListLayout {
+    /// The list viewport.
+    pub viewport: Rect,
+    /// Total item count.
+    pub item_count: usize,
+    /// Total content height in lines.
+    pub content_height: u32,
+    /// Clamped scroll offset in logical content lines.
+    pub scroll_offset: u32,
+    /// Clamped scroll position.
+    pub scroll: ScrollPosition,
+    /// Visible item metadata.
+    pub visible_items: Vec<VisibleItem>,
+    /// Selected item if it is visible.
+    pub selected: Option<VisibleItem>,
+}
+
+impl ListLayout {
+    /// Returns source item indexes visible in this layout.
+    ///
+    /// Use this when keyboard traversal or selection needs the same visible order that rendering
+    /// used, without exposing callers to row rectangles and clipping metadata. For repeated rows,
+    /// the index is the frame-local id that maps back into the app-owned collection.
+    ///
+    /// # Examples
+    ///
+    /// Move selection over only the rows visible in the current list layout:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListLayout, ScrollPosition, VisibleItem};
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let layout = ListLayout {
+    ///     viewport: Rect::new(0, 0, 10, 2),
+    ///     item_count: 3,
+    ///     content_height: 3,
+    ///     scroll_offset: 1,
+    ///     scroll: ScrollPosition::new(1, 0),
+    ///     visible_items: vec![
+    ///         VisibleItem {
+    ///             index: 1,
+    ///             area: Rect::new(0, 0, 10, 1),
+    ///             full_height: 1,
+    ///             y_offset: 0,
+    ///             clipped_top: false,
+    ///             clipped_bottom: false,
+    ///         },
+    ///         VisibleItem {
+    ///             index: 2,
+    ///             area: Rect::new(0, 1, 10, 1),
+    ///             full_height: 1,
+    ///             y_offset: 0,
+    ///             clipped_top: false,
+    ///             clipped_bottom: false,
+    ///         },
+    ///     ],
+    ///     selected: None,
+    /// };
+    /// let visible = layout.visible_indices().collect::<Vec<_>>();
+    /// let mut selection = SelectionState::new(SelectionMode::Single);
+    /// selection.select_next(&visible);
+    ///
+    /// assert_eq!(selection.primary(), Some(1));
+    /// ```
+    pub fn visible_indices(&self) -> impl Iterator<Item = usize> + '_ {
+        self.visible_items.iter().map(|item| item.index)
+    }
+
+    /// Converts visible rows into a generic region set keyed by source item index.
+    ///
+    /// Use this when a virtual list needs to participate in APIs that understand
+    /// [`Regions`](crate::regions::Regions) rather than [`ListLayout`]. The list layout remains the
+    /// richer source of truth for scroll offsets, measured heights, and clipped row slices; the
+    /// returned [`Regions`](crate::regions::Regions) value is the geometry projection used for
+    /// generic composition, pointer routing, or diagnostics.
+    ///
+    /// Clipping metadata is preserved in each [`Region`](crate::regions::Region). A row that starts
+    /// above the viewport gets a top clip equal to [`VisibleItem::y_offset`], and a row that
+    /// continues below the viewport gets a bottom clip for the hidden tail.
+    ///
+    /// Use [`ListLayout::rows_regions`] when app code needs stable record ids instead of source
+    /// item indexes.
+    ///
+    /// # Examples
+    ///
+    /// Merge visible list rows into a larger frame snapshot:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListLayout, ScrollPosition, VisibleItem};
+    ///
+    /// let layout = ListLayout {
+    ///     viewport: Rect::new(0, 0, 10, 2),
+    ///     item_count: 3,
+    ///     content_height: 3,
+    ///     scroll_offset: 0,
+    ///     scroll: ScrollPosition::default(),
+    ///     visible_items: vec![
+    ///         VisibleItem {
+    ///             index: 0,
+    ///             area: Rect::new(0, 0, 10, 1),
+    ///             full_height: 1,
+    ///             y_offset: 0,
+    ///             clipped_top: false,
+    ///             clipped_bottom: false,
+    ///         },
+    ///         VisibleItem {
+    ///             index: 1,
+    ///             area: Rect::new(0, 1, 10, 1),
+    ///             full_height: 1,
+    ///             y_offset: 0,
+    ///             clipped_top: false,
+    ///             clipped_bottom: false,
+    ///         },
+    ///     ],
+    ///     selected: None,
+    /// };
+    /// let plan = layout.row_regions();
+    ///
+    /// assert_eq!(plan.hit_test((1, 1)).unwrap().id, 1);
+    /// ```
+    pub fn row_regions(&self) -> Regions<usize> {
+        self.rows_regions(core::convert::identity)
+    }
+
+    /// Converts visible rows into a generic region set with caller-chosen row ids.
+    ///
+    /// Use this when a virtual list renders source indexes but the rest of the app routes input
+    /// through semantic ids. For example, a filtered task list can map each source index to a
+    /// `TaskId`, then merge the resulting regions into a
+    /// [`FrameSnapshot`](crate::frame::FrameSnapshot) or
+    /// [`PointerTargets`](crate::pointer::PointerTargets). This keeps row measurement in
+    /// [`ListLayout`] while letting outer coordination code speak in application terms.
+    ///
+    /// The mapper receives the source index from [`VisibleItem::index`]. If an app has filtered or
+    /// sorted rows, the mapper should use the same row order as the [`ListItems`] implementation
+    /// passed to [`VirtualList::layout`] or [`VirtualList::render`].
+    ///
+    /// # Examples
+    ///
+    /// Project source indexes into durable record ids:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListLayout, ScrollPosition, VisibleItem};
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum TaskId {
+    ///     Api,
+    ///     Docs,
+    /// }
+    ///
+    /// let ids = [TaskId::Api, TaskId::Docs];
+    /// let layout = ListLayout {
+    ///     viewport: Rect::new(0, 0, 10, 2),
+    ///     item_count: ids.len(),
+    ///     content_height: 2,
+    ///     scroll_offset: 0,
+    ///     scroll: ScrollPosition::default(),
+    ///     visible_items: vec![
+    ///         VisibleItem {
+    ///             index: 0,
+    ///             area: Rect::new(0, 0, 10, 1),
+    ///             full_height: 1,
+    ///             y_offset: 0,
+    ///             clipped_top: false,
+    ///             clipped_bottom: false,
+    ///         },
+    ///         VisibleItem {
+    ///             index: 1,
+    ///             area: Rect::new(0, 1, 10, 1),
+    ///             full_height: 1,
+    ///             y_offset: 0,
+    ///             clipped_top: false,
+    ///             clipped_bottom: false,
+    ///         },
+    ///     ],
+    ///     selected: None,
+    /// };
+    /// let plan = layout.rows_regions(|index| ids[index]);
+    ///
+    /// assert_eq!(plan.hit_test((1, 1)).unwrap().id, TaskId::Docs);
+    /// ```
+    pub fn rows_regions<Id>(&self, mut id_for: impl FnMut(usize) -> Id) -> Regions<Id> {
+        let regions: Vec<_> = self
+            .visible_items
+            .iter()
+            .map(|item| item.region(id_for(item.index)))
+            .collect();
+        Regions::from_regions(self.viewport, regions)
+    }
+
+    /// Returns the visible item hit by the position.
+    ///
+    /// The returned id is the source item index. Coordinates are relative to the visible area, not
+    /// to the full logical item. If the item is clipped at the top, add the corresponding
+    /// [`VisibleItem::y_offset`] if the row renderer needs a logical line coordinate.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListLayout, ScrollPosition, VisibleItem};
+    ///
+    /// let layout = ListLayout {
+    ///     viewport: Rect::new(0, 0, 10, 2),
+    ///     item_count: 1,
+    ///     content_height: 2,
+    ///     scroll_offset: 0,
+    ///     scroll: ScrollPosition::default(),
+    ///     visible_items: vec![VisibleItem {
+    ///         index: 7,
+    ///         area: Rect::new(0, 0, 10, 2),
+    ///         full_height: 2,
+    ///         y_offset: 0,
+    ///         clipped_top: false,
+    ///         clipped_bottom: false,
+    ///     }],
+    ///     selected: None,
+    /// };
+    ///
+    /// assert_eq!(layout.hit_test((2, 1)).unwrap().id, 7);
+    /// ```
+    pub fn hit_test<P: Into<Position>>(&self, position: P) -> Option<Hit<usize>> {
+        let position = position.into();
+        self.visible_items
+            .iter()
+            .rev()
+            .find(|item| item.area.contains(position))
+            .map(|item| Hit {
+                id: item.index,
+                area: item.area,
+                relative_x: position.x.saturating_sub(item.area.x),
+                relative_y: position.y.saturating_sub(item.area.y),
+            })
+    }
+
+    /// Returns the source item index hit by the position.
+    ///
+    /// This is the common click path when an app only needs to know which row was clicked. Use
+    /// [`ListLayout::hit_test`] when the row also needs local pointer coordinates, for example to
+    /// distinguish a disclosure icon from the rest of a tree row.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListLayout, ScrollPosition, VisibleItem};
+    ///
+    /// let layout = ListLayout {
+    ///     viewport: Rect::new(0, 0, 10, 1),
+    ///     item_count: 1,
+    ///     content_height: 1,
+    ///     scroll_offset: 0,
+    ///     scroll: ScrollPosition::default(),
+    ///     visible_items: vec![VisibleItem {
+    ///         index: 3,
+    ///         area: Rect::new(0, 0, 10, 1),
+    ///         full_height: 1,
+    ///         y_offset: 0,
+    ///         clipped_top: false,
+    ///         clipped_bottom: false,
+    ///     }],
+    ///     selected: None,
+    /// };
+    ///
+    /// assert_eq!(layout.hit_index((4, 0)), Some(3));
+    /// ```
+    pub fn hit_index<P: Into<Position>>(&self, position: P) -> Option<usize> {
+        self.hit_test(position).map(|hit| hit.id)
+    }
+
+    /// Selects the durable id for the row hit by the position.
+    ///
+    /// Use this in filtered or sorted lists where commands should target a stable record id, while
+    /// row rendering still uses the source index required by [`VirtualList`]. The `ids` slice must
+    /// be indexed the same way as the [`ListItems`] implementation used for the layout. Invalid
+    /// positions, blank space, or stale indexes leave `selection` unchanged and return `None`.
+    ///
+    /// Use [`ListLayout::hit_index`] when selection is only an index, or [`ListLayout::hit_test`]
+    /// when a row needs local coordinates.
+    ///
+    /// # Examples
+    ///
+    /// Click a filtered row and keep the selected task id:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListLayout, ScrollPosition, VisibleItem};
+    /// use ratatui_layout::selection::VisibleSelection;
+    ///
+    /// let ids = ["api", "docs"];
+    /// let layout = ListLayout {
+    ///     viewport: Rect::new(0, 0, 10, 2),
+    ///     item_count: ids.len(),
+    ///     content_height: 2,
+    ///     scroll_offset: 0,
+    ///     scroll: ScrollPosition::default(),
+    ///     visible_items: vec![
+    ///         VisibleItem {
+    ///             index: 0,
+    ///             area: Rect::new(0, 0, 10, 1),
+    ///             full_height: 1,
+    ///             y_offset: 0,
+    ///             clipped_top: false,
+    ///             clipped_bottom: false,
+    ///         },
+    ///         VisibleItem {
+    ///             index: 1,
+    ///             area: Rect::new(0, 1, 10, 1),
+    ///             full_height: 1,
+    ///             y_offset: 0,
+    ///             clipped_top: false,
+    ///             clipped_bottom: false,
+    ///         },
+    ///     ],
+    ///     selected: None,
+    /// };
+    /// let mut selection = VisibleSelection::new();
+    ///
+    /// assert_eq!(layout.select_hit((2, 1), &mut selection, &ids), Some(1));
+    /// assert_eq!(selection.selected_id(), Some("docs"));
+    /// ```
+    pub fn select_hit<Id: Copy + Eq, P: Into<Position>>(
+        &self,
+        position: P,
+        selection: &mut VisibleSelection<Id>,
+        ids: &[Id],
+    ) -> Option<usize> {
+        let index = self.hit_index(position)?;
+        selection.select_index(index, ids)
+    }
+}
+
+impl VisibleItem {
+    const fn region<Id>(self, id: Id) -> Region<Id> {
+        Region::new(id, self.area).clip(self.clip())
+    }
+
+    const fn clip(self) -> Clip {
+        Clip {
+            left: 0,
+            top: if self.clipped_top { self.y_offset } else { 0 },
+            right: 0,
+            bottom: if self.clipped_bottom {
+                self.full_height
+                    .saturating_sub(self.y_offset.saturating_add(self.area.height))
+            } else {
+                0
+            },
+        }
+    }
+}
+
+/// A vertical virtual list that asks external items to measure and render.
+///
+/// Use [`VirtualList`] when the built-in text list is the wrong ownership shape: rows are generated
+/// lazily, rows have custom renderers, row state belongs to the application, or row height depends
+/// on the final width. The list owns viewport policy; the application owns the rows.
+///
+/// [`VirtualList`] is a configuration value. It can be rebuilt each frame, like other Ratatui
+/// widgets. Persistent selection and scroll live in [`VirtualListState`].
+///
+/// # Constructors and setters
+///
+/// - [`VirtualList::new`] creates default list configuration.
+/// - [`VirtualList::scroll_padding`] asks layout to keep space around the selected item when
+///   possible.
+///
+/// # Layout and rendering
+///
+/// - [`VirtualList::layout`] computes [`ListLayout`] without drawing.
+/// - [`VirtualList::layout_cached`] computes [`ListLayout`] with explicit height caching.
+/// - [`VirtualList::render`] computes layout, renders visible rows, and returns the layout.
+/// - [`VirtualList::render_cached`] renders with explicit height caching.
+///
+/// # Examples
+///
+/// Render visible rows, keep the returned layout, and use it to route a later click:
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::list::{ListItemContext, ListItems, VirtualList, VirtualListState};
+/// use ratatui_layout::participant::MeasureContext;
+///
+/// struct Rows;
+/// impl ListItems for Rows {
+///     fn len(&self) -> usize {
+///         4
+///     }
+///     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+///         1
+///     }
+///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+/// }
+///
+/// let mut rows = Rows;
+/// let mut state = VirtualListState::default();
+/// let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 2));
+/// let layout = VirtualList::new().render(buffer.area, &mut buffer, &mut state, &mut rows);
+///
+/// assert_eq!(layout.visible_items.len(), 2);
+/// assert_eq!(layout.hit_test((0, 1)).unwrap().id, 1);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct VirtualList {
+    scroll_padding: u16,
+}
+
+impl VirtualList {
+    /// Creates a virtual list.
+    ///
+    /// # Examples
+    ///
+    /// Compute visible rows without rendering when the app wants custom drawing or hit testing:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListItemContext, ListItems, VirtualList, VirtualListState};
+    /// use ratatui_layout::participant::MeasureContext;
+    ///
+    /// struct Rows;
+    /// impl ListItems for Rows {
+    ///     fn len(&self) -> usize {
+    ///         3
+    ///     }
+    ///     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+    ///         1
+    ///     }
+    ///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+    /// }
+    ///
+    /// let mut state = VirtualListState::default();
+    /// let layout = VirtualList::new().layout(Rect::new(0, 0, 10, 2), &mut state, &Rows);
+    ///
+    /// assert_eq!(layout.visible_items.len(), 2);
+    /// ```
+    pub const fn new() -> Self {
+        Self { scroll_padding: 0 }
+    }
+
+    /// Sets scroll padding in lines.
+    ///
+    /// Scroll padding asks the layout to keep this many lines visible before and after the selected
+    /// item when possible. Padding is reduced naturally when the viewport is too small or the
+    /// selected item is too tall.
+    ///
+    /// # Examples
+    ///
+    /// Keep context around the selected row when scrolling a long list:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListItemContext, ListItems, VirtualList, VirtualListState};
+    /// use ratatui_layout::participant::MeasureContext;
+    ///
+    /// struct Rows;
+    /// impl ListItems for Rows {
+    ///     fn len(&self) -> usize {
+    ///         10
+    ///     }
+    ///     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+    ///         1
+    ///     }
+    ///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+    /// }
+    ///
+    /// let mut state = VirtualListState::default();
+    /// state.select(Some(8));
+    /// VirtualList::new()
+    ///     .scroll_padding(1)
+    ///     .layout(Rect::new(0, 0, 10, 3), &mut state, &Rows);
+    ///
+    /// assert_eq!(state.scroll().index, 7);
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub const fn scroll_padding(mut self, scroll_padding: u16) -> Self {
+        self.scroll_padding = scroll_padding;
+        self
+    }
+
+    /// Computes the list layout and updates state with clamped scroll and selection values.
+    ///
+    /// This method does not render. Use it when the caller wants to inspect the visible rows, route
+    /// input, build a scrollbar, or perform custom rendering with the returned [`ListLayout`].
+    ///
+    /// The method may mutate `state` by clamping selection and scroll to the current item count and
+    /// measured heights. If the list is empty or the area is empty, selection is cleared and scroll
+    /// is reset.
+    ///
+    /// # Examples
+    ///
+    /// Compute a layout for hit testing and scrollbar metrics without drawing rows:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{ListItemContext, ListItems, VirtualList, VirtualListState};
+    /// use ratatui_layout::participant::MeasureContext;
+    ///
+    /// struct Rows;
+    /// impl ListItems for Rows {
+    ///     fn len(&self) -> usize {
+    ///         4
+    ///     }
+    ///     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+    ///         1
+    ///     }
+    ///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+    /// }
+    ///
+    /// let mut state = VirtualListState::default();
+    /// let layout = VirtualList::new().layout(Rect::new(0, 0, 10, 2), &mut state, &Rows);
+    ///
+    /// assert_eq!(layout.hit_test((1, 1)).unwrap().id, 1);
+    /// ```
+    pub fn layout<I: ListItems>(
+        self,
+        area: Rect,
+        state: &mut VirtualListState,
+        items: &I,
+    ) -> ListLayout {
+        let item_count = items.len();
+        let heights = measure_heights(items, item_count, area.width);
+        self.layout_with_heights(area, state, item_count, &heights)
+    }
+
+    /// Computes the list layout using a measurement cache.
+    ///
+    /// Use this when item heights are expensive to compute and the list is rebuilt each frame with
+    /// the same width and item count. The cache is explicit application state so invalidation stays
+    /// visible.
+    ///
+    /// # Examples
+    ///
+    /// Reuse measured heights across frames while keeping invalidation in app state:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{
+    ///     ListHeightCache, ListItemContext, ListItems, VirtualList, VirtualListState,
+    /// };
+    /// use ratatui_layout::participant::MeasureContext;
+    ///
+    /// struct Rows;
+    /// impl ListItems for Rows {
+    ///     fn len(&self) -> usize {
+    ///         3
+    ///     }
+    ///     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+    ///         2
+    ///     }
+    ///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+    /// }
+    ///
+    /// let mut state = VirtualListState::default();
+    /// let mut cache = ListHeightCache::new();
+    /// let layout =
+    ///     VirtualList::new().layout_cached(Rect::new(0, 0, 10, 3), &mut state, &Rows, &mut cache);
+    ///
+    /// assert_eq!(layout.content_height, 6);
+    /// ```
+    pub fn layout_cached<I: ListItems>(
+        self,
+        area: Rect,
+        state: &mut VirtualListState,
+        items: &I,
+        cache: &mut ListHeightCache,
+    ) -> ListLayout {
+        let item_count = items.len();
+        let heights = cache.heights_for(items, item_count, area.width);
+        self.layout_with_heights(area, state, item_count, heights)
+    }
+
+    fn layout_with_heights(
+        self,
+        area: Rect,
+        state: &mut VirtualListState,
+        item_count: usize,
+        heights: &[u16],
+    ) -> ListLayout {
+        if area.is_empty() || item_count == 0 {
+            state.select(None);
+            state.set_scroll(ScrollPosition::default());
+            return ListLayout {
+                viewport: area,
+                item_count,
+                content_height: 0,
+                scroll_offset: 0,
+                scroll: state.scroll(),
+                visible_items: Vec::new(),
+                selected: None,
+            };
+        }
+
+        if let Some(selected) = state.selected
+            && selected >= item_count
+        {
+            state.selected = Some(item_count - 1);
+        }
+
+        let content_height = heights.iter().map(|height| u32::from(*height)).sum();
+        state.scroll = clamp_scroll(state.scroll, heights);
+        if let Some(selected) = state.selected
+            && state.scroll_selected_into_view
+        {
+            state.scroll = scroll_to_selected(
+                state.scroll,
+                selected,
+                heights,
+                area.height,
+                self.scroll_padding,
+            );
+        }
+
+        let visible_items = visible_items(area, state.scroll, heights);
+        let selected = state.selected.and_then(|selected| {
+            visible_items
+                .iter()
+                .find(|item| item.index == selected)
+                .copied()
+        });
+
+        ListLayout {
+            viewport: area,
+            item_count,
+            content_height,
+            scroll_offset: item_top(state.scroll.index, heights) + u32::from(state.scroll.y_offset),
+            scroll: state.scroll,
+            visible_items,
+            selected,
+        }
+    }
+
+    /// Computes and renders the list.
+    ///
+    /// This is the high-level convenience method. It computes a [`ListLayout`], calls
+    /// [`ListItems::render_item`] for each visible item, and returns the layout so the caller can
+    /// still inspect what happened during the frame.
+    ///
+    /// # Examples
+    ///
+    /// Render visible rows and keep the layout for the next input event:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_core::text::Line;
+    /// use ratatui_core::widgets::Widget;
+    /// use ratatui_layout::list::{ListItemContext, ListItems, VirtualList, VirtualListState};
+    /// use ratatui_layout::participant::MeasureContext;
+    ///
+    /// struct Rows(&'static [&'static str]);
+    /// impl ListItems for Rows {
+    ///     fn len(&self) -> usize {
+    ///         self.0.len()
+    ///     }
+    ///     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+    ///         1
+    ///     }
+    ///     fn render_item(&mut self, index: usize, area: Rect, buf: &mut Buffer, _: ListItemContext) {
+    ///         Line::from(self.0[index]).render(area, buf);
+    ///     }
+    /// }
+    ///
+    /// let mut rows = Rows(&["open", "save"]);
+    /// let mut state = VirtualListState::default();
+    /// let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 2));
+    /// let layout = VirtualList::new().render(buffer.area, &mut buffer, &mut state, &mut rows);
+    ///
+    /// assert_eq!(layout.visible_items.len(), 2);
+    /// ```
+    pub fn render<I: ListItems>(
+        self,
+        area: Rect,
+        buf: &mut Buffer,
+        state: &mut VirtualListState,
+        items: &mut I,
+    ) -> ListLayout {
+        let layout = self.layout(area, state, items);
+        render_visible_items(&layout, state, items, buf);
+        layout
+    }
+
+    /// Computes and renders the list using a measurement cache.
+    ///
+    /// # Examples
+    ///
+    /// Render a variable-height list while reusing row measurements:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{
+    ///     ListHeightCache, ListItemContext, ListItems, VirtualList, VirtualListState,
+    /// };
+    /// use ratatui_layout::participant::MeasureContext;
+    ///
+    /// struct Rows;
+    /// impl ListItems for Rows {
+    ///     fn len(&self) -> usize {
+    ///         2
+    ///     }
+    ///     fn height_for_width(&self, index: usize, _: u16, _: MeasureContext) -> u16 {
+    ///         (index + 1) as u16
+    ///     }
+    ///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+    /// }
+    ///
+    /// let mut rows = Rows;
+    /// let mut state = VirtualListState::default();
+    /// let mut cache = ListHeightCache::new();
+    /// let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 3));
+    /// let layout = VirtualList::new().render_cached(
+    ///     buffer.area,
+    ///     &mut buffer,
+    ///     &mut state,
+    ///     &mut rows,
+    ///     &mut cache,
+    /// );
+    ///
+    /// assert_eq!(layout.content_height, 3);
+    /// ```
+    pub fn render_cached<I: ListItems>(
+        self,
+        area: Rect,
+        buf: &mut Buffer,
+        state: &mut VirtualListState,
+        items: &mut I,
+        cache: &mut ListHeightCache,
+    ) -> ListLayout {
+        let layout = self.layout_cached(area, state, items, cache);
+        render_visible_items(&layout, state, items, buf);
+        layout
+    }
+}
+
+fn render_visible_items<I: ListItems>(
+    layout: &ListLayout,
+    state: &VirtualListState,
+    items: &mut I,
+    buf: &mut Buffer,
+) {
+    for (visible_index, item) in layout.visible_items.iter().copied().enumerate() {
+        let selected = state.selected == Some(item.index);
+        items.render_item(
+            item.index,
+            item.area,
+            buf,
+            item.context(visible_index, selected),
+        );
+    }
+}
+
+/// Explicit height cache for [`VirtualList`].
+///
+/// Use `ListHeightCache` when measuring row height is non-trivial. The cache is keyed by final
+/// width and item count; apps can invalidate all heights or selected ranges when row content
+/// changes.
+///
+/// # Constructors and invalidation
+///
+/// - [`ListHeightCache::new`] creates an empty cache.
+/// - [`ListHeightCache::clear`] drops all measured heights.
+/// - [`ListHeightCache::invalidate`] marks one item dirty.
+/// - [`ListHeightCache::invalidate_range`] marks a range of items dirty.
+///
+/// # Examples
+///
+/// Keep the cache beside list state, then invalidate affected rows when app data changes:
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::list::{
+///     ListHeightCache, ListItemContext, ListItems, VirtualList, VirtualListState,
+/// };
+/// use ratatui_layout::participant::MeasureContext;
+///
+/// struct Rows;
+/// impl ListItems for Rows {
+///     fn len(&self) -> usize {
+///         3
+///     }
+///     fn height_for_width(&self, index: usize, _: u16, _: MeasureContext) -> u16 {
+///         index as u16 + 1
+///     }
+///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+/// }
+///
+/// let mut state = VirtualListState::default();
+/// let mut cache = ListHeightCache::new();
+/// let layout =
+///     VirtualList::new().layout_cached(Rect::new(0, 0, 10, 4), &mut state, &Rows, &mut cache);
+/// cache.invalidate(1);
+///
+/// assert_eq!(layout.content_height, 6);
+/// ```
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ListHeightCache {
+    width: Option<u16>,
+    item_count: usize,
+    heights: Vec<u16>,
+    dirty: Vec<bool>,
+}
+
+impl ListHeightCache {
+    /// Creates an empty height cache.
+    ///
+    /// # Examples
+    ///
+    /// Store the cache beside list state when row measurement is expensive:
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::ListHeightCache;
+    ///
+    /// let cache = ListHeightCache::new();
+    ///
+    /// assert_eq!(cache, ListHeightCache::default());
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            width: None,
+            item_count: 0,
+            heights: Vec::new(),
+            dirty: Vec::new(),
+        }
+    }
+
+    /// Invalidates all cached heights.
+    ///
+    /// # Examples
+    ///
+    /// Clear all cached heights when a global display setting changes:
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::ListHeightCache;
+    ///
+    /// let mut cache = ListHeightCache::new();
+    /// cache.clear();
+    ///
+    /// assert_eq!(cache, ListHeightCache::new());
+    /// ```
+    pub fn clear(&mut self) {
+        self.width = None;
+        self.item_count = 0;
+        self.heights.clear();
+        self.dirty.clear();
+    }
+
+    /// Invalidates one item height.
+    ///
+    /// # Examples
+    ///
+    /// Mark one edited row dirty before the next cached layout pass:
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::ListHeightCache;
+    ///
+    /// let mut cache = ListHeightCache::new();
+    /// cache.invalidate(3);
+    /// ```
+    pub fn invalidate(&mut self, index: usize) {
+        if let Some(dirty) = self.dirty.get_mut(index) {
+            *dirty = true;
+        }
+    }
+
+    /// Invalidates a half-open item range.
+    ///
+    /// # Examples
+    ///
+    /// Mark the rows affected by a batch update dirty:
+    ///
+    /// ```rust
+    /// use ratatui_layout::list::ListHeightCache;
+    ///
+    /// let mut cache = ListHeightCache::new();
+    /// cache.invalidate_range(10..20);
+    /// ```
+    pub fn invalidate_range(&mut self, range: core::ops::Range<usize>) {
+        for index in range {
+            self.invalidate(index);
+        }
+    }
+
+    fn heights_for<I: ListItems>(&mut self, items: &I, item_count: usize, width: u16) -> &[u16] {
+        self.prepare(item_count, width);
+        for index in 0..item_count {
+            if self.dirty[index] {
+                self.heights[index] = items.height_for_width(index, width, MeasureContext).max(1);
+                self.dirty[index] = false;
+            }
+        }
+        &self.heights
+    }
+
+    fn prepare(&mut self, item_count: usize, width: u16) {
+        if self.width != Some(width) || self.item_count != item_count {
+            self.width = Some(width);
+            self.item_count = item_count;
+            self.heights.clear();
+            self.heights.resize(item_count, 1);
+            self.dirty.clear();
+            self.dirty.resize(item_count, true);
+        }
+    }
+}
+
+fn measure_heights<I: ListItems>(items: &I, item_count: usize, width: u16) -> Vec<u16> {
+    (0..item_count)
+        .map(|index| items.height_for_width(index, width, MeasureContext).max(1))
+        .collect()
+}
+
+fn clamp_scroll(scroll: ScrollPosition, heights: &[u16]) -> ScrollPosition {
+    let Some(height) = heights.get(scroll.index).copied() else {
+        return ScrollPosition::new(heights.len().saturating_sub(1), 0);
+    };
+    ScrollPosition::new(scroll.index, scroll.y_offset.min(height.saturating_sub(1)))
+}
+
+fn item_top(index: usize, heights: &[u16]) -> u32 {
+    heights[..index]
+        .iter()
+        .map(|height| u32::from(*height))
+        .sum()
+}
+
+fn scroll_to_line(line: u32, heights: &[u16]) -> ScrollPosition {
+    let mut remaining = line;
+    for (index, height) in heights.iter().copied().enumerate() {
+        let height = u32::from(height);
+        if remaining < height {
+            return ScrollPosition::new(index, remaining as u16);
+        }
+        remaining = remaining.saturating_sub(height);
+    }
+    ScrollPosition::new(heights.len().saturating_sub(1), 0)
+}
+
+fn scroll_to_selected(
+    scroll: ScrollPosition,
+    selected: usize,
+    heights: &[u16],
+    viewport_height: u16,
+    scroll_padding: u16,
+) -> ScrollPosition {
+    let viewport_height = u32::from(viewport_height);
+    let padding = u32::from(scroll_padding).min(viewport_height.saturating_sub(1) / 2);
+    let scroll_line = item_top(scroll.index, heights) + u32::from(scroll.y_offset);
+    let selected_top = item_top(selected, heights);
+    let selected_bottom = selected_top + u32::from(heights[selected]);
+
+    if selected_top < scroll_line + padding {
+        return scroll_to_line(selected_top.saturating_sub(padding), heights);
+    }
+
+    if selected_bottom + padding > scroll_line + viewport_height {
+        let target = selected_bottom
+            .saturating_add(padding)
+            .saturating_sub(viewport_height);
+        return scroll_to_line(target, heights);
+    }
+
+    scroll
+}
+
+fn visible_items(area: Rect, scroll: ScrollPosition, heights: &[u16]) -> Vec<VisibleItem> {
+    let mut items = Vec::new();
+    let mut index = scroll.index;
+    let mut y = area.y;
+    let mut remaining_height = area.height;
+    let mut y_offset = scroll.y_offset;
+
+    while remaining_height > 0 {
+        let Some(full_height) = heights.get(index).copied() else {
+            break;
+        };
+        let available_item_height = full_height.saturating_sub(y_offset);
+        let visible_height = available_item_height.min(remaining_height);
+        if visible_height == 0 {
+            break;
+        }
+
+        items.push(VisibleItem {
+            index,
+            area: Rect::new(area.x, y, area.width, visible_height),
+            full_height,
+            y_offset,
+            clipped_top: y_offset > 0,
+            clipped_bottom: y_offset + visible_height < full_height,
+        });
+
+        y = y.saturating_add(visible_height);
+        remaining_height = remaining_height.saturating_sub(visible_height);
+        index += 1;
+        y_offset = 0;
+    }
+
+    items
+}
+
+const fn offset_index(index: usize, delta: isize) -> usize {
+    if delta.is_negative() {
+        index.saturating_sub(delta.unsigned_abs())
+    } else {
+        index.saturating_add(delta as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use pretty_assertions::assert_eq;
+    use ratatui_core::buffer::Buffer;
+    use ratatui_core::layout::Rect;
+
+    use super::*;
+
+    struct Heights(Vec<u16>);
+
+    impl ListItems for Heights {
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        fn height_for_width(&self, index: usize, _: u16, _: MeasureContext) -> u16 {
+            self.0[index]
+        }
+
+        fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+    }
+
+    #[test]
+    fn empty_list_resets_state() {
+        let mut state = VirtualListState {
+            selected: Some(3),
+            scroll: ScrollPosition::new(2, 1),
+            scroll_selected_into_view: true,
+        };
+        let layout =
+            VirtualList::new().layout(Rect::new(0, 0, 10, 5), &mut state, &Heights(vec![]));
+
+        assert_eq!(state.selected(), None);
+        assert_eq!(state.scroll(), ScrollPosition::default());
+        assert!(layout.visible_items.is_empty());
+    }
+
+    #[test]
+    fn supports_line_aware_scroll_inside_item() {
+        let mut state = VirtualListState::default();
+        state.set_scroll(ScrollPosition::new(0, 2));
+        let layout =
+            VirtualList::new().layout(Rect::new(0, 0, 10, 4), &mut state, &Heights(vec![5, 2]));
+
+        assert_eq!(
+            layout.visible_items,
+            vec![
+                VisibleItem {
+                    index: 0,
+                    area: Rect::new(0, 0, 10, 3),
+                    full_height: 5,
+                    y_offset: 2,
+                    clipped_top: true,
+                    clipped_bottom: false,
+                },
+                VisibleItem {
+                    index: 1,
+                    area: Rect::new(0, 3, 10, 1),
+                    full_height: 2,
+                    y_offset: 0,
+                    clipped_top: false,
+                    clipped_bottom: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn keeps_selected_visible_with_line_padding() {
+        let mut state = VirtualListState::default();
+        state.select(Some(3));
+        let layout = VirtualList::new().scroll_padding(1).layout(
+            Rect::new(0, 0, 10, 3),
+            &mut state,
+            &Heights(vec![1, 1, 1, 1, 1]),
+        );
+
+        assert_eq!(state.scroll(), ScrollPosition::new(2, 0));
+        assert_eq!(
+            layout
+                .visible_items
+                .iter()
+                .map(|item| item.index)
+                .collect::<Vec<_>>(),
+            vec![2, 3, 4]
+        );
+    }
+
+    #[test]
+    fn relative_selection_clamps_to_item_count() {
+        let mut state = VirtualListState::default();
+
+        assert_eq!(state.select_relative(1, 3), Some(0));
+        assert_eq!(state.selected(), Some(0));
+        assert!(state.scrolls_selected_into_view());
+
+        assert_eq!(state.select_relative(1, 3), Some(1));
+        assert_eq!(state.select_relative(99, 3), Some(2));
+        assert_eq!(state.select_relative(-99, 3), Some(0));
+
+        assert_eq!(state.select_relative(1, 0), None);
+        assert_eq!(state.selected(), None);
+    }
+
+    #[test]
+    fn viewport_scroll_does_not_snap_back_to_selection() {
+        let mut state = VirtualListState::default();
+        state.select(Some(0));
+        state.scroll_viewport_by(3);
+        let layout = VirtualList::new().layout(
+            Rect::new(0, 0, 10, 2),
+            &mut state,
+            &Heights(vec![1, 1, 1, 1, 1]),
+        );
+
+        assert_eq!(state.selected(), Some(0));
+        assert_eq!(state.scroll(), ScrollPosition::new(3, 0));
+        assert_eq!(
+            layout
+                .visible_items
+                .iter()
+                .map(|item| item.index)
+                .collect::<Vec<_>>(),
+            vec![3, 4]
+        );
+        assert_eq!(layout.selected, None);
+    }
+
+    #[test]
+    fn hit_test_returns_item_relative_coordinates() {
+        let mut state = VirtualListState::default();
+        let layout =
+            VirtualList::new().layout(Rect::new(2, 3, 10, 4), &mut state, &Heights(vec![2, 2]));
+
+        assert_eq!(
+            layout.hit_test((4, 6)),
+            Some(Hit {
+                id: 1,
+                area: Rect::new(2, 5, 10, 2),
+                relative_x: 2,
+                relative_y: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn row_plan_preserves_visible_row_geometry_and_clipping() {
+        let mut state = VirtualListState::default();
+        state.set_scroll(ScrollPosition::new(0, 2));
+        let layout =
+            VirtualList::new().layout(Rect::new(2, 3, 10, 4), &mut state, &Heights(vec![5, 3]));
+        let plan = layout.row_regions();
+
+        assert_eq!(plan.area(), Rect::new(2, 3, 10, 4));
+        assert_eq!(plan.hit_test((4, 6)).unwrap().id, 1);
+        assert_eq!(plan.regions()[0].id, 0);
+        assert_eq!(plan.regions()[0].area, Rect::new(2, 3, 10, 3));
+        assert_eq!(plan.regions()[0].clip.top, 2);
+        assert_eq!(plan.regions()[1].id, 1);
+        assert_eq!(plan.regions()[1].area, Rect::new(2, 6, 10, 1));
+        assert_eq!(plan.regions()[1].clip.bottom, 2);
+    }
+
+    #[test]
+    fn rows_plan_maps_source_indexes_to_app_ids() {
+        let ids = ["api", "docs"];
+        let mut state = VirtualListState::default();
+        let layout =
+            VirtualList::new().layout(Rect::new(0, 0, 10, 2), &mut state, &Heights(vec![1, 1]));
+        let plan = layout.rows_regions(|index| ids[index]);
+
+        assert_eq!(plan.hit_test((1, 0)).unwrap().id, "api");
+        assert_eq!(plan.hit_test((1, 1)).unwrap().id, "docs");
+    }
+
+    #[test]
+    fn hit_index_and_select_hit_cover_common_click_paths() {
+        let ids = ["api", "docs"];
+        let mut state = VirtualListState::default();
+        let layout =
+            VirtualList::new().layout(Rect::new(0, 0, 10, 2), &mut state, &Heights(vec![1, 1]));
+        let mut selection = VisibleSelection::new();
+
+        assert_eq!(layout.hit_index((1, 1)), Some(1));
+        assert_eq!(layout.select_hit((1, 1), &mut selection, &ids), Some(1));
+        assert_eq!(selection.selected_id(), Some("docs"));
+        assert_eq!(layout.select_hit((1, 3), &mut selection, &ids), None);
+        assert_eq!(selection.selected_id(), Some("docs"));
+    }
+}

--- a/crates/ratatui-layout/src/measure.rs
+++ b/crates/ratatui-layout/src/measure.rs
@@ -1,0 +1,292 @@
+//! Measurement contracts for external layout participants.
+//!
+//! Measurement is the phase where externally owned content describes how much space it can use
+//! before a container assigns final rectangles. The types in this module intentionally stay small:
+//! terminal UIs usually need a width, a height, and enough bounds to explain whether a value is
+//! fixed, preferred, or flexible.
+//!
+//! The most common terminal layout question is "how tall is this item at this width?" A virtual
+//! list asks that question for every item it may need to show. More general participant-based
+//! layouts use [`MeasureConstraint`](crate::measure::MeasureConstraint) and
+//! [`SizeHint`](crate::measure::SizeHint) to keep that conversation explicit.
+//!
+//! # Types
+//!
+//! - [`MeasureConstraint`](crate::measure::MeasureConstraint) describes which dimensions the parent
+//!   already knows before asking a child to measure itself.
+//! - [`SizeHint`](crate::measure::SizeHint) reports minimum, preferred, and maximum useful sizes
+//!   for externally owned content.
+//!
+//! See [`crate::docs::widget_contracts`] for how measurement fits into the future participant and
+//! component direction. Use ordinary fixed `Rect` rendering when child content does not need to
+//! negotiate size with a parent.
+//!
+//! # Examples
+//!
+//! Return a height hint from externally owned content before a parent assigns the final area:
+//!
+//! ```rust
+//! use ratatui_core::layout::Size;
+//! use ratatui_layout::measure::{MeasureConstraint, SizeHint};
+//!
+//! fn measure_label(text: &str, constraint: MeasureConstraint) -> SizeHint {
+//!     match constraint {
+//!         MeasureConstraint::Width(width) => {
+//!             let height = text.len().div_ceil(width.max(1) as usize).max(1) as u16;
+//!             SizeHint::exact(Size::new(width, height))
+//!         }
+//!         _ => SizeHint::preferred(Size::new(text.len() as u16, 1)),
+//!     }
+//! }
+//!
+//! assert_eq!(
+//!     measure_label("abcdef", MeasureConstraint::Width(3)).preferred,
+//!     Size::new(3, 2),
+//! );
+//! ```
+
+use ratatui_core::layout::Size;
+
+/// Constraints supplied when asking external content to measure itself.
+///
+/// Use [`MeasureConstraint`](crate::measure::MeasureConstraint) when a parent needs to ask a
+/// child-sized concept a specific sizing question. A virtual list asks "how tall are you at this
+/// width?" A grid-like parent might ask for a preferred size under an exact cell size. The
+/// constraint records which dimensions are already known before the child returns a
+/// [`SizeHint`](crate::measure::SizeHint).
+///
+/// A constraint does not force the child to return a particular value by itself; the child still
+/// returns a hint that describes its useful range.
+///
+/// # Variants
+///
+/// - [`MeasureConstraint::Unbounded`](crate::measure::MeasureConstraint::Unbounded) asks for the
+///   child's natural size.
+/// - [`MeasureConstraint::Width`](crate::measure::MeasureConstraint::Width) fixes width so the
+///   child can compute height, common for wrapped text or list rows.
+/// - [`MeasureConstraint::Height`](crate::measure::MeasureConstraint::Height) fixes height so the
+///   child can compute width.
+/// - [`MeasureConstraint::Exact`](crate::measure::MeasureConstraint::Exact) fixes both dimensions
+///   when a parent has already solved the cell.
+///
+/// # Examples
+///
+/// Match on the known dimension to answer the parent's sizing question:
+///
+/// ```rust
+/// use ratatui_core::layout::Size;
+/// use ratatui_layout::measure::{MeasureConstraint, SizeHint};
+///
+/// fn measure_wrapped(text: &str, constraint: MeasureConstraint) -> SizeHint {
+///     match constraint {
+///         MeasureConstraint::Width(width) => {
+///             let height = text.len().div_ceil(width.max(1) as usize).max(1) as u16;
+///             SizeHint::exact(Size::new(width, height))
+///         }
+///         MeasureConstraint::Exact(size) => SizeHint::exact(size),
+///         _ => SizeHint::preferred(Size::new(text.len() as u16, 1)),
+///     }
+/// }
+///
+/// assert_eq!(
+///     measure_wrapped("abcdefgh", MeasureConstraint::Width(4)).preferred,
+///     Size::new(4, 2),
+/// );
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum MeasureConstraint {
+    /// No explicit width or height is known.
+    #[default]
+    Unbounded,
+    /// Width is fixed; height should be derived from that width.
+    Width(u16),
+    /// Height is fixed; width should be derived from that height.
+    Height(u16),
+    /// Both dimensions are fixed.
+    Exact(Size),
+}
+
+/// Minimum, preferred, and maximum size information for external content.
+///
+/// Use [`SizeHint`](crate::measure::SizeHint) when external content has a natural size but the
+/// parent still owns final layout. A toolbar button might have a preferred label width, a minimum
+/// icon width, and a maximum useful width. The parent can compare those hints before assigning
+/// concrete regions.
+///
+/// [`SizeHint`](crate::measure::SizeHint) is intentionally a hint, not a solved rectangle. The
+/// final assigned area is still communicated later through a [`crate::regions::Region`] or render
+/// callback.
+///
+/// # Constructors
+///
+/// - [`SizeHint::exact`](crate::measure::SizeHint::exact) creates a fixed-size hint where min,
+///   preferred, and max match.
+/// - [`SizeHint::preferred`](crate::measure::SizeHint::preferred) creates flexible bounds around a
+///   natural size.
+/// - [`SizeHint::bounded`](crate::measure::SizeHint::bounded) creates a fully specified range.
+///
+/// # Inspection
+///
+/// - [`SizeHint::clamped_preferred`](crate::measure::SizeHint::clamped_preferred) returns the
+///   preferred size after applying the advertised minimum and maximum bounds.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Size;
+/// use ratatui_layout::measure::SizeHint;
+///
+/// let fixed = SizeHint::exact(Size::new(8, 1));
+/// assert_eq!(fixed.min, fixed.max);
+///
+/// let flexible = SizeHint::bounded(Size::new(4, 1), Size::new(12, 1), Size::new(20, 1));
+/// assert_eq!(flexible.clamped_preferred(), Size::new(12, 1));
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SizeHint {
+    /// The smallest useful size.
+    pub min: Size,
+    /// The preferred size when enough space is available.
+    pub preferred: Size,
+    /// The largest useful size.
+    pub max: Size,
+}
+
+impl SizeHint {
+    /// Creates a size hint with the same min, preferred, and max size.
+    ///
+    /// Use this when an item must occupy one exact terminal-cell size, such as an icon, fixed
+    /// badge, or already-solved cell.
+    ///
+    /// # Examples
+    ///
+    /// Return a fixed one-line height for a command palette row:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Size;
+    /// use ratatui_layout::measure::SizeHint;
+    ///
+    /// let row = SizeHint::exact(Size::new(20, 1));
+    ///
+    /// assert_eq!(row.min, Size::new(20, 1));
+    /// assert_eq!(row.max, Size::new(20, 1));
+    /// ```
+    pub const fn exact(size: Size) -> Self {
+        Self {
+            min: size,
+            preferred: size,
+            max: size,
+        }
+    }
+
+    /// Creates an unconstrained hint with a preferred size.
+    ///
+    /// The minimum is zero and the maximum is [`Size::MAX`]. This is useful for content that can
+    /// shrink or grow but has a natural size.
+    ///
+    /// # Examples
+    ///
+    /// Describe a label that prefers its text width but can be clipped by the parent:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Size;
+    /// use ratatui_layout::measure::SizeHint;
+    ///
+    /// let label = SizeHint::preferred(Size::new(12, 1));
+    ///
+    /// assert_eq!(label.min, Size::ZERO);
+    /// assert_eq!(label.preferred, Size::new(12, 1));
+    /// ```
+    pub const fn preferred(size: Size) -> Self {
+        Self {
+            min: Size::ZERO,
+            preferred: size,
+            max: Size::MAX,
+        }
+    }
+
+    /// Creates a fully specified size hint.
+    ///
+    /// This constructor does not reorder the bounds. Callers should pass coherent values where
+    /// `min <= preferred <= max` for each dimension, or use
+    /// [`SizeHint::clamped_preferred`](crate::measure::SizeHint::clamped_preferred) before
+    /// relying on the preferred size.
+    ///
+    /// # Examples
+    ///
+    /// Give a resizable panel a useful range while keeping its natural size explicit:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Size;
+    /// use ratatui_layout::measure::SizeHint;
+    ///
+    /// let panel = SizeHint::bounded(Size::new(20, 5), Size::new(40, 10), Size::new(80, 20));
+    ///
+    /// assert_eq!(panel.preferred, Size::new(40, 10));
+    /// ```
+    pub const fn bounded(min: Size, preferred: Size, max: Size) -> Self {
+        Self {
+            min,
+            preferred,
+            max,
+        }
+    }
+
+    /// Returns the preferred size clamped to the min and max bounds.
+    ///
+    /// This is a convenience for simple parents that want to honor the preferred size while still
+    /// respecting the advertised bounds.
+    ///
+    /// # Examples
+    ///
+    /// Clamp an inconsistent or user-provided preferred size before assigning a region:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Size;
+    /// use ratatui_layout::measure::SizeHint;
+    ///
+    /// let hint = SizeHint::bounded(Size::new(10, 1), Size::new(5, 4), Size::new(20, 3));
+    ///
+    /// assert_eq!(hint.clamped_preferred(), Size::new(10, 3));
+    /// ```
+    pub fn clamped_preferred(self) -> Size {
+        Size::new(
+            self.preferred.width.clamp(self.min.width, self.max.width),
+            self.preferred
+                .height
+                .clamp(self.min.height, self.max.height),
+        )
+    }
+}
+
+impl Default for SizeHint {
+    fn default() -> Self {
+        Self::preferred(Size::ZERO)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use ratatui_core::layout::Size;
+
+    use super::*;
+
+    #[test]
+    fn exact_sets_all_bounds() {
+        let hint = SizeHint::exact(Size::new(3, 4));
+
+        assert_eq!(hint.min, Size::new(3, 4));
+        assert_eq!(hint.preferred, Size::new(3, 4));
+        assert_eq!(hint.max, Size::new(3, 4));
+    }
+
+    #[test]
+    fn clamps_preferred() {
+        let hint = SizeHint::bounded(Size::new(2, 3), Size::new(1, 10), Size::new(5, 6));
+
+        assert_eq!(hint.clamped_preferred(), Size::new(2, 6));
+    }
+}

--- a/crates/ratatui-layout/src/modal.rs
+++ b/crates/ratatui-layout/src/modal.rs
@@ -1,0 +1,215 @@
+//! Modal-shell geometry and outside-click routing.
+//!
+//! Dialog-like overlays usually need three pieces before any field-specific code runs: a centered
+//! outer area, an inner content area, and an optional backdrop target that can route clicks outside
+//! the dialog. [`ModalShell`](crate::modal::ModalShell) provides those pieces without rendering a
+//! border, dimming the background, owning fields, or deciding whether outside clicks dismiss the
+//! dialog.
+//!
+//! # Types
+//!
+//! - [`ModalShell`](crate::modal::ModalShell) stores size, padding, z-order, and optional backdrop
+//!   id.
+//! - [`ModalLayout`](crate::modal::ModalLayout) exposes the solved outer, inner, and backdrop areas
+//!   plus frame-local routing.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::container::Padding;
+//! use ratatui_layout::modal::ModalShell;
+//!
+//! let layout = ModalShell::new(20, 5)
+//!     .padding(Padding::all(1))
+//!     .backdrop("outside")
+//!     .layout(Rect::new(0, 0, 80, 24));
+//!
+//! assert_eq!(layout.outer().width, 20);
+//! assert_eq!(layout.inner().width, 18);
+//! assert_eq!(layout.frame().route_click((0, 0)).unwrap().id, "outside");
+//! ```
+
+use ratatui_core::layout::{Constraint, Flex, Layout, Rect};
+
+use crate::container::{Container, Padding};
+use crate::frame::FrameSnapshot;
+use crate::pointer::{PointerTarget, PointerTargets};
+
+/// Geometry policy for a centered modal surface.
+///
+/// [`ModalShell`](crate::modal::ModalShell) owns only the overlay shell: desired size, padding,
+/// z-order, and optional backdrop routing. Child forms, command rows, focus state, validation, and
+/// rendering remain app-owned. Use the returned
+/// [`ModalLayout::inner`](crate::modal::ModalLayout::inner) as the area for the dialog contents.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct ModalShell<Id = usize> {
+    width: u16,
+    height: u16,
+    padding: Padding,
+    backdrop: Option<Id>,
+    z: u16,
+}
+
+impl ModalShell {
+    /// Creates a modal shell with a desired width and height.
+    ///
+    /// The actual area is clamped by the screen area passed to
+    /// [`ModalShell::layout`](crate::modal::ModalShell::layout).
+    pub const fn new(width: u16, height: u16) -> Self {
+        Self {
+            width,
+            height,
+            padding: Padding::new(0, 0, 0, 0),
+            backdrop: None,
+            z: 100,
+        }
+    }
+}
+
+impl<Id> ModalShell<Id> {
+    /// Sets padding between the outer modal area and child content.
+    #[must_use = "method returns the modified modal shell"]
+    pub const fn padding(mut self, padding: Padding) -> Self {
+        self.padding = padding;
+        self
+    }
+
+    /// Adds a pointer target over the screen area behind the modal.
+    ///
+    /// The backdrop id lets an app implement outside-click behavior explicitly: dismiss, ignore,
+    /// flash validation errors, or move focus back to the dialog.
+    #[must_use = "method returns the modified modal shell"]
+    pub fn backdrop<Backdrop>(self, backdrop: Backdrop) -> ModalShell<Backdrop> {
+        ModalShell {
+            width: self.width,
+            height: self.height,
+            padding: self.padding,
+            backdrop: Some(backdrop),
+            z: self.z,
+        }
+    }
+
+    /// Sets the z-order for backdrop routing.
+    ///
+    /// Child frames should usually use a higher z-order than the backdrop if their areas overlap.
+    #[must_use = "method returns the modified modal shell"]
+    pub const fn z(mut self, z: u16) -> Self {
+        self.z = z;
+        self
+    }
+
+    /// Solves the centered modal and optional backdrop target.
+    ///
+    /// The returned frame contains only backdrop routing. Merge child field and button frames into
+    /// the returned frame after rendering dialog contents.
+    pub fn layout(self, screen: Rect) -> ModalLayout<Id>
+    where
+        Id: Copy,
+    {
+        let outer = center(screen, self.width, self.height);
+        let container = Container::<Id>::new().padding(self.padding).layout(outer);
+        let frame = if let Some(backdrop) = self.backdrop {
+            FrameSnapshot::new(screen)
+                .mouse(PointerTargets::new().target(PointerTarget::new(backdrop, screen).z(self.z)))
+        } else {
+            FrameSnapshot::new(screen)
+        };
+        ModalLayout {
+            screen,
+            outer,
+            inner: container.inner,
+            backdrop: self.backdrop,
+            frame,
+        }
+    }
+}
+
+/// Solved modal geometry for one frame.
+///
+/// Render the modal border or block into [`ModalLayout::outer`](crate::modal::ModalLayout::outer),
+/// render dialog contents into [`ModalLayout::inner`](crate::modal::ModalLayout::inner), and store
+/// or merge [`ModalLayout::frame`](crate::modal::ModalLayout::frame) so the next pointer event can
+/// distinguish outside clicks from dialog controls.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct ModalLayout<Id = usize> {
+    screen: Rect,
+    outer: Rect,
+    inner: Rect,
+    backdrop: Option<Id>,
+    frame: FrameSnapshot<Id>,
+}
+
+impl<Id> ModalLayout<Id> {
+    /// Returns the full screen area used for backdrop routing.
+    pub const fn screen(&self) -> Rect {
+        self.screen
+    }
+
+    /// Returns the centered modal area.
+    pub const fn outer(&self) -> Rect {
+        self.outer
+    }
+
+    /// Returns the child content area after padding.
+    pub const fn inner(&self) -> Rect {
+        self.inner
+    }
+
+    /// Returns the optional backdrop id.
+    pub const fn backdrop(&self) -> Option<&Id> {
+        self.backdrop.as_ref()
+    }
+
+    /// Returns the backdrop frame snapshot.
+    pub const fn frame(&self) -> &FrameSnapshot<Id> {
+        &self.frame
+    }
+
+    /// Merges a child frame into the modal frame.
+    ///
+    /// Use this after rendering fields and buttons so the stored frame routes controls before the
+    /// backdrop when child targets use a higher z-order or later insertion order.
+    pub fn merge_child(self, child: FrameSnapshot<Id>) -> FrameSnapshot<Id> {
+        self.frame.merge(child)
+    }
+}
+
+fn center(screen: Rect, width: u16, height: u16) -> Rect {
+    let width = width.min(screen.width);
+    let height = height.min(screen.height);
+    let vertical = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .split(screen);
+    let horizontal = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .split(vertical[0]);
+    horizontal[0]
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui_core::layout::Rect;
+
+    use super::ModalShell;
+    use crate::container::Padding;
+
+    #[test]
+    fn modal_centers_and_applies_padding() {
+        let layout = ModalShell::new(20, 6)
+            .padding(Padding::all(1))
+            .layout(Rect::new(0, 0, 80, 24));
+
+        assert_eq!(layout.outer(), Rect::new(30, 9, 20, 6));
+        assert_eq!(layout.inner(), Rect::new(31, 10, 18, 4));
+    }
+
+    #[test]
+    fn backdrop_routes_outside_clicks() {
+        let layout = ModalShell::new(10, 3)
+            .backdrop("outside")
+            .layout(Rect::new(0, 0, 40, 10));
+
+        assert_eq!(layout.frame().route_click((0, 0)).unwrap().id, "outside");
+    }
+}

--- a/crates/ratatui-layout/src/overlay.rs
+++ b/crates/ratatui-layout/src/overlay.rs
@@ -1,0 +1,169 @@
+//! Overlay regions for overlapping UI.
+//!
+//! An [`Overlay`](crate::overlay::Overlay) collects explicit regions that may overlap. It is useful
+//! for popups, floating controls, drag previews, or debug layers where the caller already knows
+//! each layer's rectangle. The overlay does not sort or clip regions; it preserves insertion order
+//! and z-order metadata for the returned [`Regions`](crate::regions::Regions).
+//!
+//! Use ordinary direct rendering when an overlay has one known rectangle and no need for hit
+//! testing or later inspection. Use this module when several explicit layers need to become one
+//! frame-local region set.
+//!
+//! See [`crate::docs::containers`] for how overlays fit with panels, dialogs, flex layouts, grids,
+//! and nested composition.
+//!
+//! # Type
+//!
+//! - [`Overlay`](crate::overlay::Overlay) collects explicit [`Region`](crate::regions::Region)
+//!   values and returns one [`Regions`](crate::regions::Regions) for hit testing, diagnostics, or
+//!   parent composition.
+//!
+//! [`Regions`](crate::regions::Regions): crate::regions::Regions
+//!
+//! # Examples
+//!
+//! Layer a popup over content and keep the topmost layer available for input routing:
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::overlay::Overlay;
+//! use ratatui_layout::regions::Region;
+//!
+//! let overlay_regions = Overlay::new()
+//!     .region(Region::new("content", Rect::new(0, 0, 40, 10)))
+//!     .region(Region::new("dialog", Rect::new(8, 2, 24, 5)).z(10))
+//!     .regions(Rect::new(0, 0, 40, 10));
+//!
+//! assert_eq!(overlay_regions.hit_test((10, 3)).unwrap().id, "dialog");
+//! ```
+
+use alloc::vec::Vec;
+
+use ratatui_core::layout::Rect;
+
+use crate::regions::{Region, Regions};
+
+/// Z-ordered region builder for explicit overlay layers.
+///
+/// Use [`Overlay`](crate::overlay::Overlay) when the caller already knows each layer's rectangle
+/// and needs those layers in one hit-testable [`Regions`](crate::regions::Regions). Popups,
+/// floating command palettes, drag previews, and debug overlays all have positioning policy outside
+/// the overlay itself.
+///
+/// [`Overlay`](crate::overlay::Overlay) is intentionally small. It provides a fluent way to build a
+/// [`Regions`](crate::regions::Regions) from already-solved regions and leaves all positioning
+/// policy to the caller.
+///
+/// # Constructors and solving
+///
+/// - [`Overlay::new`](crate::overlay::Overlay::new) creates an empty overlay.
+/// - [`Overlay::region`](crate::overlay::Overlay::region) appends an explicit layer in render
+///   order.
+/// - [`Overlay::regions`](crate::overlay::Overlay::regions) returns the collected regions as a
+///   [`Regions`](crate::regions::Regions).
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::overlay::Overlay;
+/// use ratatui_layout::regions::Region;
+///
+/// let overlay_regions = Overlay::new()
+///     .region(Region::new("content", Rect::new(0, 0, 20, 5)))
+///     .region(Region::new("popup", Rect::new(4, 1, 10, 3)).z(10))
+///     .regions(Rect::new(0, 0, 20, 5));
+///
+/// assert_eq!(overlay_regions.hit_test((5, 2)).unwrap().id, "popup");
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Overlay<Id = usize> {
+    regions: Vec<Region<Id>>,
+}
+
+impl<Id> Default for Overlay<Id> {
+    fn default() -> Self {
+        Self {
+            regions: Vec::new(),
+        }
+    }
+}
+
+impl<Id> Overlay<Id> {
+    /// Creates an empty overlay.
+    ///
+    /// # Examples
+    ///
+    /// Start an overlay when popup placement is computed elsewhere:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::overlay::Overlay;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let overlay = Overlay::new().region(Region::new("tooltip", Rect::new(2, 1, 8, 1)));
+    ///
+    /// assert_eq!(overlay.regions(Rect::new(0, 0, 20, 4)).regions().len(), 1);
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            regions: Vec::new(),
+        }
+    }
+
+    /// Adds a region to the overlay.
+    ///
+    /// Regions are appended in render order. Hit testing later uses z-order first and insertion
+    /// order as the tie-breaker.
+    ///
+    /// # Examples
+    ///
+    /// Add a floating command palette above a base content layer:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::overlay::Overlay;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let overlay = Overlay::new()
+    ///     .region(Region::new("base", Rect::new(0, 0, 30, 10)))
+    ///     .region(Region::new("palette", Rect::new(5, 2, 20, 4)).z(5));
+    ///
+    /// assert_eq!(
+    ///     overlay
+    ///         .regions(Rect::new(0, 0, 30, 10))
+    ///         .hit_test((6, 3))
+    ///         .unwrap()
+    ///         .id,
+    ///     "palette"
+    /// );
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn region(mut self, region: Region<Id>) -> Self {
+        self.regions.push(region);
+        self
+    }
+
+    /// Solves the overlay into regions.
+    ///
+    /// The supplied `area` is the parent overlay area. It does not clamp region rectangles.
+    ///
+    /// # Examples
+    ///
+    /// Store explicit overlay regions for previous-frame hit testing:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::overlay::Overlay;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let previous_frame = Overlay::new()
+    ///     .region(Region::new("drag-preview", Rect::new(10, 4, 6, 2)).z(20))
+    ///     .regions(Rect::new(0, 0, 40, 12));
+    ///
+    /// assert_eq!(previous_frame.area(), Rect::new(0, 0, 40, 12));
+    /// ```
+    pub fn regions(self, area: Rect) -> Regions<Id> {
+        Regions::from_regions(area, self.regions)
+    }
+}

--- a/crates/ratatui-layout/src/pane.rs
+++ b/crates/ratatui-layout/src/pane.rs
@@ -1,0 +1,181 @@
+//! Scrollable pane coordination.
+//!
+//! A pane often needs to scroll even when the pointer is over blank space below the last visible
+//! row. [`ScrollablePane`](crate::pane::ScrollablePane) solves that small but common problem: it
+//! computes scroll metrics for a viewport and creates a whole-pane pointer target for wheel
+//! routing. Rendering remains app-owned.
+//!
+//! # Types
+//!
+//! - [`ScrollablePane`](crate::pane::ScrollablePane) stores the pane id and optional status-line
+//!   reservation.
+//! - [`ScrollablePaneLayout`](crate::pane::ScrollablePaneLayout) exposes the content area, optional
+//!   status area, metrics, and frame.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::pane::ScrollablePane;
+//!
+//! let layout =
+//!     ScrollablePane::new("log")
+//!         .status_line(true)
+//!         .layout(Rect::new(0, 0, 20, 5), 30, 10);
+//!
+//! assert_eq!(layout.content_area().height, 4);
+//! assert_eq!(layout.metrics().visible_range(), 10..14);
+//! assert_eq!(layout.frame().route_scroll((2, 4)).unwrap().id, "log");
+//! ```
+
+use ratatui_core::layout::Rect;
+
+use crate::frame::FrameSnapshot;
+use crate::pointer::PointerTargets;
+use crate::scroll::ScrollMetrics;
+
+/// Pointer and metrics policy for one scrollable pane.
+///
+/// [`ScrollablePane`](crate::pane::ScrollablePane) does not know what content is drawn. It only
+/// records which id should receive wheel events across the pane and how a logical content length
+/// maps into the visible viewport.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct ScrollablePane<Id = usize> {
+    id: Id,
+    status_line: bool,
+    z: u16,
+}
+
+impl<Id> ScrollablePane<Id> {
+    /// Creates a pane for an app-owned id.
+    pub const fn new(id: Id) -> Self {
+        Self {
+            id,
+            status_line: false,
+            z: 0,
+        }
+    }
+
+    /// Reserves the last row for scroll status text.
+    ///
+    /// The content viewport uses the remaining rows while wheel routing still covers the full pane.
+    #[must_use = "method returns the modified pane"]
+    pub const fn status_line(mut self, status_line: bool) -> Self {
+        self.status_line = status_line;
+        self
+    }
+
+    /// Sets the z-order for the whole-pane pointer target.
+    #[must_use = "method returns the modified pane"]
+    pub const fn z(mut self, z: u16) -> Self {
+        self.z = z;
+        self
+    }
+
+    /// Computes scroll metrics and a whole-pane pointer target.
+    ///
+    /// `content_length` is the logical number of rows or records, and `offset` is the desired
+    /// starting index. The returned [`ScrollMetrics`](crate::scroll::ScrollMetrics) clamps the
+    /// offset to the visible range.
+    pub fn layout(
+        self,
+        area: Rect,
+        content_length: usize,
+        offset: usize,
+    ) -> ScrollablePaneLayout<Id>
+    where
+        Id: Copy,
+    {
+        let content_height = if self.status_line {
+            area.height.saturating_sub(1)
+        } else {
+            area.height
+        };
+        let content_area = Rect {
+            height: content_height,
+            ..area
+        };
+        let status_area = self.status_line.then(|| Rect {
+            y: area.y.saturating_add(content_height),
+            height: area.height.saturating_sub(content_height),
+            ..area
+        });
+        let content_length = content_length.min(u32::MAX as usize) as u32;
+        let offset = offset.min(u32::MAX as usize) as u32;
+        let metrics = ScrollMetrics::new(content_length, content_height, offset);
+        let pointer = PointerTargets::new().region(self.id, area);
+        let frame = FrameSnapshot::new(area).mouse(pointer);
+        ScrollablePaneLayout {
+            area,
+            content_area,
+            status_area,
+            metrics,
+            frame,
+        }
+    }
+}
+
+/// Solved scrollable-pane data for one frame.
+///
+/// Use the content area for drawing records, the metrics for scrollbar or status text, and the
+/// frame snapshot for wheel routing over both content and blank pane space.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct ScrollablePaneLayout<Id = usize> {
+    area: Rect,
+    content_area: Rect,
+    status_area: Option<Rect>,
+    metrics: ScrollMetrics,
+    frame: FrameSnapshot<Id>,
+}
+
+impl<Id> ScrollablePaneLayout<Id> {
+    /// Returns the full pane area.
+    pub const fn area(&self) -> Rect {
+        self.area
+    }
+
+    /// Returns the area available for scrollable content.
+    pub const fn content_area(&self) -> Rect {
+        self.content_area
+    }
+
+    /// Returns the optional status-line area.
+    pub const fn status_area(&self) -> Option<Rect> {
+        self.status_area
+    }
+
+    /// Returns clamped scroll metrics for the content viewport.
+    pub const fn metrics(&self) -> ScrollMetrics {
+        self.metrics
+    }
+
+    /// Returns the frame snapshot used for wheel routing.
+    pub const fn frame(&self) -> &FrameSnapshot<Id> {
+        &self.frame
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui_core::layout::Rect;
+
+    use super::ScrollablePane;
+
+    #[test]
+    fn status_line_reduces_content_height() {
+        let layout =
+            ScrollablePane::new("pane")
+                .status_line(true)
+                .layout(Rect::new(0, 0, 20, 5), 20, 0);
+
+        assert_eq!(layout.content_area(), Rect::new(0, 0, 20, 4));
+        assert_eq!(layout.status_area(), Some(Rect::new(0, 4, 20, 1)));
+    }
+
+    #[test]
+    fn wheel_routes_across_blank_pane_space() {
+        let layout = ScrollablePane::new("pane").layout(Rect::new(0, 0, 20, 5), 2, 0);
+
+        assert_eq!(layout.frame().route_scroll((10, 4)).unwrap().id, "pane");
+    }
+}

--- a/crates/ratatui-layout/src/participant.rs
+++ b/crates/ratatui-layout/src/participant.rs
@@ -1,0 +1,389 @@
+//! Traits and contexts for externally owned layout participants.
+//!
+//! A participant is application-owned content that can measure and render when a parent layout asks
+//! it to. The parent does not store the participant. Instead, it passes an id, a constraint or
+//! area, and a small context value. This keeps data ownership, widget state, and mutation policy in
+//! the application while still letting containers coordinate layout.
+//!
+//! Use [`LayoutParticipant`](crate::participant::LayoutParticipant) for reusable components and
+//! [`ParticipantFn`](crate::participant::ParticipantFn) for one-off closures in examples, tests, or
+//! small apps.
+//!
+//! Keep using Ratatui's `Widget` and `StatefulWidget` traits when a rectangle is already known and
+//! a render call is enough. Participants are for experimental parent/child contracts where a parent
+//! must ask app-owned content to measure before assigning final rectangles.
+//!
+//! # Types and traits
+//!
+//! - [`MeasureContext`](crate::participant::MeasureContext) is the shared measurement context
+//!   passed with [`MeasureConstraint`](crate::measure::MeasureConstraint).
+//! - [`RenderState`](crate::participant::RenderState) carries common interaction flags such as
+//!   focus, selection, hover, and disabled state.
+//! - [`RenderContext`](crate::participant::RenderContext) wraps
+//!   [`RenderState`](crate::participant::RenderState) for render callbacks.
+//! - [`LayoutParticipant`](crate::participant::LayoutParticipant) is the experimental
+//!   measure-then-render trait for app-owned content.
+//! - [`ParticipantFn`](crate::participant::ParticipantFn) adapts measure and render closures into
+//!   [`LayoutParticipant`](crate::participant::LayoutParticipant).
+//!
+//! See [`crate::docs::widget_contracts`] for why participants are kept experimental and separate
+//! from Ratatui's existing `Widget` and `StatefulWidget` traits.
+//!
+//! # Examples
+//!
+//! Measure app-owned content first, then render it once the parent assigns a final rectangle:
+//!
+//! ```rust
+//! use ratatui_core::buffer::Buffer;
+//! use ratatui_core::layout::{Rect, Size};
+//! use ratatui_layout::measure::{MeasureConstraint, SizeHint};
+//! use ratatui_layout::participant::{
+//!     LayoutParticipant, MeasureContext, ParticipantFn, RenderContext,
+//! };
+//!
+//! let labels = ["open", "save"];
+//! let mut participant = ParticipantFn::new(
+//!     |id: usize, _, _| SizeHint::exact(Size::new(labels[id].len() as u16, 1)),
+//!     |_, _: Rect, _: &mut Buffer, _| {},
+//! );
+//!
+//! let hint = participant.measure(0, MeasureConstraint::Unbounded, MeasureContext);
+//! let mut buffer = Buffer::empty(Rect::new(0, 0, hint.preferred.width, 1));
+//! participant.render(0, buffer.area, &mut buffer, RenderContext::default());
+//! ```
+
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+
+use crate::measure::{MeasureConstraint, SizeHint};
+
+/// Context supplied while measuring external content.
+///
+/// Use [`MeasureContext`](crate::participant::MeasureContext) as the common context argument for
+/// [`LayoutParticipant::measure`](crate::participant::LayoutParticipant::measure). It is currently
+/// empty because the first APIs only need the constraint and id, but it keeps measurement calls
+/// consistent with [`RenderContext`](crate::participant::RenderContext) and leaves room for shared
+/// measurement data later.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_layout::participant::MeasureContext;
+///
+/// let context = MeasureContext;
+/// assert_eq!(context, MeasureContext);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MeasureContext;
+
+/// Common interaction flags supplied while rendering external content.
+///
+/// Use [`RenderState`](crate::participant::RenderState) when a parent wants to pass interaction
+/// state without owning the rendering policy. A list can mark an item as selected; the row renderer
+/// decides whether to reverse the style, draw a marker, render a nested control differently, or
+/// ignore the flag.
+///
+/// # Fields
+///
+/// - [`RenderState::focused`](crate::participant::RenderState::focused) says keyboard input
+///   currently targets the item.
+/// - [`RenderState::selected`](crate::participant::RenderState::selected) says the item is part of
+///   app-owned selection.
+/// - [`RenderState::hovered`](crate::participant::RenderState::hovered) says pointer state
+///   currently rests on the item.
+/// - [`RenderState::disabled`](crate::participant::RenderState::disabled) says the item should
+///   render as unavailable.
+///
+/// # Examples
+///
+/// Combine interaction data from different values before calling an app-owned renderer:
+///
+/// ```rust
+/// use ratatui_layout::participant::RenderState;
+///
+/// let state = RenderState {
+///     focused: true,
+///     selected: false,
+///     hovered: true,
+///     disabled: false,
+/// };
+///
+/// assert!(state.focused && state.hovered);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[allow(clippy::struct_excessive_bools)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RenderState {
+    /// Whether the rendered item has focus.
+    pub focused: bool,
+    /// Whether the rendered item is selected.
+    pub selected: bool,
+    /// Whether the rendered item is hovered.
+    pub hovered: bool,
+    /// Whether the rendered item is disabled.
+    pub disabled: bool,
+}
+
+/// Context supplied while rendering external content.
+///
+/// Use [`RenderContext`](crate::participant::RenderContext) as the common rendering argument when a
+/// layout primitive calls back into app-owned content. It carries
+/// [`RenderState`](crate::participant::RenderState) shared by multiple container shapes.
+/// Specialized containers wrap it with additional fields; for example,
+/// [`crate::list::ListItemContext`] adds the item index, visible index, and clipping metadata.
+///
+/// # Constructors
+///
+/// - [`RenderContext::selected`](crate::participant::RenderContext::selected) creates a context
+///   with only selected state set.
+///
+/// # Examples
+///
+/// Pass shared render state through a list, table, or participant-specific context:
+///
+/// ```rust
+/// use ratatui_layout::participant::{RenderContext, RenderState};
+///
+/// let context = RenderContext {
+///     state: RenderState {
+///         focused: true,
+///         selected: true,
+///         ..RenderState::default()
+///     },
+/// };
+///
+/// assert!(context.state.focused);
+/// assert!(context.state.selected);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RenderContext {
+    /// Common interaction flags.
+    pub state: RenderState,
+}
+
+impl RenderContext {
+    /// Creates a context with only the selected flag set.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::participant::RenderContext;
+    ///
+    /// let context = RenderContext::selected(true);
+    /// assert!(context.state.selected);
+    /// assert!(!context.state.focused);
+    /// ```
+    pub const fn selected(selected: bool) -> Self {
+        Self {
+            state: RenderState {
+                focused: false,
+                selected,
+                hovered: false,
+                disabled: false,
+            },
+        }
+    }
+}
+
+/// Externally owned content that can collaborate with layout primitives.
+///
+/// The trait separates measurement from rendering. A parent first asks for a
+/// [`SizeHint`](crate::measure::SizeHint) under a
+/// [`MeasureConstraint`](crate::measure::MeasureConstraint), solves a layout, and later calls
+/// [`LayoutParticipant::render`](crate::participant::LayoutParticipant::render) with the
+/// final [`Rect`]. The participant may use `id` to look up application data or state.
+///
+/// The trait takes `&mut self` for rendering because rendering may update local caches, nested
+/// widget state, or diagnostics. Measurement takes `&self` so layout can be computed without
+/// implying a render-side effect.
+///
+/// # Required methods
+///
+/// - [`LayoutParticipant::measure`](crate::participant::LayoutParticipant::measure) returns a
+///   [`SizeHint`](crate::measure::SizeHint) for one app-owned id under a
+///   [`MeasureConstraint`](crate::measure::MeasureConstraint).
+/// - [`LayoutParticipant::render`](crate::participant::LayoutParticipant::render) draws one
+///   app-owned id into its final [`Rect`] with a
+///   [`RenderContext`](crate::participant::RenderContext).
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::{Rect, Size};
+/// use ratatui_core::text::Line;
+/// use ratatui_core::widgets::Widget;
+/// use ratatui_layout::measure::{MeasureConstraint, SizeHint};
+/// use ratatui_layout::participant::{LayoutParticipant, MeasureContext, RenderContext};
+///
+/// struct Labels(&'static [&'static str]);
+///
+/// impl LayoutParticipant for Labels {
+///     fn measure(&self, id: usize, _: MeasureConstraint, _: MeasureContext) -> SizeHint {
+///         SizeHint::exact(Size::new(self.0[id].len() as u16, 1))
+///     }
+///
+///     fn render(&mut self, id: usize, area: Rect, buf: &mut Buffer, _: RenderContext) {
+///         Line::from(self.0[id]).render(area, buf);
+///     }
+/// }
+/// ```
+pub trait LayoutParticipant<Id = usize> {
+    /// Measures the participant identified by `id`.
+    ///
+    /// Implementations should avoid mutating application state. If measurement depends on cached
+    /// expensive layout information, keep cache mutation explicit in the owning type rather than
+    /// hiding it behind this method unless that cache is an internal implementation detail.
+    fn measure(&self, id: Id, constraint: MeasureConstraint, ctx: MeasureContext) -> SizeHint;
+
+    /// Renders the participant identified by `id` into the assigned area.
+    ///
+    /// The `area` is final. Participants should not attempt to negotiate a different size during
+    /// rendering; they should clip, truncate, wrap, or leave empty space according to their own
+    /// rendering contract.
+    ///
+    /// # Examples
+    ///
+    /// Render app-owned content after measurement and parent layout have assigned a final area:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::{Rect, Size};
+    /// use ratatui_core::text::Line;
+    /// use ratatui_core::widgets::Widget;
+    /// use ratatui_layout::measure::{MeasureConstraint, SizeHint};
+    /// use ratatui_layout::participant::{LayoutParticipant, MeasureContext, RenderContext};
+    ///
+    /// struct Labels(&'static [&'static str]);
+    ///
+    /// impl LayoutParticipant for Labels {
+    ///     fn measure(&self, id: usize, _: MeasureConstraint, _: MeasureContext) -> SizeHint {
+    ///         SizeHint::exact(Size::new(self.0[id].len() as u16, 1))
+    ///     }
+    ///
+    ///     fn render(&mut self, id: usize, area: Rect, buf: &mut Buffer, _: RenderContext) {
+    ///         Line::from(self.0[id]).render(area, buf);
+    ///     }
+    /// }
+    ///
+    /// let mut labels = Labels(&["open"]);
+    /// let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 1));
+    /// labels.render(
+    ///     0,
+    ///     Rect::new(0, 0, 4, 1),
+    ///     &mut buffer,
+    ///     RenderContext::default(),
+    /// );
+    /// ```
+    fn render(&mut self, id: Id, area: Rect, buf: &mut Buffer, ctx: RenderContext);
+}
+
+/// Closure adapter for [`LayoutParticipant`](crate::participant::LayoutParticipant).
+///
+/// Use [`ParticipantFn`](crate::participant::ParticipantFn) for small adapters where the
+/// participant is just two closures over local state. For example, a test can measure ids from a
+/// static slice and render labels without introducing a named type.
+///
+/// Reusable components should usually implement
+/// [`LayoutParticipant`](crate::participant::LayoutParticipant) directly so their measurement
+/// and render contracts can be documented near the type.
+///
+/// # Constructor
+///
+/// - [`ParticipantFn::new`](crate::participant::ParticipantFn::new) stores measure and render
+///   closures behind the trait contract.
+///
+/// # Examples
+///
+/// Use closures for a small component while still exercising the participant contract:
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::{Rect, Size};
+/// use ratatui_layout::measure::{MeasureConstraint, SizeHint};
+/// use ratatui_layout::participant::{
+///     LayoutParticipant, MeasureContext, ParticipantFn, RenderContext,
+/// };
+///
+/// let labels = ["yes", "no"];
+/// let mut participant = ParticipantFn::new(
+///     |id: usize, _, _| SizeHint::exact(Size::new(labels[id].len() as u16, 1)),
+///     |_, _: Rect, _: &mut Buffer, _| {},
+/// );
+///
+/// assert_eq!(
+///     participant
+///         .measure(1, MeasureConstraint::Unbounded, MeasureContext)
+///         .preferred,
+///     Size::new(2, 1),
+/// );
+/// participant.render(
+///     1,
+///     Rect::new(0, 0, 2, 1),
+///     &mut Buffer::empty(Rect::new(0, 0, 2, 1)),
+///     RenderContext::default(),
+/// );
+/// ```
+#[derive(Debug, Clone)]
+pub struct ParticipantFn<M, R> {
+    measure: M,
+    render: R,
+}
+
+impl<M, R> ParticipantFn<M, R> {
+    /// Creates a participant from measure and render closures.
+    ///
+    /// The measure closure is called through `&self`; the render closure is called through
+    /// `&mut self`, matching the trait contract.
+    ///
+    /// # Examples
+    ///
+    /// Build a small participant adapter for a test or local component:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::{Rect, Size};
+    /// use ratatui_core::text::Line;
+    /// use ratatui_core::widgets::Widget;
+    /// use ratatui_layout::measure::SizeHint;
+    /// use ratatui_layout::participant::{
+    ///     LayoutParticipant, MeasureContext, ParticipantFn, RenderContext,
+    /// };
+    ///
+    /// let labels = ["open", "save"];
+    /// let mut participant = ParticipantFn::new(
+    ///     |id: usize, _, _: MeasureContext| SizeHint::exact(Size::new(labels[id].len() as u16, 1)),
+    ///     |id: usize, area: Rect, buf: &mut Buffer, _: RenderContext| {
+    ///         Line::from(labels[id]).render(area, buf);
+    ///     },
+    /// );
+    /// let mut buf = Buffer::empty(Rect::new(0, 0, 10, 1));
+    ///
+    /// assert_eq!(
+    ///     participant
+    ///         .measure(1, Default::default(), MeasureContext)
+    ///         .preferred,
+    ///     Size::new(4, 1)
+    /// );
+    /// participant.render(0, Rect::new(0, 0, 4, 1), &mut buf, RenderContext::default());
+    /// ```
+    pub const fn new(measure: M, render: R) -> Self {
+        Self { measure, render }
+    }
+}
+
+impl<Id, M, R> LayoutParticipant<Id> for ParticipantFn<M, R>
+where
+    M: Fn(Id, MeasureConstraint, MeasureContext) -> SizeHint,
+    R: FnMut(Id, Rect, &mut Buffer, RenderContext),
+{
+    fn measure(&self, id: Id, constraint: MeasureConstraint, ctx: MeasureContext) -> SizeHint {
+        (self.measure)(id, constraint, ctx)
+    }
+
+    fn render(&mut self, id: Id, area: Rect, buf: &mut Buffer, ctx: RenderContext) {
+        (self.render)(id, area, buf, ctx);
+    }
+}

--- a/crates/ratatui-layout/src/pointer.rs
+++ b/crates/ratatui-layout/src/pointer.rs
@@ -1,0 +1,1239 @@
+//! Pointer targets for backend-agnostic routing.
+//!
+//! Layout hit testing can answer "which rectangle contains this position?" but pointer handling
+//! usually needs a more specific contract: some visible regions are disabled, some are not pointer
+//! targets at all, and overlapping popups should route events according to z-order. This module
+//! records those pointer-specific data without depending on crossterm, termion, or any other event
+//! backend.
+//!
+//! [`PointerTargets`](crate::pointer::PointerTargets) is the pointer counterpart to
+//! [`crate::regions::Regions`]. It records the visible regions that can receive pointer events
+//! during the current frame, while persistent pressed and hover state stays in
+//! [`PointerState`](crate::pointer::PointerState). Use it when a previous render pass should
+//! route the next pointer event back to app-owned data.
+//!
+//! The module separates the pointer workflow into three levels:
+//!
+//! - [`PointerTarget`](crate::pointer::PointerTarget) names one rectangular region that can receive
+//!   pointer input. It adds pointer-specific data, such as disabled state and z-order, that a plain
+//!   [`crate::regions::Region`] does not carry.
+//! - [`PointerTargets`](crate::pointer::PointerTargets) is rebuilt during rendering from the
+//!   targets that are actually visible. It can merge child values, translate child-local
+//!   coordinates into parent coordinates, clip targets to a viewport, and hit test terminal
+//!   positions.
+//! - [`PointerState`](crate::pointer::PointerState) is application state that survives between
+//!   events. It remembers hover and press state so an app can distinguish a click from a press that
+//!   was released somewhere else.
+//!
+//! This is enough for backend-agnostic routing without making the target set know about crossterm,
+//! termion, mouse buttons, or callbacks. The backend converts its event position into
+//! [`ratatui_core::layout::Position`], routes through the previous frame's targets, and then the
+//! app decides what action the hit id means.
+//!
+//! # Types
+//!
+//! - [`PointerTarget`](crate::pointer::PointerTarget) describes one pointer-sensitive rectangle.
+//! - [`PointerTargets`](crate::pointer::PointerTargets) stores the visible targets from one frame
+//!   and performs hit testing.
+//! - [`PointerState`](crate::pointer::PointerState) stores hover and pressed ids across input
+//!   events.
+//! - [`PointerPhase`](crate::pointer::PointerPhase) describes backend-agnostic hover, press, and
+//!   release phases.
+//!
+//! Normal Ratatui widgets remain the better tool when pointer input is not needed, or when the
+//! input can be handled by one known widget without hit testing a set of visible targets.
+//!
+//! See [`crate::docs::interaction`] for how pointer targets, focus targets, selection, and cursor
+//! requests stay separate while sharing ids.
+//!
+//! # Examples
+//!
+//! Disabled targets remain in the target set but do not win hit testing:
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+//!
+//! let targets = PointerTargets::from_targets([
+//!     PointerTarget::new("content", Rect::new(0, 0, 10, 1)),
+//!     PointerTarget::new("disabled-popup", Rect::new(0, 0, 10, 1))
+//!         .z(10)
+//!         .disabled(true),
+//! ]);
+//!
+//! assert_eq!(targets.hit_test((1, 0)).unwrap().id, "content");
+//! ```
+//!
+//! Press/release matching helps distinguish a click from a press that moved away:
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::pointer::{PointerState, PointerTarget, PointerTargets};
+//!
+//! let targets = PointerTargets::from_targets([
+//!     PointerTarget::new("left", Rect::new(0, 0, 5, 1)),
+//!     PointerTarget::new("right", Rect::new(5, 0, 5, 1)),
+//! ]);
+//! let mut mouse = PointerState::default();
+//!
+//! mouse.press(&targets, (1, 0));
+//! assert!(mouse.release(&targets, (7, 0)).is_none());
+//! ```
+
+use alloc::vec::Vec;
+use core::slice;
+
+use ratatui_core::layout::{Position, Rect};
+
+use crate::regions::{Hit, Region};
+
+/// A rectangular pointer target for app-owned content.
+///
+/// [`PointerTarget`](crate::pointer::PointerTarget) exists so pointer routing can be described
+/// without depending on a terminal backend's event type. It owns only frame-local data: the app id,
+/// area, disabled state, and z-order. It does not store callbacks, widgets, or persistent
+/// hover/pressed state; that belongs in [`PointerState`](crate::pointer::PointerState).
+///
+/// Use a [`PointerTarget`](crate::pointer::PointerTarget) instead of relying only on
+/// [`crate::regions::Region`] when a visible region has pointer-specific behavior: disabled state,
+/// different z-order, or an area that should accept pointer events even though it is not a render
+/// region.
+///
+/// # Constructors and setters
+///
+/// - [`PointerTarget::new`](crate::pointer::PointerTarget::new) creates an enabled target at
+///   z-order zero.
+/// - [`PointerTarget::from_region`](crate::pointer::PointerTarget::from_region) converts a
+///   [`Region`](crate::regions::Region) when layout regions and pointer targets match.
+/// - [`PointerTarget::z`](crate::pointer::PointerTarget::z) changes hit-test priority for overlays
+///   or floating controls.
+/// - [`PointerTarget::disabled`](crate::pointer::PointerTarget::disabled) keeps a target visible
+///   while skipping real routing.
+///
+/// # Geometry helpers
+///
+/// - [`PointerTarget::contains`](crate::pointer::PointerTarget::contains) checks whether a terminal
+///   position falls inside the target.
+/// - [`PointerTarget::local_position`](crate::pointer::PointerTarget::local_position) converts
+///   terminal coordinates into target-local coordinates.
+/// - [`PointerTarget::translate`](crate::pointer::PointerTarget::translate) places a child-local
+///   target in parent coordinates.
+/// - [`PointerTarget::clip_to`](crate::pointer::PointerTarget::clip_to) trims a target to a
+///   viewport and drops it when fully hidden.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::pointer::PointerTarget;
+///
+/// let target = PointerTarget::new("save", Rect::new(10, 2, 8, 1)).z(2);
+///
+/// assert!(target.contains((11, 2)));
+/// assert_eq!(target.local_position((11, 2)).unwrap().x, 1);
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PointerTarget<Id = usize> {
+    /// Application-owned target id.
+    ///
+    /// The id should be something the app can route back to its own state. Use integers for
+    /// generated indexed regions, string names for examples or diagnostics, enums for normal app
+    /// controls, and stable record keys for reorderable rows or cells.
+    pub id: Id,
+    /// Current frame area for the pointer target.
+    ///
+    /// Hit testing uses terminal coordinates against this rectangle.
+    pub area: Rect,
+    /// Z ordering used for hit testing.
+    ///
+    /// Higher values win. Equal z values fall back to insertion order, where later targets win.
+    pub z: u16,
+    /// Whether pointer routing should skip this target.
+    ///
+    /// Disabled targets remain in the target set for diagnostics and stable structure, but
+    /// [`PointerTargets::hit_test`](crate::pointer::PointerTargets::hit_test) ignores them.
+    pub disabled: bool,
+}
+
+impl<Id> PointerTarget<Id> {
+    /// Creates an enabled pointer target with z-order zero.
+    ///
+    /// This is the normal constructor when render order alone is enough for hit-test tie breaking.
+    ///
+    /// # Examples
+    ///
+    /// Build a target for a rendered button and route a click through a target set:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let plan =
+    ///     PointerTargets::new().target(PointerTarget::new("save-button", Rect::new(10, 2, 6, 1)));
+    ///
+    /// assert_eq!(plan.hit_test((12, 2)).unwrap().id, "save-button");
+    /// ```
+    pub const fn new(id: Id, area: Rect) -> Self {
+        Self {
+            id,
+            area,
+            z: 0,
+            disabled: false,
+        }
+    }
+
+    /// Sets the target z-order.
+    ///
+    /// Use this for overlays, popups, and floating controls that should receive pointer events
+    /// before lower visual layers.
+    ///
+    /// # Examples
+    ///
+    /// Let a popup route clicks before the content underneath it:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::from_targets([
+    ///     PointerTarget::new("editor", Rect::new(0, 0, 20, 5)),
+    ///     PointerTarget::new("palette", Rect::new(4, 1, 10, 3)).z(10),
+    /// ]);
+    ///
+    /// assert_eq!(plan.hit_test((5, 2)).unwrap().id, "palette");
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub const fn z(mut self, z: u16) -> Self {
+        self.z = z;
+        self
+    }
+
+    /// Sets whether the target is disabled.
+    ///
+    /// Disabled targets are useful when a control should remain visible but should not react to
+    /// hover, press, or release.
+    ///
+    /// # Examples
+    ///
+    /// Keep a disabled command visible while allowing the enabled target below to receive input:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::from_targets([
+    ///     PointerTarget::new("fallback", Rect::new(0, 0, 10, 1)),
+    ///     PointerTarget::new("disabled-save", Rect::new(0, 0, 10, 1))
+    ///         .z(5)
+    ///         .disabled(true),
+    /// ]);
+    ///
+    /// assert_eq!(plan.hit_test((1, 0)).unwrap().id, "fallback");
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub const fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Creates a pointer target from a layout region.
+    ///
+    /// This is the quickest path when every rendered region is also interactive. The target copies
+    /// the region id, area, and z-order, but starts enabled because [`crate::regions::Region`] has
+    /// no pointer disabled state.
+    ///
+    /// # Examples
+    ///
+    /// Derive pointer targets from a region set when every region behaves like a button:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let layout = Regions::from_regions(
+    ///     Rect::new(0, 0, 12, 1),
+    ///     [
+    ///         Region::new("open", Rect::new(0, 0, 6, 1)),
+    ///         Region::new("save", Rect::new(6, 0, 6, 1)),
+    ///     ],
+    /// );
+    /// let plan = PointerTargets::from_targets(
+    ///     layout
+    ///         .regions()
+    ///         .iter()
+    ///         .copied()
+    ///         .map(PointerTarget::from_region)
+    ///         .collect::<Vec<_>>(),
+    /// );
+    ///
+    /// assert_eq!(plan.hit_test((7, 0)).unwrap().id, "save");
+    /// ```
+    pub fn from_region(region: Region<Id>) -> Self {
+        Self {
+            id: region.id,
+            area: region.area,
+            z: region.z,
+            disabled: false,
+        }
+    }
+
+    /// Returns true when the target area contains the position.
+    ///
+    /// This checks geometry only. It does not consider
+    /// [`PointerTarget::disabled`](crate::pointer::PointerTarget::disabled); use
+    /// [`PointerTargets::hit_test`](crate::pointer::PointerTargets::hit_test) when routing real
+    /// events.
+    ///
+    /// # Examples
+    ///
+    /// Use geometry checks for diagnostics or pointer previews before full routing:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::PointerTarget;
+    ///
+    /// let tab = PointerTarget::new("settings", Rect::new(8, 0, 10, 1)).disabled(true);
+    ///
+    /// assert!(tab.contains((9, 0)));
+    /// assert!(tab.disabled);
+    /// ```
+    pub fn contains<P: Into<Position>>(&self, position: P) -> bool {
+        self.area.contains(position.into())
+    }
+
+    /// Returns the position relative to the target area.
+    ///
+    /// Local coordinates let a row, cell, or control interpret the event without re-subtracting its
+    /// terminal origin.
+    ///
+    /// # Examples
+    ///
+    /// Convert a table-row hit into a column offset inside that row:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Position, Rect};
+    /// use ratatui_layout::pointer::PointerTarget;
+    ///
+    /// let row = PointerTarget::new("row-42", Rect::new(5, 10, 30, 1));
+    ///
+    /// assert_eq!(row.local_position((12, 10)), Some(Position::new(7, 0)));
+    /// assert_eq!(row.local_position((12, 11)), None);
+    /// ```
+    pub fn local_position<P: Into<Position>>(&self, position: P) -> Option<Position> {
+        let position = position.into();
+        self.contains(position).then(|| {
+            Position::new(
+                position.x.saturating_sub(self.area.x),
+                position.y.saturating_sub(self.area.y),
+            )
+        })
+    }
+
+    /// Moves the target area by a signed offset.
+    ///
+    /// This supports component composition where a child produced local coordinates and a parent
+    /// later places that child in the terminal.
+    ///
+    /// # Examples
+    ///
+    /// Move a child component's local button target into its parent panel:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::PointerTarget;
+    ///
+    /// let local_button = PointerTarget::new("ok", Rect::new(0, 0, 4, 1));
+    /// let placed = local_button.translate(10, 3);
+    ///
+    /// assert_eq!(placed.area, Rect::new(10, 3, 4, 1));
+    /// ```
+    #[must_use = "method returns the translated target"]
+    pub const fn translate(mut self, dx: i16, dy: i16) -> Self {
+        self.area = translate_rect(self.area, dx, dy);
+        self
+    }
+
+    /// Clips the target to a visible viewport.
+    ///
+    /// Returns `None` when the target is entirely outside the viewport.
+    ///
+    /// # Examples
+    ///
+    /// Clip an oversized row target to the visible viewport before hit testing:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::PointerTarget;
+    ///
+    /// let row = PointerTarget::new("row", Rect::new(0, 2, 20, 1));
+    /// let visible = row.clip_to(Rect::new(4, 0, 8, 4)).unwrap();
+    ///
+    /// assert_eq!(visible.area, Rect::new(4, 2, 8, 1));
+    /// assert!(row.clip_to(Rect::new(0, 4, 8, 2)).is_none());
+    /// ```
+    pub fn clip_to(mut self, viewport: Rect) -> Option<Self> {
+        self.area = intersect(self.area, viewport)?;
+        Some(self)
+    }
+}
+
+/// Pointer targets produced by one render pass.
+///
+/// [`PointerTargets`](crate::pointer::PointerTargets) owns no application state and has no
+/// backend-specific event knowledge. Store it after rendering, then route the next event by
+/// converting its coordinates to a [`ratatui_core::layout::Position`].
+///
+/// A target set is rebuilt every frame from visible targets. The app should keep long-lived
+/// interaction data, such as the target currently pressed, in
+/// [`PointerState`](crate::pointer::PointerState).
+///
+/// # Constructors and builders
+///
+/// - [`PointerTargets::new`](crate::pointer::PointerTargets::new) creates an empty target set for
+///   incremental construction.
+/// - [`PointerTargets::from_targets`](crate::pointer::PointerTargets::from_targets) creates a
+///   target set from targets already collected during rendering.
+/// - [`PointerTargets::target`](crate::pointer::PointerTargets::target) appends one target in
+///   builder style.
+/// - [`PointerTargets::region`](crate::pointer::PointerTargets::region) appends a whole-region
+///   target, which is useful for scrollable pane backgrounds and blank viewport space.
+/// - [`PointerTargets::extend`](crate::pointer::PointerTargets::extend) appends many targets to an
+///   existing target set.
+/// - [`PointerTargets::merge`](crate::pointer::PointerTargets::merge) combines child values while
+///   preserving ordering.
+///
+/// # Inspection and routing
+///
+/// - [`PointerTargets::targets`](crate::pointer::PointerTargets::targets) and
+///   [`PointerTargets::iter`](crate::pointer::PointerTargets::iter) expose the visible targets for
+///   diagnostics or derived state.
+/// - [`PointerTargets::hit_test`](crate::pointer::PointerTargets::hit_test) routes a terminal
+///   position to the topmost enabled target and returns a [`crate::regions::Hit`] with local
+///   coordinates.
+///
+/// # Composition
+///
+/// - [`PointerTargets::map_id`](crate::pointer::PointerTargets::map_id) converts child ids into
+///   parent app ids.
+/// - [`PointerTargets::translate`](crate::pointer::PointerTargets::translate) places child-local
+///   targets in parent coordinates.
+/// - [`PointerTargets::clip_to`](crate::pointer::PointerTargets::clip_to) removes hidden target
+///   regions before storing targets for input.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+///
+/// let local = PointerTargets::from_targets([PointerTarget::new(0, Rect::new(0, 0, 10, 1))]);
+/// let parent = local.translate(5, 2).map_id(|id| ("toolbar", id));
+///
+/// assert_eq!(parent.hit_test((6, 2)).unwrap().id, ("toolbar", 0));
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PointerTargets<Id = usize> {
+    targets: Vec<PointerTarget<Id>>,
+}
+
+impl<Id> Default for PointerTargets<Id> {
+    fn default() -> Self {
+        Self {
+            targets: Vec::new(),
+        }
+    }
+}
+
+impl<Id> PointerTargets<Id> {
+    /// Creates an empty pointer target collection.
+    ///
+    /// Use this before the first frame or for components with no pointer-interactive regions.
+    ///
+    /// # Examples
+    ///
+    /// Build toolbar targets as each command is rendered:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::new()
+    ///     .target(PointerTarget::new("open", Rect::new(0, 0, 6, 1)))
+    ///     .target(PointerTarget::new("save", Rect::new(6, 0, 6, 1)));
+    ///
+    /// assert_eq!(plan.hit_test((7, 0)).unwrap().id, "save");
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            targets: Vec::new(),
+        }
+    }
+
+    /// Creates a pointer target collection from targets.
+    ///
+    /// Targets keep their input order. That order matters when two enabled targets have the same
+    /// z-order and both contain a position.
+    ///
+    /// # Examples
+    ///
+    /// Build a target set from the targets returned by a component render function:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let rendered_targets = vec![
+    ///     PointerTarget::new("row-1", Rect::new(0, 0, 20, 1)),
+    ///     PointerTarget::new("row-2", Rect::new(0, 1, 20, 1)),
+    /// ];
+    /// let plan = PointerTargets::from_targets(rendered_targets);
+    ///
+    /// assert_eq!(plan.targets().len(), 2);
+    /// ```
+    pub fn from_targets(targets: impl Into<Vec<PointerTarget<Id>>>) -> Self {
+        Self {
+            targets: targets.into(),
+        }
+    }
+
+    /// Adds a target and returns the modified target set.
+    ///
+    /// This builder-style method appends in render order.
+    ///
+    /// # Examples
+    ///
+    /// Add a row target only after the row is known to be visible:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let row_area = Rect::new(0, 3, 40, 1);
+    /// let plan = PointerTargets::new().target(PointerTarget::new(3, row_area));
+    ///
+    /// assert_eq!(plan.hit_test((2, 3)).unwrap().id, 3);
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn target(mut self, target: PointerTarget<Id>) -> Self {
+        self.targets.push(target);
+        self
+    }
+
+    /// Adds an enabled target for a whole region and returns the modified plan.
+    ///
+    /// Use this when the pointer-sensitive area is the region itself rather than a specific region.
+    /// The most common case is mouse-wheel routing over blank space in a scrollable pane: visible
+    /// rows may not fill the whole pane, but the pane should still receive scroll input anywhere
+    /// inside its viewport.
+    ///
+    /// # Examples
+    ///
+    /// Route wheel input over a list viewport even when the pointer is below the last visible row:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::PointerTargets;
+    ///
+    /// let plan = PointerTargets::new().region("queue-pane", Rect::new(0, 0, 30, 10));
+    ///
+    /// assert_eq!(plan.hit_test((2, 8)).unwrap().id, "queue-pane");
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn region(self, id: Id, area: Rect) -> Self {
+        self.target(PointerTarget::new(id, area))
+    }
+
+    /// Returns all pointer targets in render order.
+    ///
+    /// # Examples
+    ///
+    /// Inspect visible targets when deriving hoverable ids for a status view:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::from_targets([
+    ///     PointerTarget::new("open", Rect::new(0, 0, 4, 1)),
+    ///     PointerTarget::new("save", Rect::new(5, 0, 4, 1)),
+    /// ]);
+    /// let ids: Vec<_> = plan.targets().iter().map(|target| target.id).collect();
+    ///
+    /// assert_eq!(ids, ["open", "save"]);
+    /// ```
+    pub fn targets(&self) -> &[PointerTarget<Id>] {
+        &self.targets
+    }
+
+    /// Returns an iterator over targets.
+    ///
+    /// # Examples
+    ///
+    /// Count enabled targets before deciding whether to enable mouse capture:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::from_targets([
+    ///     PointerTarget::new("enabled", Rect::new(0, 0, 8, 1)),
+    ///     PointerTarget::new("disabled", Rect::new(0, 1, 8, 1)).disabled(true),
+    /// ]);
+    ///
+    /// assert_eq!(plan.iter().filter(|target| !target.disabled).count(), 1);
+    /// ```
+    pub fn iter(&self) -> slice::Iter<'_, PointerTarget<Id>> {
+        self.targets.iter()
+    }
+
+    /// Extends the target set with additional targets.
+    ///
+    /// Appended targets win same-z hit-test ties over earlier targets.
+    ///
+    /// # Examples
+    ///
+    /// Append a modal target after base content so it wins same-z overlap by render order:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let mut plan =
+    ///     PointerTargets::from_targets([PointerTarget::new("content", Rect::new(0, 0, 10, 3))]);
+    /// plan.extend([PointerTarget::new("modal", Rect::new(2, 1, 6, 1))]);
+    ///
+    /// assert_eq!(plan.hit_test((3, 1)).unwrap().id, "modal");
+    /// ```
+    pub fn extend<I>(&mut self, targets: I)
+    where
+        I: IntoIterator<Item = PointerTarget<Id>>,
+    {
+        self.targets.extend(targets);
+    }
+
+    /// Returns a target set containing this set's targets followed by another set's targets.
+    ///
+    /// # Examples
+    ///
+    /// Merge child component targets into the parent frame snapshot:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let list =
+    ///     PointerTargets::from_targets([PointerTarget::new("list-row", Rect::new(0, 0, 20, 1))]);
+    /// let footer = PointerTargets::from_targets([PointerTarget::new("help", Rect::new(0, 3, 20, 1))]);
+    ///
+    /// let plan = list.merge(footer);
+    /// assert_eq!(plan.hit_test((1, 3)).unwrap().id, "help");
+    /// ```
+    #[must_use = "method returns the merged target set"]
+    pub fn merge(mut self, other: Self) -> Self {
+        self.extend(other.targets);
+        self
+    }
+
+    /// Maps target ids while preserving areas, z-order, and disabled state.
+    ///
+    /// Use this when a child component exposes local ids and the parent needs to route events using
+    /// a larger application id type.
+    ///
+    /// # Examples
+    ///
+    /// Wrap child ids in an app-level enum before storing the plan:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum Region {
+    ///     Palette(usize),
+    /// }
+    ///
+    /// let child = PointerTargets::from_targets([PointerTarget::new(0, Rect::new(0, 0, 5, 1))]);
+    /// let plan = child.map_id(Region::Palette);
+    ///
+    /// assert_eq!(plan.hit_test((1, 0)).unwrap().id, Region::Palette(0));
+    /// ```
+    pub fn map_id<NextId, F>(self, mut map: F) -> PointerTargets<NextId>
+    where
+        F: FnMut(Id) -> NextId,
+    {
+        PointerTargets::from_targets(
+            self.targets
+                .into_iter()
+                .map(|target| PointerTarget {
+                    id: map(target.id),
+                    area: target.area,
+                    z: target.z,
+                    disabled: target.disabled,
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Moves all target areas by a signed offset.
+    ///
+    /// # Examples
+    ///
+    /// Place child targets solved in local coordinates into a parent area:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let child = PointerTargets::from_targets([PointerTarget::new("item", Rect::new(0, 0, 8, 1))]);
+    /// let placed = child.translate(10, 4);
+    ///
+    /// assert_eq!(placed.hit_test((11, 4)).unwrap().id, "item");
+    /// ```
+    #[must_use = "method returns the translated target set"]
+    pub fn translate(mut self, dx: i16, dy: i16) -> Self {
+        self.targets = self
+            .targets
+            .into_iter()
+            .map(|target| target.translate(dx, dy))
+            .collect();
+        self
+    }
+
+    /// Clips all target areas to a viewport and drops targets outside it.
+    ///
+    /// This keeps hidden child controls from receiving pointer events after a parent applies
+    /// viewport or container clipping.
+    ///
+    /// # Examples
+    ///
+    /// Drop targets outside a scroll viewport before saving the previous-frame snapshot:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::from_targets([
+    ///     PointerTarget::new("visible", Rect::new(0, 1, 10, 1)),
+    ///     PointerTarget::new("hidden", Rect::new(0, 5, 10, 1)),
+    /// ])
+    /// .clip_to(Rect::new(0, 0, 10, 3));
+    ///
+    /// assert_eq!(plan.targets().len(), 1);
+    /// assert_eq!(plan.hit_test((1, 1)).unwrap().id, "visible");
+    /// ```
+    #[must_use = "method returns the clipped target set"]
+    pub fn clip_to(mut self, viewport: Rect) -> Self {
+        self.targets = self
+            .targets
+            .into_iter()
+            .filter_map(|target| target.clip_to(viewport))
+            .collect();
+        self
+    }
+}
+
+impl<Id: Copy> PointerTargets<Id> {
+    /// Returns the topmost enabled target containing the position.
+    ///
+    /// Higher z-order wins. For matching z-order values, later targets win because they are
+    /// usually rendered later.
+    ///
+    /// # Examples
+    ///
+    /// Route a backend mouse event position to an app command and local x/y coordinates:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::from_targets([PointerTarget::new(
+    ///     "status-command",
+    ///     Rect::new(20, 10, 12, 1),
+    /// )]);
+    ///
+    /// let hit = plan.hit_test((24, 10)).unwrap();
+    /// assert_eq!(hit.id, "status-command");
+    /// assert_eq!((hit.relative_x, hit.relative_y), (4, 0));
+    /// ```
+    pub fn hit_test<P: Into<Position>>(&self, position: P) -> Option<Hit<Id>> {
+        let position = position.into();
+        let mut hit = None;
+        for target in self
+            .targets
+            .iter()
+            .filter(|target| !target.disabled && target.area.contains(position))
+        {
+            if hit.is_none_or(|current: &PointerTarget<Id>| target.z >= current.z) {
+                hit = Some(target);
+            }
+        }
+
+        hit.map(|target| Hit {
+            id: target.id,
+            area: target.area,
+            relative_x: position.x.saturating_sub(target.area.x),
+            relative_y: position.y.saturating_sub(target.area.y),
+        })
+    }
+}
+
+impl<'a, Id> IntoIterator for &'a PointerTargets<Id> {
+    type Item = &'a PointerTarget<Id>;
+    type IntoIter = slice::Iter<'a, PointerTarget<Id>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Backend-agnostic pointer event phase.
+///
+/// [`PointerPhase`](crate::pointer::PointerPhase) is the small piece of event information that
+/// [`PointerState::route`](crate::pointer::PointerState::route) needs to update hover and press
+/// state. Terminal backends still own their full event types, button data, modifiers, drag policy,
+/// and scroll events. Convert only the phases that should use ordinary hover/press/release routing
+/// into this enum.
+///
+/// # Variants
+///
+/// - [`PointerPhase::Hover`](crate::pointer::PointerPhase::Hover) updates the hovered target.
+/// - [`PointerPhase::Press`](crate::pointer::PointerPhase::Press) records the target where a click
+///   or drag began.
+/// - [`PointerPhase::Release`](crate::pointer::PointerPhase::Release) clears the pressed target and
+///   returns a hit only when release lands on the same target.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::pointer::{PointerPhase, PointerState, PointerTarget, PointerTargets};
+///
+/// let targets =
+///     PointerTargets::from_targets([PointerTarget::new("button", Rect::new(0, 0, 8, 1))]);
+/// let mut mouse = PointerState::default();
+///
+/// mouse.route(&targets, (2, 0), PointerPhase::Press);
+/// assert_eq!(
+///     mouse
+///         .route(&targets, (2, 0), PointerPhase::Release)
+///         .unwrap()
+///         .id,
+///     "button"
+/// );
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum PointerPhase {
+    /// Pointer moved over the terminal without starting or completing an activation.
+    #[default]
+    Hover,
+    /// Pointer button was pressed.
+    Press,
+    /// Pointer button was released.
+    Release,
+}
+
+/// Persistent pointer state for an app or component.
+///
+/// [`PointerState`](crate::pointer::PointerState) stores event-to-event data: the currently hovered
+/// target and the target that was pressed. It does not own target geometry; pair it with the
+/// current or previous [`PointerTargets`](crate::pointer::PointerTargets) to update that data from
+/// terminal coordinates.
+///
+/// The state is intentionally small because different backends report different event details. Apps
+/// can keep backend-specific button, modifier, or drag information next to this state when needed.
+///
+/// # Accessors and updates
+///
+/// - [`PointerState::hovered`](crate::pointer::PointerState::hovered) returns the id most recently
+///   hit by hover, press, or release.
+/// - [`PointerState::pressed`](crate::pointer::PointerState::pressed) returns the id where the
+///   current press began.
+/// - [`PointerState::clear`](crate::pointer::PointerState::clear) resets state when a view closes
+///   or the pointer leaves the terminal.
+/// - [`PointerState::hover`](crate::pointer::PointerState::hover) updates hover from a
+///   [`PointerTargets`](crate::pointer::PointerTargets) and terminal position.
+/// - [`PointerState::press`](crate::pointer::PointerState::press) records where a click or drag
+///   began.
+/// - [`PointerState::release`](crate::pointer::PointerState::release) clears the press and returns
+///   a hit only when press and release match.
+/// - [`PointerState::route`](crate::pointer::PointerState::route) applies a backend-agnostic
+///   [`PointerPhase`](crate::pointer::PointerPhase) to the state.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::pointer::{PointerState, PointerTarget, PointerTargets};
+///
+/// let targets =
+///     PointerTargets::from_targets([PointerTarget::new("button", Rect::new(0, 0, 6, 1))]);
+/// let mut state = PointerState::default();
+///
+/// state.hover(&targets, (2, 0));
+/// assert_eq!(state.hovered(), Some("button"));
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PointerState<Id = usize> {
+    hovered: Option<Id>,
+    pressed: Option<Id>,
+}
+
+impl<Id> Default for PointerState<Id> {
+    fn default() -> Self {
+        Self {
+            hovered: None,
+            pressed: None,
+        }
+    }
+}
+
+impl<Id> PointerState<Id> {
+    /// Returns the currently hovered target id.
+    ///
+    /// This is updated by [`PointerState::hover`](crate::pointer::PointerState::hover),
+    /// [`PointerState::press`](crate::pointer::PointerState::press), and
+    /// [`PointerState::release`](crate::pointer::PointerState::release).
+    ///
+    /// # Examples
+    ///
+    /// Drive hover styling from the previous frame's pointer target collection:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerState, PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::from_targets([PointerTarget::new("delete", Rect::new(0, 0, 8, 1))]);
+    /// let mut mouse = PointerState::default();
+    ///
+    /// mouse.hover(&plan, (2, 0));
+    /// assert_eq!(mouse.hovered(), Some("delete"));
+    /// ```
+    pub const fn hovered(&self) -> Option<Id>
+    where
+        Id: Copy,
+    {
+        self.hovered
+    }
+
+    /// Returns the target id that was pressed.
+    ///
+    /// A later release only counts as activation when it lands on the same target.
+    ///
+    /// # Examples
+    ///
+    /// Remember which target began a click while the pointer is still down:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerState, PointerTarget, PointerTargets};
+    ///
+    /// let plan =
+    ///     PointerTargets::from_targets([PointerTarget::new("drag-handle", Rect::new(0, 0, 4, 1))]);
+    /// let mut mouse = PointerState::default();
+    ///
+    /// mouse.press(&plan, (1, 0));
+    /// assert_eq!(mouse.pressed(), Some("drag-handle"));
+    /// ```
+    pub const fn pressed(&self) -> Option<Id>
+    where
+        Id: Copy,
+    {
+        self.pressed
+    }
+
+    /// Clears hover and pressed state.
+    ///
+    /// Use this when a view is closed, the pointer leaves the terminal, or the previous frame is no
+    /// longer relevant.
+    ///
+    /// # Examples
+    ///
+    /// Clear stale state when closing a popup that owned the pressed target:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerState, PointerTarget, PointerTargets};
+    ///
+    /// let plan =
+    ///     PointerTargets::from_targets([PointerTarget::new("popup-ok", Rect::new(0, 0, 8, 1))]);
+    /// let mut mouse = PointerState::default();
+    ///
+    /// mouse.press(&plan, (1, 0));
+    /// mouse.clear();
+    ///
+    /// assert_eq!(mouse.hovered(), None);
+    /// assert_eq!(mouse.pressed(), None);
+    /// ```
+    pub fn clear(&mut self) {
+        self.hovered = None;
+        self.pressed = None;
+    }
+}
+
+impl<Id: Copy + Eq> PointerState<Id> {
+    /// Routes a backend-agnostic pointer phase through a pointer target collection.
+    ///
+    /// Use this after converting a terminal backend event into
+    /// [`PointerPhase`](crate::pointer::PointerPhase) plus terminal coordinates. The method
+    /// centralizes the ordinary hover, press, and release state transitions while leaving
+    /// scroll, drag, buttons, and modifiers to the application.
+    ///
+    /// # Examples
+    ///
+    /// Convert a press/release pair into an activation only when both phases hit the same target:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerPhase, PointerState, PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::from_targets([
+    ///     PointerTarget::new("open", Rect::new(0, 0, 6, 1)),
+    ///     PointerTarget::new("save", Rect::new(6, 0, 6, 1)),
+    /// ]);
+    /// let mut mouse = PointerState::default();
+    ///
+    /// mouse.route(&plan, (1, 0), PointerPhase::Press);
+    /// assert!(mouse.route(&plan, (7, 0), PointerPhase::Release).is_none());
+    ///
+    /// mouse.route(&plan, (7, 0), PointerPhase::Press);
+    /// assert_eq!(
+    ///     mouse
+    ///         .route(&plan, (7, 0), PointerPhase::Release)
+    ///         .unwrap()
+    ///         .id,
+    ///     "save"
+    /// );
+    /// ```
+    pub fn route<P: Into<Position>>(
+        &mut self,
+        plan: &PointerTargets<Id>,
+        position: P,
+        phase: PointerPhase,
+    ) -> Option<Hit<Id>> {
+        match phase {
+            PointerPhase::Hover => self.hover(plan, position),
+            PointerPhase::Press => self.press(plan, position),
+            PointerPhase::Release => self.release(plan, position),
+        }
+    }
+
+    /// Updates hover state from a position and returns the hit target.
+    ///
+    /// # Examples
+    ///
+    /// Update app hover state from a mouse-move event:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerState, PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::from_targets([
+    ///     PointerTarget::new("row-0", Rect::new(0, 0, 20, 1)),
+    ///     PointerTarget::new("row-1", Rect::new(0, 1, 20, 1)),
+    /// ]);
+    /// let mut mouse = PointerState::default();
+    ///
+    /// let hit = mouse.hover(&plan, (3, 1)).unwrap();
+    ///
+    /// assert_eq!(hit.id, "row-1");
+    /// assert_eq!(mouse.hovered(), Some("row-1"));
+    /// ```
+    pub fn hover<P: Into<Position>>(
+        &mut self,
+        plan: &PointerTargets<Id>,
+        position: P,
+    ) -> Option<Hit<Id>> {
+        let hit = plan.hit_test(position);
+        self.hovered = hit.map(|hit| hit.id);
+        hit
+    }
+
+    /// Records a press from a position and returns the hit target.
+    ///
+    /// The pressed id is stored so [`PointerState::release`](crate::pointer::PointerState::release)
+    /// can distinguish a click from a press that moved to another target before release.
+    ///
+    /// # Examples
+    ///
+    /// Start a click only when the press begins on an enabled target:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerState, PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::from_targets([PointerTarget::new("save", Rect::new(0, 0, 6, 1))]);
+    /// let mut mouse = PointerState::default();
+    ///
+    /// assert_eq!(mouse.press(&plan, (2, 0)).unwrap().id, "save");
+    /// assert_eq!(mouse.pressed(), Some("save"));
+    /// ```
+    pub fn press<P: Into<Position>>(
+        &mut self,
+        plan: &PointerTargets<Id>,
+        position: P,
+    ) -> Option<Hit<Id>> {
+        let hit = self.hover(plan, position);
+        self.pressed = hit.map(|hit| hit.id);
+        hit
+    }
+
+    /// Releases the current press and returns the released target when press and release match.
+    ///
+    /// # Examples
+    ///
+    /// Treat a press/release on the same target as activation, and a moved release as cancellation:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::pointer::{PointerState, PointerTarget, PointerTargets};
+    ///
+    /// let plan = PointerTargets::from_targets([
+    ///     PointerTarget::new("open", Rect::new(0, 0, 6, 1)),
+    ///     PointerTarget::new("save", Rect::new(6, 0, 6, 1)),
+    /// ]);
+    /// let mut mouse = PointerState::default();
+    ///
+    /// mouse.press(&plan, (1, 0));
+    /// assert!(mouse.release(&plan, (7, 0)).is_none());
+    ///
+    /// mouse.press(&plan, (7, 0));
+    /// assert_eq!(mouse.release(&plan, (7, 0)).unwrap().id, "save");
+    /// ```
+    pub fn release<P: Into<Position>>(
+        &mut self,
+        plan: &PointerTargets<Id>,
+        position: P,
+    ) -> Option<Hit<Id>> {
+        let hit = self.hover(plan, position);
+        let released = hit.filter(|hit| Some(hit.id) == self.pressed);
+        self.pressed = None;
+        released
+    }
+}
+
+const fn translate_rect(rect: Rect, dx: i16, dy: i16) -> Rect {
+    Rect::new(
+        translate_coordinate(rect.x, dx),
+        translate_coordinate(rect.y, dy),
+        rect.width,
+        rect.height,
+    )
+}
+
+const fn translate_coordinate(value: u16, delta: i16) -> u16 {
+    if delta.is_negative() {
+        value.saturating_sub(delta.unsigned_abs())
+    } else {
+        value.saturating_add(delta as u16)
+    }
+}
+
+fn intersect(a: Rect, b: Rect) -> Option<Rect> {
+    let x = a.x.max(b.x);
+    let y = a.y.max(b.y);
+    let right = a.right().min(b.right());
+    let bottom = a.bottom().min(b.bottom());
+
+    (x < right && y < bottom).then(|| Rect::new(x, y, right - x, bottom - y))
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn hit_test_prefers_topmost_enabled_target() {
+        let plan = PointerTargets::from_targets([
+            PointerTarget::new("bottom", Rect::new(0, 0, 4, 4)).z(1),
+            PointerTarget::new("disabled", Rect::new(0, 0, 4, 4))
+                .z(3)
+                .disabled(true),
+            PointerTarget::new("top", Rect::new(0, 0, 4, 4)).z(2),
+        ]);
+
+        assert_eq!(plan.hit_test((1, 1)).map(|hit| hit.id), Some("top"));
+        assert_eq!(
+            plan.hit_test((1, 1))
+                .map(|hit| (hit.relative_x, hit.relative_y)),
+            Some((1, 1))
+        );
+    }
+
+    #[test]
+    fn press_release_requires_same_target() {
+        let plan = PointerTargets::from_targets([
+            PointerTarget::new("first", Rect::new(0, 0, 2, 1)),
+            PointerTarget::new("second", Rect::new(2, 0, 2, 1)),
+        ]);
+        let mut state = PointerState::default();
+
+        assert_eq!(state.press(&plan, (0, 0)).map(|hit| hit.id), Some("first"));
+        assert_eq!(state.release(&plan, (2, 0)).map(|hit| hit.id), None);
+        assert_eq!(state.press(&plan, (2, 0)).map(|hit| hit.id), Some("second"));
+        assert_eq!(
+            state.release(&plan, (2, 0)).map(|hit| hit.id),
+            Some("second")
+        );
+    }
+
+    #[test]
+    fn route_applies_pointer_phase_state_transitions() {
+        let plan = PointerTargets::from_targets([
+            PointerTarget::new("first", Rect::new(0, 0, 2, 1)),
+            PointerTarget::new("second", Rect::new(2, 0, 2, 1)),
+        ]);
+        let mut state = PointerState::default();
+
+        assert_eq!(
+            state
+                .route(&plan, (0, 0), PointerPhase::Hover)
+                .map(|hit| hit.id),
+            Some("first")
+        );
+        assert_eq!(state.hovered(), Some("first"));
+
+        assert_eq!(
+            state
+                .route(&plan, (0, 0), PointerPhase::Press)
+                .map(|hit| hit.id),
+            Some("first")
+        );
+        assert_eq!(state.pressed(), Some("first"));
+        assert_eq!(
+            state
+                .route(&plan, (2, 0), PointerPhase::Release)
+                .map(|hit| hit.id),
+            None
+        );
+        assert_eq!(state.pressed(), None);
+    }
+
+    #[test]
+    fn clips_and_translates_targets() {
+        let plan = PointerTargets::from_targets([
+            PointerTarget::new("kept", Rect::new(1, 1, 4, 4)),
+            PointerTarget::new("dropped", Rect::new(10, 10, 1, 1)),
+        ])
+        .translate(1, 0)
+        .clip_to(Rect::new(0, 0, 4, 3));
+
+        assert_eq!(
+            plan.targets(),
+            &[PointerTarget::new("kept", Rect::new(2, 1, 2, 2))]
+        );
+    }
+
+    #[test]
+    fn region_adds_whole_area_target() {
+        let plan = PointerTargets::new().region("pane", Rect::new(0, 0, 10, 5));
+
+        assert_eq!(plan.hit_test((1, 4)).map(|hit| hit.id), Some("pane"));
+    }
+}

--- a/crates/ratatui-layout/src/record_list.rs
+++ b/crates/ratatui-layout/src/record_list.rs
@@ -1,0 +1,336 @@
+//! Durable-id adapter for virtual lists.
+//!
+//! [`crate::list::VirtualList`] works in source indexes because measurement and rendering need to
+//! ask an app-owned collection for item `n`. Real apps often want selection and input routing to
+//! use stable record ids instead, especially when rows can be filtered, sorted, inserted, or
+//! removed. [`VirtualRecordList`](crate::record_list::VirtualRecordList) bridges those two
+//! identities.
+//!
+//! # Types
+//!
+//! - [`VirtualRecordListState`](crate::record_list::VirtualRecordListState) stores index-based list
+//!   state plus durable-id selection.
+//! - [`VirtualRecordList`](crate::record_list::VirtualRecordList) computes or renders a list and
+//!   produces durable-id row regions.
+//! - [`VirtualRecordListLayout`](crate::record_list::VirtualRecordListLayout) exposes the
+//!   underlying list layout and durable row regions.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::record_list::VirtualRecordListState;
+//!
+//! let ids = ["api", "worker", "docs"];
+//! let mut state = VirtualRecordListState::new();
+//! state.select_id("worker", &ids);
+//! state.move_selection_by(1, &ids);
+//!
+//! assert_eq!(state.selected_id(), Some("docs"));
+//! assert_eq!(state.list_state().selected(), Some(2));
+//! ```
+
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::{Position, Rect};
+
+use crate::list::{ListItems, ListLayout, VirtualList, VirtualListState};
+use crate::regions::{Hit, Regions};
+use crate::selection::VisibleSelection;
+
+/// Persistent state for a [`VirtualRecordList`](crate::record_list::VirtualRecordList).
+///
+/// The state keeps two related views of selection:
+///
+/// - [`VirtualListState`] stores the source index needed by measurement and rendering.
+/// - [`VisibleSelection`](crate::selection::VisibleSelection) stores the durable record id used by
+///   application commands.
+///
+/// Keep this state beside the app collection and pass the current ordered id slice on each input or
+/// render pass. The adapter repairs stale ids and indexes against that slice.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct VirtualRecordListState<Id = usize> {
+    list: VirtualListState,
+    selection: VisibleSelection<Id>,
+}
+
+impl<Id> Default for VirtualRecordListState<Id> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Id> VirtualRecordListState<Id> {
+    /// Creates empty list and durable-selection state.
+    pub fn new() -> Self {
+        Self {
+            list: VirtualListState::default(),
+            selection: VisibleSelection::new(),
+        }
+    }
+
+    /// Returns the underlying index-based list state.
+    pub const fn list_state(&self) -> &VirtualListState {
+        &self.list
+    }
+
+    /// Returns mutable access to the underlying index-based list state.
+    ///
+    /// Use this for advanced scroll control that is still index-based. Prefer the durable-id
+    /// methods on this type for selection.
+    pub const fn list_state_mut(&mut self) -> &mut VirtualListState {
+        &mut self.list
+    }
+
+    /// Returns the durable visible selection state.
+    pub const fn selection(&self) -> &VisibleSelection<Id> {
+        &self.selection
+    }
+
+    /// Returns the selected durable record id.
+    pub const fn selected_id(&self) -> Option<Id>
+    where
+        Id: Copy,
+    {
+        self.selection.selected_id()
+    }
+
+    /// Selects a durable id and syncs the backing list index.
+    ///
+    /// Use this after pointer routing, command activation, or restoring selection from app state.
+    pub fn select_id(&mut self, id: Id, visible_ids: &[Id]) -> bool
+    where
+        Id: Copy + Eq,
+    {
+        let Some(index) = visible_ids.iter().position(|visible| *visible == id) else {
+            return false;
+        };
+        self.selection.select_visible(index, id);
+        self.list.select(Some(index));
+        true
+    }
+
+    /// Moves durable selection by a signed row delta.
+    ///
+    /// Keyboard row movement should normally call this rather than moving the raw list index so
+    /// app commands continue to work with durable ids.
+    pub fn move_selection_by(&mut self, delta: isize, visible_ids: &[Id]) -> Option<Id>
+    where
+        Id: Copy + Eq,
+    {
+        self.selection.move_by(delta, visible_ids);
+        self.list.select(self.selection.position());
+        self.selection.selected_id()
+    }
+
+    /// Scrolls the viewport without changing durable selection.
+    ///
+    /// This is the mouse-wheel path: move what is visible, leave the selected record alone, and let
+    /// the next layout decide whether that record is still visible.
+    pub const fn scroll_viewport_by(&mut self, delta: isize) {
+        self.list.scroll_viewport_by(delta);
+    }
+
+    /// Repairs durable and index selection against the current ordered ids.
+    ///
+    /// Call this after filtering, sorting, or replacing the collection. The previous durable id is
+    /// kept when possible; otherwise selection moves to the first visible id.
+    pub fn sync_ids(&mut self, visible_ids: &[Id])
+    where
+        Id: Copy + Eq,
+    {
+        self.selection.sync_ids(visible_ids);
+        self.list
+            .select_without_scrolling(self.selection.position());
+    }
+
+    fn prepare_for_layout(&mut self, visible_ids: &[Id])
+    where
+        Id: Copy + Eq,
+    {
+        self.sync_ids(visible_ids);
+        if self.list.scrolls_selected_into_view() {
+            self.list.select(self.selection.position());
+        }
+    }
+}
+
+/// Durable-id wrapper around [`VirtualList`].
+///
+/// The wrapper keeps the existing list measurement and rendering model, but returns row regions
+/// keyed by stable ids instead of source indexes. The app must pass an `ids` slice in the same
+/// order as the [`ListItems`] source.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct VirtualRecordList {
+    list: VirtualList,
+}
+
+impl VirtualRecordList {
+    /// Creates a durable-id virtual list adapter.
+    pub const fn new() -> Self {
+        Self {
+            list: VirtualList::new(),
+        }
+    }
+
+    /// Computes list layout and durable-id row regions without rendering.
+    ///
+    /// Use this when another widget owns row rendering but the app still needs virtualized
+    /// selection and pointer routing.
+    pub fn layout<Id, Items>(
+        self,
+        area: Rect,
+        state: &mut VirtualRecordListState<Id>,
+        ids: &[Id],
+        items: &Items,
+    ) -> VirtualRecordListLayout<Id>
+    where
+        Id: Copy + Eq,
+        Items: ListItems,
+    {
+        state.prepare_for_layout(ids);
+        let layout = self.list.layout(area, &mut state.list, items);
+        let regions = durable_regions(&layout, ids);
+        VirtualRecordListLayout { layout, regions }
+    }
+
+    /// Renders visible rows and returns durable-id row regions.
+    ///
+    /// This delegates measurement and row rendering to [`VirtualList`]. The durable adapter only
+    /// keeps selection ids and returned row regions aligned with the app's ids.
+    pub fn render<Id, Items>(
+        self,
+        area: Rect,
+        buf: &mut Buffer,
+        state: &mut VirtualRecordListState<Id>,
+        ids: &[Id],
+        items: &mut Items,
+    ) -> VirtualRecordListLayout<Id>
+    where
+        Id: Copy + Eq,
+        Items: ListItems,
+    {
+        state.prepare_for_layout(ids);
+        let layout = self.list.render(area, buf, &mut state.list, items);
+        let regions = durable_regions(&layout, ids);
+        VirtualRecordListLayout { layout, regions }
+    }
+}
+
+/// Solved output for a [`VirtualRecordList`](crate::record_list::VirtualRecordList) pass.
+///
+/// The underlying [`ListLayout`] remains available for scroll metrics and visible-row metadata.
+/// [`VirtualRecordListLayout::regions`](crate::record_list::VirtualRecordListLayout::regions) gives
+/// pointer and hit-test code durable record ids.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct VirtualRecordListLayout<Id = usize> {
+    layout: ListLayout,
+    regions: Regions<Id>,
+}
+
+impl<Id> VirtualRecordListLayout<Id> {
+    /// Returns the underlying index-based virtual-list layout.
+    pub const fn layout(&self) -> &ListLayout {
+        &self.layout
+    }
+
+    /// Returns row regions keyed by durable ids.
+    pub const fn regions(&self) -> &Regions<Id> {
+        &self.regions
+    }
+
+    /// Hit tests a position against durable row regions.
+    pub fn hit_test(&self, position: impl Into<Position>) -> Option<Hit<Id>>
+    where
+        Id: Copy,
+    {
+        self.regions.hit_test(position)
+    }
+
+    /// Selects the row at a pointer position.
+    ///
+    /// This updates both durable-id selection and the backing list index when the position hits a
+    /// visible row.
+    pub fn select_hit(
+        &self,
+        position: impl Into<Position>,
+        state: &mut VirtualRecordListState<Id>,
+        visible_ids: &[Id],
+    ) -> Option<Id>
+    where
+        Id: Copy + Eq,
+    {
+        let hit = self.hit_test(position)?;
+        state.select_id(hit.id, visible_ids);
+        Some(hit.id)
+    }
+}
+
+fn durable_regions<Id>(layout: &ListLayout, ids: &[Id]) -> Regions<Id>
+where
+    Id: Copy,
+{
+    layout.rows_regions(|index| ids[index])
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui_core::buffer::Buffer;
+    use ratatui_core::layout::Rect;
+
+    use super::{VirtualRecordList, VirtualRecordListState};
+    use crate::list::{ListItemContext, ListItems};
+    use crate::participant::MeasureContext;
+
+    struct Rows(usize);
+
+    impl ListItems for Rows {
+        fn len(&self) -> usize {
+            self.0
+        }
+
+        fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+            1
+        }
+
+        fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+    }
+
+    #[test]
+    fn keeps_durable_selection_across_reordered_ids() {
+        let ids = ["api", "worker", "docs"];
+        let mut state = VirtualRecordListState::new();
+
+        state.select_id("worker", &ids);
+        state.sync_ids(&["docs", "worker", "api"]);
+
+        assert_eq!(state.selected_id(), Some("worker"));
+        assert_eq!(state.list_state().selected(), Some(1));
+    }
+
+    #[test]
+    fn wheel_scroll_does_not_change_durable_selection() {
+        let ids = ["api", "worker", "docs"];
+        let mut state = VirtualRecordListState::new();
+        state.select_id("worker", &ids);
+
+        state.scroll_viewport_by(1);
+
+        assert_eq!(state.selected_id(), Some("worker"));
+    }
+
+    #[test]
+    fn hit_testing_uses_durable_row_ids() {
+        let ids = ["api", "worker", "docs"];
+        let mut rows = Rows(ids.len());
+        let mut state = VirtualRecordListState::new();
+        let layout =
+            VirtualRecordList::new().layout(Rect::new(0, 0, 20, 3), &mut state, &ids, &rows);
+
+        assert_eq!(layout.hit_test((0, 1)).unwrap().id, "worker");
+        assert_eq!(layout.select_hit((0, 2), &mut state, &ids), Some("docs"));
+        assert_eq!(state.selected_id(), Some("docs"));
+
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 20, 3));
+        VirtualRecordList::new().render(buffer.area, &mut buffer, &mut state, &ids, &mut rows);
+    }
+}

--- a/crates/ratatui-layout/src/regions.rs
+++ b/crates/ratatui-layout/src/regions.rs
@@ -1,0 +1,1354 @@
+//! Layout values and hit testing.
+//!
+//! A region set is the reusable result of a container's geometry calculation. It contains the area
+//! the container solved against and an ordered set of [`Region`](crate::regions::Region) values for
+//! externally owned content. The value is useful even when the caller does not render immediately:
+//! it can drive hit testing, status text, scrollbars, pointer handling, debugging output, or custom
+//! render passes.
+//!
+//! This module uses "area" and "region" for related but different ideas. An area is a
+//! [`ratatui_core::layout::Rect`]: geometry only. A region is a frame-local record built from an
+//! area plus the app id, clipping metadata, and z-order needed for routing and composition. If a
+//! rectangle is consumed immediately by `Widget::render`, call it an area. If it must be stored,
+//! hit tested, merged, or mapped back to app state after rendering, call it a region.
+//!
+//! Region sets deliberately store identifiers instead of widgets. The identifier can be an index,
+//! an enum, a stable application key, or any small value the caller can use to find its own data.
+//!
+//! A region set is not needed for every layout. When a render function can destructure rectangles
+//! and render immediately, Ratatui's built-in layout APIs are simpler. Use a region set when the
+//! rectangles need to cross a boundary: input handling, custom containers, tests, diagnostics, or
+//! external rendering.
+//!
+//! # Common uses
+//!
+//! - **Route input from the previous frame.** Store a [`Regions`](crate::regions::Regions) after
+//!   drawing, then call [`Regions::hit_test`](crate::regions::Regions::hit_test) when the next
+//!   pointer event arrives.
+//! - **Render app-owned children.** A parent can solve a list of [`Region`](crate::regions::Region)
+//!   values while the application keeps ownership of rows, cells, or controls.
+//! - **Compose child components.** A child can solve local geometry, then a parent can
+//!   [`translate`](crate::regions::Regions::translate), [`clip`](crate::regions::Regions::clip_to),
+//!   [`map`](crate::regions::Regions::map_id), and [`merge`](crate::regions::Regions::merge) it
+//!   into a larger region set.
+//! - **Make layout testable.** Tests can assert on assigned rectangles, clipping, and z-order
+//!   without rendering a terminal buffer.
+//!
+//! # Types
+//!
+//! - [`Clip`](crate::regions::Clip) stores per-edge clipping metadata for partially visible
+//!   regions.
+//! - [`Region`](crate::regions::Region) names one visible rectangle with an app-owned id, clip
+//!   metadata, and z-order.
+//! - [`Hit`](crate::regions::Hit) is returned by hit testing and includes the winning id plus local
+//!   coordinates.
+//! - [`Regions`](crate::regions::Regions) stores a parent area and ordered regions for one frame.
+//!
+//! A stored region set can route a later input event back to app data:
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::regions::{Region, Regions};
+//!
+//! let previous_frame = Regions::from_regions(
+//!     Rect::new(0, 0, 30, 1),
+//!     [
+//!         Region::new("open", Rect::new(0, 0, 10, 1)),
+//!         Region::new("save", Rect::new(10, 0, 10, 1)),
+//!     ],
+//! );
+//!
+//! assert_eq!(previous_frame.hit_test((12, 0)).unwrap().id, "save");
+//! ```
+//!
+//! Child values can also be composed without the parent owning child widgets:
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::regions::{Region, Regions};
+//!
+//! #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+//! enum AppRegion {
+//!     DialogField(usize),
+//!     Help,
+//! }
+//!
+//! let field_regions = [
+//!     Region::new(0, Rect::new(0, 0, 20, 1)),
+//!     Region::new(1, Rect::new(0, 1, 20, 1)),
+//! ];
+//! let fields = Regions::from_regions(Rect::new(0, 0, 20, 2), field_regions)
+//!     .map_id(AppRegion::DialogField)
+//!     .translate(5, 3);
+//! let help = Regions::from_regions(
+//!     Rect::new(0, 0, 40, 10),
+//!     [Region::new(AppRegion::Help, Rect::new(0, 9, 40, 1))],
+//! );
+//!
+//! let screen = help.merge(fields);
+//! assert_eq!(
+//!     screen.hit_test((6, 4)).unwrap().id,
+//!     AppRegion::DialogField(1)
+//! );
+//! ```
+//!
+//! See [`crate::docs::regions`] for the broader explanation of values as frame-local geometry
+//! data, and [`crate::docs::frame_snapshots`] for how region data compose with focus, pointer, and
+//! cursor requests.
+
+use alloc::vec::Vec;
+use core::slice;
+
+use ratatui_core::layout::{Position, Rect};
+
+/// Clipping metadata for a partially visible region.
+///
+/// Use [`Clip`](crate::regions::Clip) when a renderer needs to know that its assigned rectangle is
+/// only part of a larger logical item. A virtual list row, for example, may start above the
+/// viewport and receive only its visible tail. The region area tells the renderer where to draw;
+/// the clip metadata explains which edges were omitted.
+///
+/// Linear layouts usually leave this empty. Viewports and virtualized containers use it to preserve
+/// enough information for continuation markers, clipped-line rendering, or hit-test adjustment.
+///
+/// # Common uses
+///
+/// - A virtual list can tell a row renderer that the first two logical lines were scrolled off the
+///   top of the viewport.
+/// - A clipped overlay can preserve that an item continues beyond the right edge, even though the
+///   visible [`Region::area`](crate::regions::Region::area) is smaller.
+/// - Tests can assert that a container dropped hidden regions and correctly recorded the visible
+///   edges of partially visible regions.
+///
+/// # Method
+///
+/// - [`Clip::is_empty`](crate::regions::Clip::is_empty) reports whether any edge was clipped.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::regions::{Clip, Region};
+///
+/// let region = Region::new("row", Rect::new(0, 0, 10, 3))
+///     .clip_to(Rect::new(0, 1, 10, 1))
+///     .unwrap();
+///
+/// assert_eq!(region.area, Rect::new(0, 1, 10, 1));
+/// assert_eq!(region.clip.top, 1);
+/// assert_eq!(region.clip.bottom, 1);
+/// assert!(!region.clip.is_empty());
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Clip {
+    /// The number of cells clipped from the left side.
+    pub left: u16,
+    /// The number of cells clipped from the top side.
+    pub top: u16,
+    /// The number of cells clipped from the right side.
+    pub right: u16,
+    /// The number of cells clipped from the bottom side.
+    pub bottom: u16,
+}
+
+impl Clip {
+    /// Returns true when no edge is clipped.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::regions::Clip;
+    ///
+    /// assert!(Clip::default().is_empty());
+    /// assert!(
+    ///     !Clip {
+    ///         top: 1,
+    ///         ..Clip::default()
+    ///     }
+    ///     .is_empty()
+    /// );
+    /// ```
+    pub const fn is_empty(self) -> bool {
+        self.left == 0 && self.top == 0 && self.right == 0 && self.bottom == 0
+    }
+}
+
+/// A frame-local region for externally owned content.
+///
+/// Use [`Region`](crate::regions::Region) when the parent layout knows where something belongs but
+/// the application still owns the thing itself. For example, a grid can return a region with id
+/// `row * column_count + column`, and the app can use that id to look up and render the
+/// corresponding cell.
+///
+/// A [`Region`](crate::regions::Region) is the smallest unit in a
+/// [`Regions`](crate::regions::Regions). It answers: "render the external item with this id in this
+/// area, at this z-order, with this clipping metadata." The region does not store the external item
+/// or any widget state.
+///
+/// The [`Region::area`](crate::regions::Region::area) field is still a plain
+/// [`ratatui_core::layout::Rect`]. That is intentional: rendering code should pass the area to
+/// Ratatui widgets exactly as it would any other rectangle. The surrounding
+/// [`Region`](crate::regions::Region) exists only when the rectangle also needs an id, clipping
+/// metadata, or z-order for later coordination. A local variable named `area` should usually be a
+/// `Rect`; a value named `region` should usually be a `Region<Id>`.
+///
+/// # Type parameter
+///
+/// `Id` is chosen by the caller. The default is `usize`, which works well for row-major grids and
+/// indexed collections. String names are useful in examples, tests, diagnostics, and small
+/// prototypes because hit-test failures are easy to read. Enums are usually the best fit for app
+/// controls because they give the compiler a closed set of routes. Use a stable record key when the
+/// region identity should survive filtering, sorting, or reordering.
+///
+/// # Common uses
+///
+/// - Use `usize` ids for simple row-major grids, tabs, or toolbar segments where index order is the
+///   stable contract.
+/// - Use an enum id when a region represents a named control such as `Save`, `Cancel`, or `Search`.
+/// - Use a stable application key when rows can be filtered or reordered but input should still
+///   route to the same underlying item.
+/// - Use z-order on overlay regions so a floating popup can win hit testing over the content below.
+///
+/// # Constructors and setters
+///
+/// - [`Region::new`](crate::regions::Region::new) creates a fully visible z-zero region.
+/// - [`Region::clip`](crate::regions::Region::clip) sets clipping metadata when a viewport has
+///   already computed it.
+/// - [`Region::z`](crate::regions::Region::z) sets hit-test priority for overlays and floating
+///   regions.
+///
+/// # Geometry helpers
+///
+/// - [`Region::contains`](crate::regions::Region::contains) checks geometry without z-order.
+/// - [`Region::local_position`](crate::regions::Region::local_position) converts terminal
+///   coordinates to region-local coordinates.
+/// - [`Region::translate`](crate::regions::Region::translate) moves child-local geometry into
+///   parent coordinates.
+/// - [`Region::clip_to`](crate::regions::Region::clip_to) clips a region to a viewport and records
+///   omitted edges.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::regions::{Region, Regions};
+///
+/// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// enum Button {
+///     Save,
+///     Cancel,
+/// }
+///
+/// let button_regions = Regions::from_regions(
+///     Rect::new(0, 0, 20, 1),
+///     [
+///         Region::new(Button::Save, Rect::new(0, 0, 10, 1)),
+///         Region::new(Button::Cancel, Rect::new(10, 0, 10, 1)),
+///     ],
+/// );
+///
+/// assert_eq!(button_regions.hit_test((12, 0)).unwrap().id, Button::Cancel);
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Region<Id = usize> {
+    /// The external identifier this region belongs to.
+    ///
+    /// This is the value returned by hit testing and used by the app to find its own data.
+    pub id: Id,
+    /// The assigned area.
+    ///
+    /// Render app-owned content into this rectangle. The area is already clipped when the region
+    /// came from [`Region::clip_to`](crate::regions::Region::clip_to) or
+    /// [`Regions::clip_to`](crate::regions::Regions::clip_to).
+    pub area: Rect,
+    /// Clipping metadata for the assigned area.
+    ///
+    /// Renderers can use this to decide whether to skip logical content, draw continuation
+    /// markers, or adjust local hit coordinates.
+    pub clip: Clip,
+    /// Z ordering used for hit testing and overlays.
+    ///
+    /// Higher values win. When z-order ties, later regions win because they are usually rendered
+    /// later.
+    pub z: u16,
+}
+
+impl<Id> Region<Id> {
+    /// Creates a region with no clipping and z-order zero.
+    ///
+    /// Use this for ordinary regions where render order is enough and the region is fully visible.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let region = Region::new("status", Rect::new(0, 0, 10, 1));
+    /// assert_eq!(region.id, "status");
+    /// assert_eq!(region.z, 0);
+    /// ```
+    pub const fn new(id: Id, area: Rect) -> Self {
+        Self {
+            id,
+            area,
+            clip: Clip {
+                left: 0,
+                top: 0,
+                right: 0,
+                bottom: 0,
+            },
+            z: 0,
+        }
+    }
+
+    /// Sets the region clipping metadata.
+    ///
+    /// This is a fluent setter that is most useful when a viewport or virtualized layout has
+    /// already computed visible clipping and wants to preserve that information in the region.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Clip, Region};
+    ///
+    /// let region = Region::new("item", Rect::new(0, 0, 5, 1)).clip(Clip {
+    ///     left: 2,
+    ///     ..Clip::default()
+    /// });
+    ///
+    /// assert_eq!(region.clip.left, 2);
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub const fn clip(mut self, clip: Clip) -> Self {
+        self.clip = clip;
+        self
+    }
+
+    /// Sets the region z-order.
+    ///
+    /// Higher z-order regions win hit testing. When z-order is equal, later regions win because
+    /// they are usually rendered later.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let plan = Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 1),
+    ///     [
+    ///         Region::new("content", Rect::new(0, 0, 10, 1)),
+    ///         Region::new("popup", Rect::new(0, 0, 10, 1)).z(10),
+    ///     ],
+    /// );
+    ///
+    /// assert_eq!(plan.hit_test((1, 0)).unwrap().id, "popup");
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub const fn z(mut self, z: u16) -> Self {
+        self.z = z;
+        self
+    }
+
+    /// Returns true when the region area contains the position.
+    ///
+    /// This is a geometry-only check. It ignores z-order and disabled state. Use
+    /// [`Regions::hit_test`](crate::regions::Regions::hit_test) or
+    /// [`crate::pointer::PointerTargets::hit_test`] when routing real input.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let region = Region::new("button", Rect::new(4, 2, 8, 1));
+    /// assert!(region.contains((5, 2)));
+    /// assert!(!region.contains((3, 2)));
+    /// ```
+    pub fn contains<P: Into<Position>>(&self, position: P) -> bool {
+        self.area.contains(position.into())
+    }
+
+    /// Returns the position relative to the region area.
+    ///
+    /// Use this when routing pointer input to app-owned content that wants local coordinates
+    /// instead of terminal coordinates.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Position, Rect};
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let region = Region::new("cell", Rect::new(10, 5, 4, 2));
+    /// assert_eq!(region.local_position((12, 6)), Some(Position::new(2, 1)));
+    /// ```
+    pub fn local_position<P: Into<Position>>(&self, position: P) -> Option<Position> {
+        let position = position.into();
+        self.contains(position).then(|| {
+            Position::new(
+                position.x.saturating_sub(self.area.x),
+                position.y.saturating_sub(self.area.y),
+            )
+        })
+    }
+
+    /// Moves the region area by a signed offset.
+    ///
+    /// This is useful when child regions were solved in local coordinates and then need to be moved
+    /// into its parent area before being merged.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let region = Region::new("field", Rect::new(1, 1, 10, 1)).translate(20, 3);
+    /// assert_eq!(region.area, Rect::new(21, 4, 10, 1));
+    /// ```
+    #[must_use = "method returns the translated region"]
+    pub const fn translate(mut self, dx: i16, dy: i16) -> Self {
+        self.area = translate_rect(self.area, dx, dy);
+        self
+    }
+
+    /// Clips the region to a viewport area.
+    ///
+    /// Returns `None` when the region is entirely outside the viewport. The returned region
+    /// preserves the id and z-order and adds clipping metadata for the omitted edges.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::Region;
+    ///
+    /// let visible = Region::new("row", Rect::new(0, 0, 10, 3))
+    ///     .clip_to(Rect::new(0, 1, 10, 2))
+    ///     .unwrap();
+    ///
+    /// assert_eq!(visible.area, Rect::new(0, 1, 10, 2));
+    /// assert_eq!(visible.clip.top, 1);
+    /// ```
+    pub fn clip_to(mut self, viewport: Rect) -> Option<Self> {
+        let clipped = intersect(self.area, viewport)?;
+        self.clip.left = self
+            .clip
+            .left
+            .saturating_add(clipped.x.saturating_sub(self.area.x));
+        self.clip.top = self
+            .clip
+            .top
+            .saturating_add(clipped.y.saturating_sub(self.area.y));
+        self.clip.right = self
+            .clip
+            .right
+            .saturating_add(self.area.right().saturating_sub(clipped.right()));
+        self.clip.bottom = self
+            .clip
+            .bottom
+            .saturating_add(self.area.bottom().saturating_sub(clipped.bottom()));
+        self.area = clipped;
+        Some(self)
+    }
+}
+
+/// A hit-tested region with coordinates relative to the region area.
+///
+/// Use [`Hit`](crate::regions::Hit) when a pointer position needs to be routed back to application
+/// data. The id identifies the external item, and the relative coordinates let the item interpret
+/// the event in its own local coordinate system.
+///
+/// [`Hit`](crate::regions::Hit) is returned by
+/// [`Regions::hit_test`](crate::regions::Regions::hit_test). It carries the external id and both
+/// the absolute region area and the pointer position relative to that area.
+///
+/// # Common uses
+///
+/// - Route a click to an app-owned row or cell using [`Hit::id`](crate::regions::Hit::id).
+/// - Interpret pointer position inside a row using
+///   [`Hit::relative_x`](crate::regions::Hit::relative_x) and
+///   [`Hit::relative_y`](crate::regions::Hit::relative_y).
+/// - Keep the absolute [`Hit::area`](crate::regions::Hit::area) around when drawing feedback such
+///   as hover or selection styling on the next frame.
+///
+/// # Fields
+///
+/// - [`Hit::id`](crate::regions::Hit::id) is the app-owned id copied from the winning region or
+///   target.
+/// - [`Hit::area`](crate::regions::Hit::area) is the terminal-space rectangle that was hit.
+/// - [`Hit::relative_x`](crate::regions::Hit::relative_x) and
+///   [`Hit::relative_y`](crate::regions::Hit::relative_y) are coordinates inside
+///   [`Hit::area`](crate::regions::Hit::area).
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::regions::{Region, Regions};
+///
+/// let row_regions = Regions::from_regions(
+///     Rect::new(0, 0, 20, 2),
+///     [Region::new("row-42", Rect::new(2, 0, 10, 2))],
+/// );
+/// let hit = row_regions.hit_test((5, 1)).unwrap();
+///
+/// assert_eq!(hit.id, "row-42");
+/// assert_eq!((hit.relative_x, hit.relative_y), (3, 1));
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Hit<Id = usize> {
+    /// The external identifier hit.
+    ///
+    /// This is copied from the winning [`Region`](crate::regions::Region) and should be enough for
+    /// the app to route the event.
+    pub id: Id,
+    /// The region area.
+    ///
+    /// This is the absolute terminal rectangle that was hit.
+    pub area: Rect,
+    /// X coordinate relative to the region.
+    ///
+    /// Use this when a child renderer wants local coordinates.
+    pub relative_x: u16,
+    /// Y coordinate relative to the region.
+    ///
+    /// Use this when a row or cell needs to know which local line was hit.
+    pub relative_y: u16,
+}
+
+/// A reusable layout result with inspectable regions and hit testing.
+///
+/// Use [`Regions`](crate::regions::Regions) when a layout result needs to cross a boundary. A
+/// render function that immediately destructures rectangles can use Ratatui's built-in `Layout`
+/// directly. A component that needs to render app-owned items, route pointer events, test geometry,
+/// or report visible regions benefits from carrying a region set.
+///
+/// A [`Regions`](crate::regions::Regions) is a value object. It does not borrow the layout that
+/// produced it and it does not borrow the external content identified by its regions. Callers can
+/// pass it to render code, inspect it in tests, or keep it around until the next frame to route
+/// input.
+///
+/// # Common uses
+///
+/// 1. **Hit-test app-owned content.** A virtual list can expose visible row regions, and the app
+///    can route a pointer event to the row id returned by
+///    [`Regions::hit_test`](crate::regions::Regions::hit_test).
+/// 2. **Build parent regions from children.** A dialog can solve its fields locally, map field ids
+///    into an app enum, translate them into the dialog area, and merge them with overlay regions.
+/// 3. **Clip nested UI.** A scroll viewport can clip child regions so hidden rows do not receive
+///    input or appear in diagnostics.
+/// 4. **Assert layout behavior.** A test can compare
+///    [`Regions::regions`](crate::regions::Regions::regions) against expected rectangles without
+///    constructing widgets.
+///
+/// # Constructors and builders
+///
+/// - [`Regions::new`](crate::regions::Regions::new) creates an empty region set for a solved parent
+///   area.
+/// - [`Regions::from_regions`](crate::regions::Regions::from_regions) creates a region set from
+///   precomputed regions.
+/// - [`Regions::push`](crate::regions::Regions::push) and
+///   [`Regions::region`](crate::regions::Regions::region) append regions.
+/// - [`Regions::extend`](crate::regions::Regions::extend) and
+///   [`Regions::merge`](crate::regions::Regions::merge) combine child regions.
+///
+/// # Inspection and routing
+///
+/// - [`Regions::area`](crate::regions::Regions::area) returns the solved parent area.
+/// - [`Regions::regions`](crate::regions::Regions::regions) and
+///   [`Regions::iter`](crate::regions::Regions::iter) expose regions in render order.
+/// - [`Regions::ids`](crate::regions::Regions::ids) exposes only region ids for selection traversal
+///   or diagnostics.
+/// - [`Regions::is_empty`](crate::regions::Regions::is_empty) reports whether the set has regions.
+/// - [`Regions::hit_test`](crate::regions::Regions::hit_test) routes a terminal position to the
+///   topmost region and returns a [`Hit`](crate::regions::Hit).
+///
+/// # Composition
+///
+/// - [`Regions::map_id`](crate::regions::Regions::map_id) converts local ids into app-level ids.
+/// - [`Regions::translate`](crate::regions::Regions::translate) moves child-local geometry into
+///   parent coordinates.
+/// - [`Regions::clip_to`](crate::regions::Regions::clip_to) removes hidden regions and records
+///   clipping metadata.
+///
+/// The following example shows the render-loop shape without requiring a terminal buffer: app data
+/// stays in a slice, while the region set only stores ids and rectangles.
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::regions::{Region, Regions};
+///
+/// let labels = ["open", "save"];
+/// let label_regions = Regions::from_regions(
+///     Rect::new(0, 0, 20, 1),
+///     [
+///         Region::new(0, Rect::new(0, 0, 10, 1)),
+///         Region::new(1, Rect::new(10, 0, 10, 1)),
+///     ],
+/// );
+///
+/// let rendered_labels = label_regions
+///     .regions()
+///     .iter()
+///     .map(|region| labels[region.id])
+///     .collect::<Vec<_>>();
+///
+/// assert_eq!(rendered_labels, ["open", "save"]);
+/// ```
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::regions::{Region, Regions};
+///
+/// let field_regions = Regions::from_regions(
+///     Rect::new(0, 0, 20, 1),
+///     [Region::new("name", Rect::new(0, 0, 10, 1))],
+/// );
+///
+/// assert_eq!(field_regions.hit_test((3, 0)).unwrap().id, "name");
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Regions<Id = usize> {
+    area: Rect,
+    regions: Vec<Region<Id>>,
+}
+
+impl<Id> Regions<Id> {
+    /// Creates an empty region set for the given area.
+    ///
+    /// Use this when a container has no visible children but the solved area is still meaningful
+    /// for diagnostics, hit testing, or later mutation with
+    /// [`Regions::push`](crate::regions::Regions::push).
+    ///
+    /// # Examples
+    ///
+    /// Start with empty screen regions and append regions as components render:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let mut screen_regions = Regions::new(Rect::new(0, 0, 20, 1));
+    /// screen_regions.push(Region::new("status", Rect::new(0, 0, 20, 1)));
+    ///
+    /// assert_eq!(screen_regions.hit_test((3, 0)).unwrap().id, "status");
+    /// ```
+    pub const fn new(area: Rect) -> Self {
+        Self {
+            area,
+            regions: Vec::new(),
+        }
+    }
+
+    /// Creates a region set from precomputed regions.
+    ///
+    /// This is the common constructor for layout solvers. The regions retain their input order, and
+    /// that order is part of hit-test tie-breaking when z-order is equal.
+    ///
+    /// Use this when a layout helper has already solved every child rectangle and wants to return
+    /// one inspectable [`Regions`](crate::regions::Regions) value to the caller.
+    ///
+    /// # Examples
+    ///
+    /// Return app-owned button regions from a small layout helper:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let button_regions = Regions::from_regions(
+    ///     Rect::new(0, 0, 16, 1),
+    ///     [
+    ///         Region::new("ok", Rect::new(0, 0, 8, 1)),
+    ///         Region::new("cancel", Rect::new(8, 0, 8, 1)),
+    ///     ],
+    /// );
+    ///
+    /// assert_eq!(button_regions.regions()[1].id, "cancel");
+    /// ```
+    pub fn from_regions(area: Rect, regions: impl Into<Vec<Region<Id>>>) -> Self {
+        Self {
+            area,
+            regions: regions.into(),
+        }
+    }
+
+    /// Returns the area the region set was solved for.
+    ///
+    /// This is the parent area, not the union of all regions. Empty space and clipped content may
+    /// make those values differ.
+    ///
+    /// # Examples
+    ///
+    /// Keep the solved parent area for diagnostics even when there are no regions:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::Regions;
+    ///
+    /// let plan = Regions::<()>::new(Rect::new(0, 0, 80, 24));
+    ///
+    /// assert_eq!(plan.area(), Rect::new(0, 0, 80, 24));
+    /// ```
+    pub const fn area(&self) -> Rect {
+        self.area
+    }
+
+    /// Returns all regions.
+    ///
+    /// Regions are returned in render order. Later regions are considered later-rendered for
+    /// hit-test ties.
+    ///
+    /// This is the main render loop API: iterate the regions, look up app-owned data by
+    /// [`Region::id`](crate::regions::Region::id), and render into
+    /// [`Region::area`](crate::regions::Region::area).
+    ///
+    /// # Examples
+    ///
+    /// Use region ids to look up app-owned labels during rendering:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let labels = ["open", "save"];
+    /// let plan = Regions::from_regions(
+    ///     Rect::new(0, 0, 20, 1),
+    ///     [
+    ///         Region::new(0, Rect::new(0, 0, 10, 1)),
+    ///         Region::new(1, Rect::new(10, 0, 10, 1)),
+    ///     ],
+    /// );
+    /// let rendered: Vec<_> = plan
+    ///     .regions()
+    ///     .iter()
+    ///     .map(|region| labels[region.id])
+    ///     .collect();
+    ///
+    /// assert_eq!(rendered, ["open", "save"]);
+    /// ```
+    pub fn regions(&self) -> &[Region<Id>] {
+        &self.regions
+    }
+
+    /// Returns region ids in render order.
+    ///
+    /// Use this when another state object needs only the visible identities, not the rectangles.
+    /// The most common case is selection traversal: a region set already knows which controls or
+    /// rows are visible, and [`crate::selection::SelectionState`] can move through those ids
+    /// without learning about geometry.
+    ///
+    /// # Examples
+    ///
+    /// Drive selection traversal from the ids visible in a frame-local region set:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let plan = Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 2),
+    ///     [
+    ///         Region::new("first", Rect::new(0, 0, 10, 1)),
+    ///         Region::new("second", Rect::new(0, 1, 10, 1)),
+    ///     ],
+    /// );
+    /// let visible = plan.ids().copied().collect::<Vec<_>>();
+    /// let mut selection = SelectionState::new(SelectionMode::Single);
+    /// selection.select_next(&visible);
+    ///
+    /// assert_eq!(selection.primary(), Some("first"));
+    /// ```
+    pub fn ids(&self) -> impl Iterator<Item = &Id> {
+        self.regions.iter().map(|region| &region.id)
+    }
+
+    /// Pairs regions with another id list in render order.
+    ///
+    /// Use this when a layout helper emits structural positions but rendering and routing should
+    /// use application ids. A toolbar is the common case: a [`Grid`](crate::grid::Grid) may produce
+    /// [`GridPosition`](crate::grid::GridPosition) regions, while the app wants to render and route
+    /// `Command` enum values. Pairing regions and ids in one iterator keeps render code and
+    /// frame-snapshot construction from each rebuilding the same index mapping.
+    ///
+    /// The iterator stops at the shorter input. That makes it useful for visible subsets, but fixed
+    /// layouts should still keep tests around the expected count so missing controls are caught
+    /// where the layout is defined.
+    ///
+    /// # Examples
+    ///
+    /// Render a toolbar with command ids instead of grid coordinates:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::grid::{Grid, GridPosition};
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum Command {
+    ///     Edit,
+    ///     Save,
+    /// }
+    ///
+    /// let grid = Grid::new(
+    ///     [Constraint::Length(1)],
+    ///     [Constraint::Length(4), Constraint::Length(4)],
+    /// )
+    /// .layout(Rect::new(0, 0, 8, 1));
+    /// let paired = grid
+    ///     .cells()
+    ///     .zip_ids(&[Command::Edit, Command::Save])
+    ///     .map(|(region, command)| (region.id, command))
+    ///     .collect::<Vec<_>>();
+    ///
+    /// assert_eq!(paired[0], (GridPosition::new(0, 0), Command::Edit));
+    /// ```
+    pub fn zip_ids<'a, OtherId: Copy>(
+        &'a self,
+        ids: &'a [OtherId],
+    ) -> impl Iterator<Item = (&'a Region<Id>, OtherId)> + 'a {
+        self.regions.iter().zip(ids.iter().copied())
+    }
+
+    /// Returns the first region with the requested id.
+    ///
+    /// This is the structural-layout lookup API. Use it when a region set represents named areas
+    /// such as a page header, body, and footer. Iterating
+    /// [`Regions::regions`](crate::regions::Regions::regions) remains the better tool for
+    /// repeated rows where duplicate ids are expected or where render order matters more than
+    /// direct lookup.
+    ///
+    /// If a region set contains duplicate ids, this returns the first matching region in render
+    /// order. For fixed page structure, prefer unique ids so the lookup reads like a total map
+    /// from region name to rectangle.
+    ///
+    /// # Examples
+    ///
+    /// Look up a named body region after solving a page column:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::Column;
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum PageSlot {
+    ///     Header,
+    ///     Body,
+    /// }
+    ///
+    /// let page_slots = [
+    ///     (PageSlot::Header, Constraint::Length(1)),
+    ///     (PageSlot::Body, Constraint::Fill(1)),
+    /// ];
+    /// let page = Column::named(page_slots).regions(Rect::new(0, 0, 20, 5));
+    ///
+    /// assert_eq!(page.region_for(PageSlot::Body).unwrap().area.height, 4);
+    /// ```
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "enum ids are the normal lookup case, and value lookup keeps call sites readable"
+    )]
+    pub fn region_for(&self, id: Id) -> Option<&Region<Id>>
+    where
+        Id: Eq,
+    {
+        self.regions.iter().find(|region| region.id == id)
+    }
+
+    /// Returns the area of the first region with the requested id.
+    ///
+    /// This is a convenience wrapper around
+    /// [`Regions::region_for`](crate::regions::Regions::region_for) for the common case where a
+    /// parent layout only needs a child region's rectangle. Use
+    /// [`Regions::region_for`](crate::regions::Regions::region_for) when code also needs
+    /// clipping or z-order metadata.
+    ///
+    /// # Examples
+    ///
+    /// Pass a named body area to a nested row:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::linear::{Column, Row};
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum PageSlot {
+    ///     Header,
+    ///     Body,
+    /// }
+    ///
+    /// let page_slots = [
+    ///     (PageSlot::Header, Constraint::Length(1)),
+    ///     (PageSlot::Body, Constraint::Fill(1)),
+    /// ];
+    /// let page = Column::named(page_slots).regions(Rect::new(0, 0, 20, 5));
+    /// let body_area = page.area_for(PageSlot::Body).unwrap();
+    /// let body = Row::new([Constraint::Fill(1)]).regions(body_area);
+    ///
+    /// assert_eq!(body.regions()[0].area, Rect::new(0, 1, 20, 4));
+    /// ```
+    pub fn area_for(&self, id: Id) -> Option<Rect>
+    where
+        Id: Eq,
+    {
+        self.region_for(id).map(|region| region.area)
+    }
+
+    /// Returns an iterator over regions.
+    ///
+    /// This is equivalent to iterating over `&plan`.
+    ///
+    /// # Examples
+    ///
+    /// Collect visible ids for selection traversal:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let plan = Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 2),
+    ///     [
+    ///         Region::new("first", Rect::new(0, 0, 10, 1)),
+    ///         Region::new("second", Rect::new(0, 1, 10, 1)),
+    ///     ],
+    /// );
+    /// let visible: Vec<_> = plan.iter().map(|region| region.id).collect();
+    ///
+    /// assert_eq!(visible, ["first", "second"]);
+    /// ```
+    pub fn iter(&self) -> slice::Iter<'_, Region<Id>> {
+        self.regions.iter()
+    }
+
+    /// Adds a region to the region set.
+    ///
+    /// Pushed regions are appended after existing regions and therefore win same-z hit-test ties
+    /// over earlier regions.
+    ///
+    /// This is useful for incremental builders, overlays, or tests that want to start from
+    /// [`Regions::new`](crate::regions::Regions::new) and add regions one at a time.
+    ///
+    /// # Examples
+    ///
+    /// Append a popup region after the base content so it wins same-z ties:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let mut plan = Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 2),
+    ///     [Region::new("content", Rect::new(0, 0, 10, 2))],
+    /// );
+    /// plan.push(Region::new("popup", Rect::new(0, 0, 10, 2)));
+    ///
+    /// assert_eq!(plan.hit_test((1, 1)).unwrap().id, "popup");
+    /// ```
+    pub fn push(&mut self, region: Region<Id>) {
+        self.regions.push(region);
+    }
+
+    /// Adds a region and returns the modified region set.
+    ///
+    /// Use this fluent form when building values inline, especially overlays or small test values.
+    ///
+    /// # Examples
+    ///
+    /// Build a compact previous-frame snapshot inline:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let plan =
+    ///     Regions::new(Rect::new(0, 0, 8, 1)).region(Region::new("button", Rect::new(0, 0, 8, 1)));
+    ///
+    /// assert_eq!(plan.hit_test((2, 0)).unwrap().id, "button");
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn region(mut self, region: Region<Id>) -> Self {
+        self.push(region);
+        self
+    }
+
+    /// Extends the region set with regions from another iterator.
+    ///
+    /// Use this when a layout solver already has an iterator of regions and wants to append them
+    /// without allocating an intermediate child region set.
+    ///
+    /// # Examples
+    ///
+    /// Append row regions produced by an iterator:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let mut plan = Regions::new(Rect::new(0, 0, 10, 2));
+    /// plan.extend((0..2).map(|row| Region::new(row, Rect::new(0, row as u16, 10, 1))));
+    ///
+    /// assert_eq!(plan.regions().len(), 2);
+    /// ```
+    pub fn extend<I>(&mut self, regions: I)
+    where
+        I: IntoIterator<Item = Region<Id>>,
+    {
+        self.regions.extend(regions);
+    }
+
+    /// Returns a region set containing this set's regions followed by another set's regions.
+    ///
+    /// The merged region set keeps this set's parent area. Later regions preserve their normal
+    /// hit-test tie-breaking behavior.
+    ///
+    /// Use this when a parent aggregates child component values. If the child was solved in local
+    /// coordinates, call [`Regions::translate`](crate::regions::Regions::translate) before merging.
+    ///
+    /// # Examples
+    ///
+    /// Merge footer regions with content regions:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let content = Regions::from_regions(
+    ///     Rect::new(0, 0, 20, 3),
+    ///     [Region::new("body", Rect::new(0, 0, 20, 2))],
+    /// );
+    /// let footer = Regions::from_regions(
+    ///     Rect::new(0, 0, 20, 3),
+    ///     [Region::new("status", Rect::new(0, 2, 20, 1))],
+    /// );
+    /// let frame = content.merge(footer);
+    ///
+    /// assert_eq!(frame.hit_test((1, 2)).unwrap().id, "status");
+    /// ```
+    #[must_use = "method returns the merged plan"]
+    pub fn merge(mut self, other: Self) -> Self {
+        self.extend(other.regions);
+        self
+    }
+
+    /// Maps region ids while preserving areas, clipping, and z-order.
+    ///
+    /// This lets a child component solve a local region set with simple indexes and then lift those
+    /// ids into an application enum or stable key before merging with a parent region set.
+    ///
+    /// Common examples include mapping row indexes to app record ids, mapping dialog field indexes
+    /// to a `Field` enum, or wrapping child ids in a parent enum variant.
+    ///
+    /// # Examples
+    ///
+    /// Convert child-local integer ids into an enum used by the app event router:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum AppRegion {
+    ///     Field(usize),
+    /// }
+    ///
+    /// let child = Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 1),
+    ///     [Region::new(0, Rect::new(0, 0, 10, 1))],
+    /// );
+    /// let parent = child.map_id(AppRegion::Field);
+    ///
+    /// assert_eq!(parent.hit_test((1, 0)).unwrap().id, AppRegion::Field(0));
+    /// ```
+    pub fn map_id<NextId, F>(self, mut map: F) -> Regions<NextId>
+    where
+        F: FnMut(Id) -> NextId,
+    {
+        let regions: Vec<_> = self
+            .regions
+            .into_iter()
+            .map(|region| Region {
+                id: map(region.id),
+                area: region.area,
+                clip: region.clip,
+                z: region.z,
+            })
+            .collect();
+        Regions::from_regions(self.area, regions)
+    }
+
+    /// Moves the parent area and all regions by a signed offset.
+    ///
+    /// Use this when composing child regions that were solved relative to a local origin.
+    ///
+    /// A component can solve itself against `Rect::new(0, 0, width, height)`, then the parent can
+    /// translate the result into the actual terminal area where the component was drawn.
+    ///
+    /// # Examples
+    ///
+    /// Place child-local regions inside a parent panel:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let child = Regions::from_regions(
+    ///     Rect::new(0, 0, 8, 1),
+    ///     [Region::new("field", Rect::new(0, 0, 8, 1))],
+    /// );
+    /// let placed = child.translate(10, 4);
+    ///
+    /// assert_eq!(placed.area(), Rect::new(10, 4, 8, 1));
+    /// assert_eq!(placed.regions()[0].area, Rect::new(10, 4, 8, 1));
+    /// ```
+    #[must_use = "method returns the translated plan"]
+    pub fn translate(mut self, dx: i16, dy: i16) -> Self {
+        self.area = translate_rect(self.area, dx, dy);
+        self.regions = self
+            .regions
+            .into_iter()
+            .map(|region| region.translate(dx, dy))
+            .collect();
+        self
+    }
+
+    /// Clips all regions to the viewport area and drops regions outside it.
+    ///
+    /// The parent area is changed to the viewport so downstream code can treat the returned value
+    /// as visible child regions.
+    ///
+    /// Use this for scroll views, containers with inner clipping, and popups that should hide child
+    /// targets outside their visible boundary.
+    ///
+    /// # Examples
+    ///
+    /// Clip hidden rows before storing previous-frame hit-test regions:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let child = Regions::from_regions(
+    ///     Rect::new(0, 0, 10, 5),
+    ///     [
+    ///         Region::new("visible", Rect::new(0, 1, 10, 1)),
+    ///         Region::new("hidden", Rect::new(0, 4, 10, 1)),
+    ///     ],
+    /// );
+    /// let visible = child.clip_to(Rect::new(0, 0, 10, 3));
+    ///
+    /// assert_eq!(visible.regions().len(), 1);
+    /// assert_eq!(visible.regions()[0].id, "visible");
+    /// ```
+    #[must_use = "method returns the clipped plan"]
+    pub fn clip_to(mut self, viewport: Rect) -> Self {
+        self.area = viewport;
+        self.regions = self
+            .regions
+            .into_iter()
+            .filter_map(|region| region.clip_to(viewport))
+            .collect();
+        self
+    }
+
+    /// Returns true when the region set has no regions.
+    ///
+    /// Empty values are normal for empty collections, fully clipped children, and components that
+    /// expose an area but no externally addressable regions.
+    ///
+    /// # Examples
+    ///
+    /// Check whether an empty collection exposed any visible rows:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::Regions;
+    ///
+    /// let plan = Regions::<usize>::new(Rect::new(0, 0, 20, 4));
+    ///
+    /// assert!(plan.is_empty());
+    /// ```
+    pub const fn is_empty(&self) -> bool {
+        self.regions.is_empty()
+    }
+}
+
+const fn translate_rect(rect: Rect, dx: i16, dy: i16) -> Rect {
+    Rect::new(
+        translate_coordinate(rect.x, dx),
+        translate_coordinate(rect.y, dy),
+        rect.width,
+        rect.height,
+    )
+}
+
+const fn translate_coordinate(value: u16, delta: i16) -> u16 {
+    if delta.is_negative() {
+        value.saturating_sub(delta.unsigned_abs())
+    } else {
+        value.saturating_add(delta as u16)
+    }
+}
+
+fn intersect(a: Rect, b: Rect) -> Option<Rect> {
+    let x = a.x.max(b.x);
+    let y = a.y.max(b.y);
+    let right = a.right().min(b.right());
+    let bottom = a.bottom().min(b.bottom());
+
+    (x < right && y < bottom).then(|| Rect::new(x, y, right - x, bottom - y))
+}
+
+impl<'a, Id> IntoIterator for &'a Regions<Id> {
+    type Item = &'a Region<Id>;
+    type IntoIter = slice::Iter<'a, Region<Id>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<Id: Copy> Regions<Id> {
+    /// Returns the topmost region containing the position.
+    ///
+    /// Higher z-order wins. For matching z-order values, later regions win because they are usually
+    /// rendered later.
+    ///
+    /// Use this when layout geometry is enough to route input. If pointer behavior has disabled
+    /// state or pointer-only regions, build a [`crate::pointer::PointerTargets`] and route through
+    /// that instead.
+    ///
+    /// # Examples
+    ///
+    /// Route a previous-frame click to the topmost visible region:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::regions::{Region, Regions};
+    ///
+    /// let plan = Regions::from_regions(
+    ///     Rect::new(0, 0, 20, 2),
+    ///     [
+    ///         Region::new("body", Rect::new(0, 0, 20, 2)),
+    ///         Region::new("popup", Rect::new(4, 0, 8, 2)).z(10),
+    ///     ],
+    /// );
+    /// let hit = plan.hit_test((5, 1)).unwrap();
+    ///
+    /// assert_eq!(hit.id, "popup");
+    /// assert_eq!((hit.relative_x, hit.relative_y), (1, 1));
+    /// ```
+    pub fn hit_test<P: Into<Position>>(&self, position: P) -> Option<Hit<Id>> {
+        let position = position.into();
+        let mut hit = None;
+        for region in self
+            .regions
+            .iter()
+            .filter(|region| region.area.contains(position))
+        {
+            if hit.is_none_or(|current: &Region<Id>| region.z >= current.z) {
+                hit = Some(region);
+            }
+        }
+
+        hit.map(|region| Hit {
+            id: region.id,
+            area: region.area,
+            relative_x: position.x.saturating_sub(region.area.x),
+            relative_y: position.y.saturating_sub(region.area.y),
+        })
+    }
+}
+
+impl<Id> IntoIterator for Regions<Id> {
+    type Item = Region<Id>;
+    type IntoIter = alloc::vec::IntoIter<Region<Id>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.regions.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use ratatui_core::layout::Rect;
+
+    use super::*;
+
+    #[test]
+    fn hit_test_returns_relative_coordinates() {
+        let plan = Regions::from_regions(
+            Rect::new(0, 0, 20, 10),
+            [Region::new("row", Rect::new(2, 3, 5, 4))],
+        );
+
+        assert_eq!(
+            plan.hit_test((4, 5)),
+            Some(Hit {
+                id: "row",
+                area: Rect::new(2, 3, 5, 4),
+                relative_x: 2,
+                relative_y: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn hit_test_prefers_higher_z_then_later_regions() {
+        let plan = Regions::from_regions(
+            Rect::new(0, 0, 20, 10),
+            [
+                Region::new("first", Rect::new(0, 0, 10, 10)).z(2),
+                Region::new("second", Rect::new(0, 0, 10, 10)).z(1),
+                Region::new("third", Rect::new(0, 0, 10, 10)).z(2),
+            ],
+        );
+
+        assert_eq!(plan.hit_test((1, 1)).map(|hit| hit.id), Some("third"));
+    }
+
+    #[test]
+    fn clips_regions_to_viewport() {
+        let plan = Regions::from_regions(
+            Rect::new(0, 0, 10, 10),
+            [
+                Region::new("visible", Rect::new(2, 2, 4, 4)),
+                Region::new("clipped", Rect::new(8, 8, 4, 4)),
+                Region::new("hidden", Rect::new(20, 20, 2, 2)),
+            ],
+        )
+        .clip_to(Rect::new(0, 0, 10, 10));
+
+        assert_eq!(plan.regions().len(), 2);
+        assert_eq!(plan.regions()[1].area, Rect::new(8, 8, 2, 2));
+        assert_eq!(plan.regions()[1].clip.right, 2);
+        assert_eq!(plan.regions()[1].clip.bottom, 2);
+    }
+
+    #[test]
+    fn maps_and_translates_child_plans() {
+        let plan = Regions::from_regions(
+            Rect::new(0, 0, 4, 1),
+            [Region::new(0, Rect::new(1, 0, 2, 1))],
+        )
+        .map_id(|id| if id == 0 { "label" } else { "other" })
+        .translate(4, 2);
+
+        assert_eq!(plan.area(), Rect::new(4, 2, 4, 1));
+        assert_eq!(plan.regions()[0].id, "label");
+        assert_eq!(plan.regions()[0].area, Rect::new(5, 2, 2, 1));
+    }
+}

--- a/crates/ratatui-layout/src/scroll.rs
+++ b/crates/ratatui-layout/src/scroll.rs
@@ -1,0 +1,362 @@
+//! Scroll metrics for app-owned scrollbars and status displays.
+//!
+//! Layout primitives such as [`crate::viewport::Viewport`] and [`crate::list::VirtualList`] expose
+//! content length and offset, but applications often need the same derived scrollbar values.
+//! [`ScrollMetrics`](crate::scroll::ScrollMetrics) keeps that math in one inspectable value without
+//! making this crate render a scrollbar widget.
+//!
+//! Use a fixed status string or no scrollbar at all when the content always fits. Use this module
+//! when the app renders its own scrollbar, minimap, or scroll status from frame-local viewport
+//! data.
+//!
+//! # Type
+//!
+//! - [`ScrollMetrics`](crate::scroll::ScrollMetrics) stores one-axis content length, viewport
+//!   length, clamped offset, maximum offset, and scrollbar thumb geometry.
+//!
+//! See [`crate::docs::virtualization`] for how scroll metrics fit with viewports, virtual lists,
+//! and virtual tables.
+//!
+//! # Examples
+//!
+//! Compute scrollbar geometry from a virtualized layout and let the app decide how to render it:
+//!
+//! ```rust
+//! use ratatui_core::buffer::Buffer;
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::list::{ListItemContext, ListItems, VirtualList, VirtualListState};
+//! use ratatui_layout::participant::MeasureContext;
+//! use ratatui_layout::scroll::ScrollMetrics;
+//!
+//! struct Rows;
+//! impl ListItems for Rows {
+//!     fn len(&self) -> usize {
+//!         20
+//!     }
+//!     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+//!         1
+//!     }
+//!     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+//! }
+//!
+//! let mut state = VirtualListState::default();
+//! state.set_scroll(ratatui_layout::list::ScrollPosition::new(5, 0));
+//! let layout = VirtualList::new().layout(Rect::new(0, 0, 10, 5), &mut state, &Rows);
+//! let metrics = ScrollMetrics::from_list(&layout);
+//!
+//! assert_eq!(metrics.offset, 5);
+//! assert!(metrics.thumb_length > 0);
+//! ```
+
+use ratatui_core::layout::Size;
+
+use crate::list::ListLayout;
+use crate::viewport::ViewportLayout;
+
+/// Derived scrollbar geometry for one scroll axis.
+///
+/// Use [`ScrollMetrics`](crate::scroll::ScrollMetrics) when an app-owned scrollbar, minimap, or
+/// status line needs to describe a scroll position. It stores the full logical content length,
+/// visible viewport length, current offset, and the thumb range within the viewport.
+///
+/// # Constructors
+///
+/// - [`ScrollMetrics::new`](crate::scroll::ScrollMetrics::new) computes metrics directly for one
+///   scroll axis.
+/// - [`ScrollMetrics::from_list`](crate::scroll::ScrollMetrics::from_list) derives vertical metrics
+///   from a [`ListLayout`].
+/// - [`ScrollMetrics::horizontal`](crate::scroll::ScrollMetrics::horizontal) and
+///   [`ScrollMetrics::vertical`](crate::scroll::ScrollMetrics::vertical) derive metrics from a
+///   [`ViewportLayout`](crate::viewport::ViewportLayout).
+///
+/// # Inspection
+///
+/// - [`ScrollMetrics::fits`](crate::scroll::ScrollMetrics::fits) reports whether the content fits
+///   without scrolling.
+/// - [`ScrollMetrics::visible_range`](crate::scroll::ScrollMetrics::visible_range) returns the
+///   clamped content indexes visible in a simple fixed-height pane.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_layout::scroll::ScrollMetrics;
+///
+/// let metrics = ScrollMetrics::new(100, 10, 30);
+///
+/// assert_eq!(metrics.offset, 30);
+/// assert_eq!(metrics.max_offset, 90);
+/// assert!(metrics.thumb_length > 0);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ScrollMetrics {
+    /// Full scrollable content length on this axis.
+    pub content_length: u32,
+
+    /// Visible viewport length on this axis.
+    pub viewport_length: u16,
+
+    /// Clamped content offset on this axis.
+    pub offset: u32,
+
+    /// Maximum valid offset on this axis.
+    pub max_offset: u32,
+
+    /// Thumb start within the viewport axis.
+    pub thumb_start: u16,
+
+    /// Thumb length within the viewport axis.
+    pub thumb_length: u16,
+}
+
+impl ScrollMetrics {
+    /// Creates metrics for one scroll axis.
+    ///
+    /// # Examples
+    ///
+    /// Compute the scrollbar thumb for a list with more rows than the viewport can show:
+    ///
+    /// ```rust
+    /// use ratatui_layout::scroll::ScrollMetrics;
+    ///
+    /// let metrics = ScrollMetrics::new(50, 10, 15);
+    ///
+    /// assert_eq!(metrics.offset, 15);
+    /// assert_eq!(metrics.max_offset, 40);
+    /// assert_eq!(metrics.thumb_length, 2);
+    /// ```
+    pub fn new(content_length: u32, viewport_length: u16, offset: u32) -> Self {
+        let viewport = u32::from(viewport_length);
+        let max_offset = content_length.saturating_sub(viewport);
+        let offset = offset.min(max_offset);
+        let thumb_length = thumb_length(content_length, viewport_length);
+        let thumb_start = thumb_start(offset, max_offset, viewport_length, thumb_length);
+
+        Self {
+            content_length,
+            viewport_length,
+            offset,
+            max_offset,
+            thumb_start,
+            thumb_length,
+        }
+    }
+
+    /// Returns true when the content fits without scrolling.
+    ///
+    /// # Examples
+    ///
+    /// Hide scrollbar chrome when all content is visible:
+    ///
+    /// ```rust
+    /// use ratatui_layout::scroll::ScrollMetrics;
+    ///
+    /// let metrics = ScrollMetrics::new(5, 10, 0);
+    ///
+    /// assert!(metrics.fits());
+    /// ```
+    pub const fn fits(self) -> bool {
+        self.max_offset == 0
+    }
+
+    /// Returns the visible content range for fixed-height line or row panes.
+    ///
+    /// Use this when the content is already a slice of equally sized rows and the app only needs to
+    /// render the rows visible in the current viewport. Virtualized lists and tables expose richer
+    /// visible item metadata, but simple log panes and status panes often only need this range.
+    ///
+    /// # Examples
+    ///
+    /// Render the lines visible in a simple scroll pane:
+    ///
+    /// ```rust
+    /// use ratatui_layout::scroll::ScrollMetrics;
+    ///
+    /// let rows = ["zero", "one", "two", "three", "four"];
+    /// let metrics = ScrollMetrics::new(rows.len() as u32, 2, 3);
+    ///
+    /// assert_eq!(&rows[metrics.visible_range()], &["three", "four"]);
+    /// ```
+    pub fn visible_range(self) -> core::ops::Range<usize> {
+        let start = self.offset as usize;
+        let end = self
+            .offset
+            .saturating_add(u32::from(self.viewport_length))
+            .min(self.content_length) as usize;
+
+        start..end
+    }
+
+    /// Builds vertical metrics from a virtual list layout.
+    ///
+    /// Use this when [`crate::list::VirtualList`] already computed content height and scroll
+    /// offset, and the app wants a scrollbar or status indicator beside the list.
+    ///
+    /// # Examples
+    ///
+    /// Derive scrollbar values from the same layout used for list hit testing:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::list::{
+    ///     ListItemContext, ListItems, ScrollPosition, VirtualList, VirtualListState,
+    /// };
+    /// use ratatui_layout::participant::MeasureContext;
+    /// use ratatui_layout::scroll::ScrollMetrics;
+    ///
+    /// struct Rows;
+    /// impl ListItems for Rows {
+    ///     fn len(&self) -> usize {
+    ///         10
+    ///     }
+    ///     fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 {
+    ///         1
+    ///     }
+    ///     fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+    /// }
+    ///
+    /// let mut state = VirtualListState::default();
+    /// state.set_scroll(ScrollPosition::new(3, 0));
+    /// let layout = VirtualList::new().layout(Rect::new(0, 0, 10, 4), &mut state, &Rows);
+    /// let metrics = ScrollMetrics::from_list(&layout);
+    ///
+    /// assert_eq!(metrics.viewport_length, 4);
+    /// assert_eq!(metrics.offset, 3);
+    /// ```
+    pub fn from_list(layout: &ListLayout) -> Self {
+        Self::new(
+            layout.content_height,
+            layout.viewport.height,
+            layout.scroll_offset,
+        )
+    }
+
+    /// Builds horizontal metrics from a rectangular viewport layout.
+    ///
+    /// # Examples
+    ///
+    /// Derive horizontal scrollbar values from a two-axis viewport:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Position, Rect, Size};
+    /// use ratatui_layout::scroll::ScrollMetrics;
+    /// use ratatui_layout::viewport::{Viewport, ViewportState};
+    ///
+    /// let mut state = ViewportState::new(Position::new(20, 0));
+    /// let layout = Viewport::new(Size::new(100, 10)).layout(Rect::new(0, 0, 20, 5), &mut state);
+    /// let metrics = ScrollMetrics::horizontal(&layout);
+    ///
+    /// assert_eq!(metrics.offset, 20);
+    /// ```
+    pub fn horizontal(viewport: &ViewportLayout) -> Self {
+        let viewport_size = Size::new(viewport.viewport.width, viewport.viewport.height);
+        Self::from_viewport(
+            viewport.content_size,
+            viewport_size,
+            viewport.offset.x,
+            Axis::X,
+        )
+    }
+
+    /// Builds vertical metrics from a rectangular viewport layout.
+    ///
+    /// # Examples
+    ///
+    /// Derive vertical scrollbar values from a viewport layout:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Position, Rect, Size};
+    /// use ratatui_layout::scroll::ScrollMetrics;
+    /// use ratatui_layout::viewport::{Viewport, ViewportState};
+    ///
+    /// let mut state = ViewportState::new(Position::new(0, 30));
+    /// let layout = Viewport::new(Size::new(20, 100)).layout(Rect::new(0, 0, 20, 10), &mut state);
+    /// let metrics = ScrollMetrics::vertical(&layout);
+    ///
+    /// assert_eq!(metrics.offset, 30);
+    /// ```
+    pub fn vertical(viewport: &ViewportLayout) -> Self {
+        let viewport_size = Size::new(viewport.viewport.width, viewport.viewport.height);
+        Self::from_viewport(
+            viewport.content_size,
+            viewport_size,
+            viewport.offset.y,
+            Axis::Y,
+        )
+    }
+
+    fn from_viewport(content: Size, viewport: Size, offset: u16, axis: Axis) -> Self {
+        match axis {
+            Axis::X => Self::new(u32::from(content.width), viewport.width, u32::from(offset)),
+            Axis::Y => Self::new(
+                u32::from(content.height),
+                viewport.height,
+                u32::from(offset),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Axis {
+    X,
+    Y,
+}
+
+fn thumb_length(content_length: u32, viewport_length: u16) -> u16 {
+    if viewport_length == 0 || content_length == 0 {
+        return 0;
+    }
+
+    let viewport = u32::from(viewport_length);
+    if content_length <= viewport {
+        return viewport_length;
+    }
+
+    ((viewport * viewport) / content_length)
+        .max(1)
+        .min(viewport) as u16
+}
+
+fn thumb_start(offset: u32, max_offset: u32, viewport_length: u16, thumb_length: u16) -> u16 {
+    if max_offset == 0 || viewport_length <= thumb_length {
+        return 0;
+    }
+
+    let track = u32::from(viewport_length - thumb_length);
+    ((offset * track) / max_offset).min(track) as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn content_that_fits_uses_full_thumb() {
+        let metrics = ScrollMetrics::new(5, 10, 0);
+
+        assert!(metrics.fits());
+        assert_eq!(metrics.thumb_start, 0);
+        assert_eq!(metrics.thumb_length, 10);
+    }
+
+    #[test]
+    fn oversized_content_computes_thumb_range() {
+        let metrics = ScrollMetrics::new(100, 10, 45);
+
+        assert_eq!(metrics.max_offset, 90);
+        assert_eq!(metrics.thumb_length, 1);
+        assert_eq!(metrics.thumb_start, 4);
+    }
+
+    #[test]
+    fn visible_range_uses_clamped_offset_and_content_end() {
+        let metrics = ScrollMetrics::new(5, 2, 99);
+
+        assert_eq!(metrics.offset, 3);
+        assert_eq!(metrics.visible_range(), 3..5);
+    }
+}

--- a/crates/ratatui-layout/src/selection.rs
+++ b/crates/ratatui-layout/src/selection.rs
@@ -1,0 +1,964 @@
+//! App-owned selection state over visible ids.
+//!
+//! Selection is often durable application state: a selected row may stay selected while it scrolls
+//! out of view, and a selected command may matter independently from hover or keyboard focus.
+//! [`SelectionState`](crate::selection::SelectionState) is therefore deliberately not a widget
+//! state type. It has no geometry and does not know how rows, cells, or buttons are rendered. Pair
+//! it with a frame-local ordered list of visible ids from a layout, grid, list, or table when
+//! keyboard or pointer input changes selection.
+//!
+//! The shared idea in this module is that selection is about application meaning, not terminal
+//! coordinates. A [`crate::regions::Regions`], [`crate::pointer::PointerTargets`],
+//! [`crate::focus::FocusTargets`], grid, list, or table can tell the app which ids are visible this
+//! frame. [`SelectionState`](crate::selection::SelectionState) decides which of those ids are
+//! selected and keeps that decision after the frame is gone.
+//!
+//! Use existing Ratatui widget state when that widget fully owns the list or table selection
+//! behavior. Use this module when selection belongs to application data and must coordinate with
+//! custom layout, focus, pointer routing, or virtualization.
+//!
+//! That split is useful for common UI workflows:
+//!
+//! - a list can render the selected row differently while using
+//!   [`SelectionState::select_next`](crate::selection::SelectionState::select_next) and
+//!   [`SelectionState::select_previous`](crate::selection::SelectionState::select_previous) to move
+//!   through only currently visible ids;
+//! - a pointer click can route through [`crate::pointer::PointerTargets`] and then call
+//!   [`SelectionState::select`](crate::selection::SelectionState::select) or
+//!   [`SelectionState::toggle`](crate::selection::SelectionState::toggle) with the hit id;
+//! - a palette can use [`crate::focus::FocusState`] for keyboard focus and
+//!   [`SelectionState`](crate::selection::SelectionState) for the chosen item, avoiding a single
+//!   overloaded state value;
+//! - a multi-select table can preserve selected ids even when filtering or scrolling temporarily
+//!   hides them.
+//!
+//! # Types
+//!
+//! - [`SelectionMode`](crate::selection::SelectionMode) describes whether selection is disabled,
+//!   single-choice, or multi-choice.
+//! - [`SelectionState`](crate::selection::SelectionState) stores selected ids in insertion order
+//!   and applies the mode rules.
+//! - [`VisibleSelection`](crate::selection::VisibleSelection) bridges one durable selected id to
+//!   the visible position used by a virtualized view.
+//!
+//! See [`crate::docs::interaction`] for how selection differs from focus and hover, and why it
+//! remains app-owned rather than part of a region set.
+//!
+//! # Examples
+//!
+//! Single selection replaces the previous id:
+//!
+//! ```rust
+//! use ratatui_layout::selection::{SelectionMode, SelectionState};
+//!
+//! let mut selection = SelectionState::new(SelectionMode::Single);
+//! selection.select("open");
+//! selection.select("save");
+//!
+//! assert_eq!(selection.selected(), &["save"]);
+//! ```
+//!
+//! Multi-selection keeps insertion order and supports toggling:
+//!
+//! ```rust
+//! use ratatui_layout::selection::{SelectionMode, SelectionState};
+//!
+//! let mut selection = SelectionState::new(SelectionMode::Multi);
+//! selection.toggle("alpha");
+//! selection.toggle("beta");
+//! selection.toggle("alpha");
+//!
+//! assert_eq!(selection.selected(), &["beta"]);
+//! ```
+
+use alloc::vec::Vec;
+
+/// Selection behavior for a collection of app-owned ids.
+///
+/// The mode explains how [`SelectionState`](crate::selection::SelectionState) should interpret
+/// [`SelectionState::select`](crate::selection::SelectionState::select) and
+/// [`SelectionState::toggle`](crate::selection::SelectionState::toggle). It does not decide which
+/// ids are visible or enabled; callers pass the ordered visible ids used for traversal.
+///
+/// Use [`SelectionMode::None`](crate::selection::SelectionMode::None) when a component should keep
+/// the same input code but temporarily avoid retaining a selection,
+/// [`SelectionMode::Single`](crate::selection::SelectionMode::Single) for menus and palettes where
+/// one choice replaces another, and
+/// [`SelectionMode::Multi`](crate::selection::SelectionMode::Multi) for checklist or table
+/// workflows where several ids can be active at once.
+///
+/// # Examples
+///
+/// Pick the mode from the interaction model, then let
+/// [`SelectionState`](crate::selection::SelectionState) enforce it:
+///
+/// ```rust
+/// use ratatui_layout::selection::{SelectionMode, SelectionState};
+///
+/// let mut menu = SelectionState::new(SelectionMode::Single);
+/// menu.select("open");
+/// menu.select("save");
+/// assert_eq!(menu.selected(), &["save"]);
+///
+/// let mut checklist = SelectionState::new(SelectionMode::Multi);
+/// checklist.toggle("fast");
+/// checklist.toggle("verbose");
+/// assert_eq!(checklist.selected(), &["fast", "verbose"]);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum SelectionMode {
+    /// Selection is disabled.
+    ///
+    /// Use this when a component wants to share traversal code with selectable views but should not
+    /// currently retain a selected id.
+    #[default]
+    None,
+    /// At most one id is selected.
+    ///
+    /// This fits menus, radio-like palettes, selected table cells, and other views where the
+    /// current choice replaces the previous choice.
+    Single,
+    /// Multiple ids can be selected in insertion order.
+    ///
+    /// This fits checklists and multi-select tables. Insertion order is preserved so callers can
+    /// display or process selections predictably.
+    Multi,
+}
+
+/// Persistent selection for app-owned ids.
+///
+/// [`SelectionState`](crate::selection::SelectionState) owns only the selected ids and the
+/// [`SelectionMode`](crate::selection::SelectionMode). It does not own layout rectangles, item
+/// data, focus, or hover state. Use the current frame's visible ids to move the selection with
+/// [`select_next`](Self::select_next) or [`select_previous`](Self::select_previous).
+///
+/// The id type should match the ids emitted by the frame-local data that drive the view, such as
+/// [`crate::grid::GridPosition`] for a grid palette or [`crate::table::CellPosition`] for a virtual
+/// table.
+///
+/// # Constructors and configuration
+///
+/// - [`SelectionState::new`](crate::selection::SelectionState::new) creates empty state in a chosen
+///   [`SelectionMode`](crate::selection::SelectionMode).
+/// - [`SelectionState::mode`](crate::selection::SelectionState::mode) returns the current behavior.
+/// - [`SelectionState::set_mode`](crate::selection::SelectionState::set_mode) changes behavior and
+///   drops selections that no longer fit.
+///
+/// # Reading and clearing selection
+///
+/// - [`SelectionState::selected`](crate::selection::SelectionState::selected) returns all selected
+///   ids in insertion order.
+/// - [`SelectionState::primary`](crate::selection::SelectionState::primary) returns the
+///   representative selected id for rendering status text or moving from the current item.
+/// - [`SelectionState::is_selected`](crate::selection::SelectionState::is_selected) checks one id
+///   while rendering rows, cells, or commands.
+/// - [`SelectionState::clear`](crate::selection::SelectionState::clear) removes all selected ids,
+///   commonly for Escape or filter changes.
+///
+/// # User actions
+///
+/// - [`SelectionState::select`](crate::selection::SelectionState::select) applies normal selection
+///   rules for click, Enter, or focus commit.
+/// - [`SelectionState::toggle`](crate::selection::SelectionState::toggle) applies checkbox-like or
+///   modifier-click behavior.
+/// - [`SelectionState::select_next`](crate::selection::SelectionState::select_next) and
+///   [`SelectionState::select_previous`](crate::selection::SelectionState::select_previous) move
+///   over the ordered ids visible in the current frame.
+///
+/// # Examples
+///
+/// Traverse over the ids visible in the current frame:
+///
+/// ```rust
+/// use ratatui_layout::selection::{SelectionMode, SelectionState};
+///
+/// let visible_ids = ["first", "second", "third"];
+/// let mut selection = SelectionState::new(SelectionMode::Single);
+///
+/// selection.select_next(&visible_ids);
+/// assert_eq!(selection.primary(), Some("first"));
+///
+/// selection.select_next(&visible_ids);
+/// assert_eq!(selection.primary(), Some("second"));
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SelectionState<Id = usize> {
+    mode: SelectionMode,
+    selected: Vec<Id>,
+}
+
+impl<Id> Default for SelectionState<Id> {
+    fn default() -> Self {
+        Self {
+            mode: SelectionMode::default(),
+            selected: Vec::new(),
+        }
+    }
+}
+
+impl<Id> SelectionState<Id> {
+    /// Creates selection state for the given mode.
+    ///
+    /// New state starts empty. Call
+    /// [`SelectionState::select`](crate::selection::SelectionState::select) or one of the traversal
+    /// methods after the first frame has produced visible ids.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let selection = SelectionState::<usize>::new(SelectionMode::None);
+    /// assert!(selection.selected().is_empty());
+    /// ```
+    pub const fn new(mode: SelectionMode) -> Self {
+        Self {
+            mode,
+            selected: Vec::new(),
+        }
+    }
+
+    /// Returns the current selection mode.
+    ///
+    /// # Examples
+    ///
+    /// Branch input behavior based on whether the current view supports multi-select:
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let selection = SelectionState::<usize>::new(SelectionMode::Multi);
+    /// let uses_checkbox_gutter = selection.mode() == SelectionMode::Multi;
+    ///
+    /// assert!(uses_checkbox_gutter);
+    /// ```
+    pub const fn mode(&self) -> SelectionMode {
+        self.mode
+    }
+
+    /// Sets the current selection mode and removes selections that cannot be represented.
+    ///
+    /// Switching to [`SelectionMode::None`](crate::selection::SelectionMode::None) clears all ids.
+    /// Switching to [`SelectionMode::Single`](crate::selection::SelectionMode::Single)
+    /// keeps only the primary id.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let mut selection = SelectionState::new(SelectionMode::Multi);
+    /// selection.select("a");
+    /// selection.select("b");
+    ///
+    /// selection.set_mode(SelectionMode::Single);
+    /// assert_eq!(selection.selected(), &["a"]);
+    /// ```
+    pub fn set_mode(&mut self, mode: SelectionMode) {
+        self.mode = mode;
+        match self.mode {
+            SelectionMode::None => self.clear(),
+            SelectionMode::Single => self.selected.truncate(1),
+            SelectionMode::Multi => {}
+        }
+    }
+
+    /// Returns selected ids in insertion order.
+    ///
+    /// Single-selection state returns either an empty slice or one id.
+    ///
+    /// # Examples
+    ///
+    /// Read selected ids when applying a bulk action:
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let mut selection = SelectionState::new(SelectionMode::Multi);
+    /// selection.select("alpha");
+    /// selection.select("beta");
+    ///
+    /// let selected: Vec<_> = selection.selected().iter().copied().collect();
+    /// assert_eq!(selected, ["alpha", "beta"]);
+    /// ```
+    pub fn selected(&self) -> &[Id] {
+        &self.selected
+    }
+
+    /// Clears selection.
+    ///
+    /// # Examples
+    ///
+    /// Clear row selection when Escape closes selection mode:
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let mut selection = SelectionState::new(SelectionMode::Single);
+    /// selection.select("row-4");
+    /// selection.clear();
+    ///
+    /// assert!(selection.selected().is_empty());
+    /// ```
+    pub fn clear(&mut self) {
+        self.selected.clear();
+    }
+}
+
+impl<Id: Copy + Eq> SelectionState<Id> {
+    /// Returns the primary selected id.
+    ///
+    /// The primary id is the first selected id. Multi-selection traversal advances from the most
+    /// recently selected id, but this method is stable for callers that need a representative
+    /// selection.
+    ///
+    /// # Examples
+    ///
+    /// Show a stable representative item in status text even when multiple ids are selected:
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let mut selection = SelectionState::new(SelectionMode::Multi);
+    /// selection.select("first");
+    /// selection.select("second");
+    ///
+    /// assert_eq!(selection.primary(), Some("first"));
+    /// ```
+    pub fn primary(&self) -> Option<Id> {
+        self.selected.first().copied()
+    }
+
+    /// Returns true when the id is selected.
+    ///
+    /// # Examples
+    ///
+    /// Check each rendered row id while choosing its visual style:
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let rows = ["alpha", "beta"];
+    /// let mut selection = SelectionState::new(SelectionMode::Single);
+    /// selection.select("beta");
+    ///
+    /// let selected_rows: Vec<_> = rows
+    ///     .into_iter()
+    ///     .filter(|row| selection.is_selected(*row))
+    ///     .collect();
+    ///
+    /// assert_eq!(selected_rows, ["beta"]);
+    /// ```
+    pub fn is_selected(&self, id: Id) -> bool {
+        self.selected.contains(&id)
+    }
+
+    /// Selects an id according to the current mode.
+    ///
+    /// In single-selection mode, this replaces the previous id. In multi-selection mode, this adds
+    /// the id if it is not already present. In none mode, it does nothing.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let mut single = SelectionState::new(SelectionMode::Single);
+    /// single.select(1);
+    /// single.select(2);
+    /// assert_eq!(single.selected(), &[2]);
+    /// ```
+    pub fn select(&mut self, id: Id) {
+        match self.mode {
+            SelectionMode::None => {}
+            SelectionMode::Single => {
+                self.selected.clear();
+                self.selected.push(id);
+            }
+            SelectionMode::Multi => {
+                if !self.selected.contains(&id) {
+                    self.selected.push(id);
+                }
+            }
+        }
+    }
+
+    /// Toggles an id according to the current mode.
+    ///
+    /// Toggle is useful for checkbox-like input and multi-select mouse clicks. In single-selection
+    /// mode, toggling the current id clears it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let mut multi = SelectionState::new(SelectionMode::Multi);
+    /// multi.toggle("debug");
+    /// assert!(multi.is_selected("debug"));
+    /// multi.toggle("debug");
+    /// assert!(!multi.is_selected("debug"));
+    /// ```
+    pub fn toggle(&mut self, id: Id) {
+        match self.mode {
+            SelectionMode::None => {}
+            SelectionMode::Single => {
+                if self.selected == [id] {
+                    self.clear();
+                } else {
+                    self.select(id);
+                }
+            }
+            SelectionMode::Multi => {
+                if let Some(index) = self.selected.iter().position(|selected| *selected == id) {
+                    self.selected.remove(index);
+                } else {
+                    self.selected.push(id);
+                }
+            }
+        }
+    }
+
+    /// Selects the next visible id, wrapping at the end.
+    ///
+    /// The visible ids come from the current frame's layout order. This keeps traversal aligned
+    /// with what the user can see, even when filtering or scrolling changes the underlying data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let mut selection = SelectionState::new(SelectionMode::Single);
+    /// selection.select("third");
+    /// selection.select_next(&["first", "second", "third"]);
+    ///
+    /// assert_eq!(selection.primary(), Some("first"));
+    /// ```
+    pub fn select_next(&mut self, visible_ids: &[Id]) {
+        self.select_relative(visible_ids, Direction::Next);
+    }
+
+    /// Selects the previous visible id, wrapping at the start.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::{SelectionMode, SelectionState};
+    ///
+    /// let mut selection = SelectionState::new(SelectionMode::Single);
+    /// selection.select("first");
+    /// selection.select_previous(&["first", "second", "third"]);
+    ///
+    /// assert_eq!(selection.primary(), Some("third"));
+    /// ```
+    pub fn select_previous(&mut self, visible_ids: &[Id]) {
+        self.select_relative(visible_ids, Direction::Previous);
+    }
+
+    fn select_relative(&mut self, visible_ids: &[Id], direction: Direction) {
+        if self.mode == SelectionMode::None || visible_ids.is_empty() {
+            return;
+        }
+        let next = match self
+            .selected
+            .last()
+            .copied()
+            .and_then(|id| visible_ids.iter().position(|visible| *visible == id))
+        {
+            Some(index) => match direction {
+                Direction::Next => visible_ids[(index + 1) % visible_ids.len()],
+                Direction::Previous => {
+                    visible_ids[(index + visible_ids.len() - 1) % visible_ids.len()]
+                }
+            },
+            None => visible_ids[0],
+        };
+        self.select(next);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+enum Direction {
+    Next,
+    Previous,
+}
+
+/// Bridge between durable selection ids and frame-local visible positions.
+///
+/// Virtualized views often need two identities for the same selection. Application commands should
+/// operate on a durable id such as a record key, while render and focus code often need a visible
+/// position such as a row index or table cell.
+/// [`VisibleSelection`](crate::selection::VisibleSelection) stores both values together and
+/// provides small helpers for the common conversions.
+///
+/// The type does not know how to look up data. Callers provide closures that map a visible position
+/// to a durable id or map a durable id back to its current visible position. That keeps it useful
+/// for lists, tables, grids, and filtered views without making it depend on any one collection
+/// type.
+///
+/// Use [`SelectionState`](crate::selection::SelectionState) when selection is simply a set of ids.
+/// Use [`VisibleSelection`](crate::selection::VisibleSelection) when a component must also keep a
+/// rendered position synchronized with a durable application id.
+///
+/// # Common uses
+///
+/// - Keep a selected row attached to a stable record id while filtering changes visible indexes.
+/// - Convert a clicked table cell into the durable id used by commands.
+/// - Keep keyboard focus on a visible cell while details panes and commands use a record key.
+/// - Pair `VisibleSelection<RecordId>` with `VirtualListState` so rendering can select by visible
+///   source index while commands still use a durable record id.
+///
+/// # Visible id helpers
+///
+/// When the visible positions are ordinary indexes into a slice of ids, use
+/// [`VisibleSelection::sync_ids`](crate::selection::VisibleSelection::sync_ids),
+/// [`VisibleSelection::select_index`](crate::selection::VisibleSelection::select_index), and
+/// [`VisibleSelection::move_by`](crate::selection::VisibleSelection::move_by). Keep
+/// [`VisibleSelection::sync`](crate::selection::VisibleSelection::sync) and
+/// [`VisibleSelection::select_position`](crate::selection::VisibleSelection::select_position) for
+/// custom projections such as tables, grouped rows, or views where a visible position is not a
+/// `usize` index.
+///
+/// # Examples
+///
+/// Synchronize a durable id after filtering changes the visible rows:
+///
+/// ```rust
+/// use ratatui_layout::selection::VisibleSelection;
+///
+/// let rows = [(0, "api"), (1, "docs")];
+/// let mut selection = VisibleSelection::new();
+///
+/// selection.select_position(1, |row| rows.get(row).map(|(_, id)| *id));
+/// assert_eq!(selection.selected_id(), Some("docs"));
+///
+/// let filtered = [(0, "docs")];
+/// selection.sync(
+///     || filtered.first().copied(),
+///     |id| filtered.iter().copied().find(|(_, row_id)| *row_id == id),
+/// );
+///
+/// assert_eq!(selection.position(), Some(0));
+/// assert_eq!(selection.selected_id(), Some("docs"));
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct VisibleSelection<Id, Position = usize> {
+    id: Option<Id>,
+    position: Option<Position>,
+}
+
+impl<Id, Position> Default for VisibleSelection<Id, Position> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Id, Position> VisibleSelection<Id, Position> {
+    /// Creates an empty visible-selection bridge.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::VisibleSelection;
+    ///
+    /// let selection = VisibleSelection::<&str>::new();
+    ///
+    /// assert_eq!(selection.selected_id(), None);
+    /// ```
+    pub const fn new() -> Self {
+        Self {
+            id: None,
+            position: None,
+        }
+    }
+
+    /// Clears both the durable id and the visible position.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::VisibleSelection;
+    ///
+    /// let mut selection = VisibleSelection::new();
+    /// selection.select_visible(2, "row-2");
+    /// selection.clear();
+    ///
+    /// assert_eq!(selection.position(), None);
+    /// ```
+    pub fn clear(&mut self) {
+        self.id = None;
+        self.position = None;
+    }
+}
+
+impl<Id: Copy, Position: Copy> VisibleSelection<Id, Position> {
+    /// Returns the durable selected id, if any.
+    ///
+    /// Commands and details panes usually want this value because it remains meaningful after
+    /// filtering, sorting, or scrolling.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::VisibleSelection;
+    ///
+    /// let mut selection = VisibleSelection::new();
+    /// selection.select_visible(0, "api");
+    ///
+    /// assert_eq!(selection.selected_id(), Some("api"));
+    /// ```
+    pub const fn selected_id(&self) -> Option<Id> {
+        self.id
+    }
+
+    /// Returns the current visible position, if any.
+    ///
+    /// Render and focus code usually want this value because it names what is currently on screen.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::VisibleSelection;
+    ///
+    /// let mut selection = VisibleSelection::new();
+    /// selection.select_visible(3, "docs");
+    ///
+    /// assert_eq!(selection.position(), Some(3));
+    /// ```
+    pub const fn position(&self) -> Option<Position> {
+        self.position
+    }
+
+    /// Selects a known visible position and durable id together.
+    ///
+    /// Use this after a caller has already resolved a click or keyboard movement to both pieces of
+    /// information.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::VisibleSelection;
+    ///
+    /// let mut selection = VisibleSelection::new();
+    /// let position = selection.select_visible(4, "release-4");
+    ///
+    /// assert_eq!(position, 4);
+    /// assert_eq!(selection.selected_id(), Some("release-4"));
+    /// ```
+    pub const fn select_visible(&mut self, position: Position, id: Id) -> Position {
+        self.id = Some(id);
+        self.position = Some(position);
+        position
+    }
+
+    /// Selects a visible position by looking up its durable id.
+    ///
+    /// This is the mouse-click path for virtualized views: input routing gives a visible position,
+    /// and the view supplies the durable id at that position. If the position is no longer visible,
+    /// the selection is left unchanged.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::VisibleSelection;
+    ///
+    /// let rows = ["api", "docs"];
+    /// let mut selection = VisibleSelection::new();
+    ///
+    /// assert_eq!(
+    ///     selection.select_position(1, |row| rows.get(row).copied()),
+    ///     Some(1)
+    /// );
+    /// assert_eq!(selection.selected_id(), Some("docs"));
+    /// ```
+    pub fn select_position(
+        &mut self,
+        position: Position,
+        id_at: impl FnOnce(Position) -> Option<Id>,
+    ) -> Option<Position> {
+        let id = id_at(position)?;
+        Some(self.select_visible(position, id))
+    }
+
+    /// Synchronizes the stored durable id with the current visible positions.
+    ///
+    /// `fallback` returns the position and id to use when there is no selection or the selected id
+    /// is filtered out. `locate` returns the current visible position for an existing durable id.
+    /// When neither closure can produce a visible row, the selection is cleared.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::VisibleSelection;
+    ///
+    /// let mut selection = VisibleSelection::new();
+    /// selection.select_visible(2, "docs");
+    ///
+    /// let visible = [(0, "api")];
+    /// let position = selection.sync(
+    ///     || visible.first().copied(),
+    ///     |id| visible.iter().copied().find(|(_, row_id)| *row_id == id),
+    /// );
+    ///
+    /// assert_eq!(position, Some(0));
+    /// assert_eq!(selection.selected_id(), Some("api"));
+    /// ```
+    pub fn sync(
+        &mut self,
+        fallback: impl FnOnce() -> Option<(Position, Id)>,
+        locate: impl FnOnce(Id) -> Option<(Position, Id)>,
+    ) -> Option<Position> {
+        let next = self.id.and_then(locate).or_else(fallback);
+        if let Some((position, id)) = next {
+            Some(self.select_visible(position, id))
+        } else {
+            self.clear();
+            None
+        }
+    }
+}
+
+impl<Id: Copy + Eq> VisibleSelection<Id, usize> {
+    /// Synchronizes selection against a visible slice of durable ids.
+    ///
+    /// This is the common filtered-list path. If the current selected id is still visible, its
+    /// visible index is refreshed. If the selected id is missing or there is no selection yet, the
+    /// first visible id becomes selected. Empty visible slices clear the selection.
+    ///
+    /// Use [`VisibleSelection::sync`](crate::selection::VisibleSelection::sync) when visible
+    /// positions are not ordinary indexes or when the fallback should be something other than
+    /// the first visible id.
+    ///
+    /// # Examples
+    ///
+    /// Keep a selected record id valid after filtering hides some rows:
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::VisibleSelection;
+    ///
+    /// let mut selection = VisibleSelection::new();
+    /// selection.select_visible(1, "docs");
+    ///
+    /// let visible_ids = ["api", "docs"];
+    /// assert_eq!(selection.sync_ids(&visible_ids), Some(1));
+    ///
+    /// let filtered_ids = ["api"];
+    /// assert_eq!(selection.sync_ids(&filtered_ids), Some(0));
+    /// assert_eq!(selection.selected_id(), Some("api"));
+    /// ```
+    pub fn sync_ids(&mut self, visible_ids: &[Id]) -> Option<usize> {
+        self.sync(
+            || visible_ids.first().copied().map(|id| (0, id)),
+            |id| {
+                visible_ids
+                    .iter()
+                    .position(|visible| *visible == id)
+                    .map(|position| (position, id))
+            },
+        )
+    }
+
+    /// Selects the durable id at a visible index.
+    ///
+    /// This is the direct click or keyboard-commit path when input has already resolved to a
+    /// visible row index. Invalid indexes leave the selection unchanged and return `None`.
+    ///
+    /// # Examples
+    ///
+    /// Select the record id at the clicked visible row:
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::VisibleSelection;
+    ///
+    /// let visible_ids = ["api", "docs"];
+    /// let mut selection = VisibleSelection::new();
+    ///
+    /// assert_eq!(selection.select_index(1, &visible_ids), Some(1));
+    /// assert_eq!(selection.selected_id(), Some("docs"));
+    /// assert_eq!(selection.select_index(9, &visible_ids), None);
+    /// assert_eq!(selection.selected_id(), Some("docs"));
+    /// ```
+    pub fn select_index(&mut self, index: usize, visible_ids: &[Id]) -> Option<usize> {
+        let id = visible_ids.get(index).copied()?;
+        Some(self.select_visible(index, id))
+    }
+
+    /// Moves selection by a signed offset through visible ids.
+    ///
+    /// Movement is clamped at the first and last visible id. If the current selected id is visible,
+    /// movement starts there. If there is no current visible id, the first visible id becomes the
+    /// fallback selection. Empty visible slices clear the selection.
+    ///
+    /// # Examples
+    ///
+    /// Move through filtered ids without losing the durable selected id:
+    ///
+    /// ```rust
+    /// use ratatui_layout::selection::VisibleSelection;
+    ///
+    /// let visible_ids = ["api", "docs", "ops"];
+    /// let mut selection = VisibleSelection::new();
+    ///
+    /// assert_eq!(selection.move_by(1, &visible_ids), Some(0));
+    /// assert_eq!(selection.selected_id(), Some("api"));
+    ///
+    /// assert_eq!(selection.move_by(1, &visible_ids), Some(1));
+    /// assert_eq!(selection.selected_id(), Some("docs"));
+    /// ```
+    pub fn move_by(&mut self, delta: isize, visible_ids: &[Id]) -> Option<usize> {
+        if visible_ids.is_empty() {
+            self.clear();
+            return None;
+        }
+
+        let Some(current) = self
+            .id
+            .and_then(|id| visible_ids.iter().position(|visible| *visible == id))
+        else {
+            return self.select_index(0, visible_ids);
+        };
+        let index = current
+            .saturating_add_signed(delta)
+            .min(visible_ids.len() - 1);
+
+        self.select_index(index, visible_ids)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn none_mode_ignores_selection() {
+        let mut state = SelectionState::new(crate::selection::SelectionMode::None);
+        state.select(1);
+        state.toggle(2);
+        state.select_next(&[1, 2]);
+
+        assert!(state.selected().is_empty());
+    }
+
+    #[test]
+    fn single_mode_replaces_and_toggles() {
+        let mut state = SelectionState::new(crate::selection::SelectionMode::Single);
+        state.select(1);
+        state.select(2);
+        assert_eq!(state.selected(), &[2]);
+
+        state.toggle(2);
+        assert!(state.selected().is_empty());
+    }
+
+    #[test]
+    fn multi_mode_toggles_in_insertion_order() {
+        let mut state = SelectionState::new(crate::selection::SelectionMode::Multi);
+        state.toggle("a");
+        state.toggle("b");
+        state.toggle("a");
+
+        assert_eq!(state.selected(), &["b"]);
+    }
+
+    #[test]
+    fn traversal_wraps_visible_ids() {
+        let mut state = SelectionState::new(crate::selection::SelectionMode::Single);
+        state.select_next(&[1, 2, 3]);
+        assert_eq!(state.primary(), Some(1));
+        state.select_previous(&[1, 2, 3]);
+        assert_eq!(state.primary(), Some(3));
+    }
+
+    #[test]
+    fn multi_traversal_uses_most_recent_selection() {
+        let mut state = SelectionState::new(crate::selection::SelectionMode::Multi);
+        state.select_next(&[1, 2, 3]);
+        state.select_next(&[1, 2, 3]);
+        state.select_next(&[1, 2, 3]);
+
+        assert_eq!(state.selected(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn visible_selection_bridges_position_and_durable_id() {
+        let rows = [(0, "api"), (1, "docs")];
+        let mut selection = VisibleSelection::new();
+
+        selection.select_position(1, |row| rows.get(row).map(|(_, id)| *id));
+
+        assert_eq!(selection.selected_id(), Some("docs"));
+        assert_eq!(selection.position(), Some(1));
+    }
+
+    #[test]
+    fn visible_selection_falls_back_when_id_is_filtered_out() {
+        let mut selection = VisibleSelection::new();
+        selection.select_visible(1, "docs");
+
+        let visible = [(0, "api")];
+        let position = selection.sync(
+            || visible.first().copied(),
+            |id| visible.iter().copied().find(|(_, row_id)| *row_id == id),
+        );
+
+        assert_eq!(position, Some(0));
+        assert_eq!(selection.selected_id(), Some("api"));
+    }
+
+    #[test]
+    fn visible_selection_syncs_visible_id_slices() {
+        let mut selection = VisibleSelection::new();
+        selection.select_visible(1, "docs");
+
+        assert_eq!(selection.sync_ids(&["api", "docs"]), Some(1));
+        assert_eq!(selection.position(), Some(1));
+        assert_eq!(selection.selected_id(), Some("docs"));
+
+        assert_eq!(selection.sync_ids(&["api"]), Some(0));
+        assert_eq!(selection.position(), Some(0));
+        assert_eq!(selection.selected_id(), Some("api"));
+
+        assert_eq!(selection.sync_ids(&[]), None);
+        assert_eq!(selection.selected_id(), None);
+    }
+
+    #[test]
+    fn visible_selection_selects_visible_index() {
+        let mut selection = VisibleSelection::new();
+
+        assert_eq!(selection.select_index(1, &["api", "docs"]), Some(1));
+        assert_eq!(selection.position(), Some(1));
+        assert_eq!(selection.selected_id(), Some("docs"));
+
+        assert_eq!(selection.select_index(9, &["api", "docs"]), None);
+        assert_eq!(selection.position(), Some(1));
+        assert_eq!(selection.selected_id(), Some("docs"));
+    }
+
+    #[test]
+    fn visible_selection_moves_over_visible_ids() {
+        let mut selection = VisibleSelection::new();
+        let visible = ["api", "docs", "ops"];
+
+        assert_eq!(selection.move_by(1, &visible), Some(0));
+        assert_eq!(selection.selected_id(), Some("api"));
+
+        assert_eq!(selection.move_by(1, &visible), Some(1));
+        assert_eq!(selection.selected_id(), Some("docs"));
+
+        assert_eq!(selection.move_by(99, &visible), Some(2));
+        assert_eq!(selection.selected_id(), Some("ops"));
+
+        assert_eq!(selection.move_by(-99, &visible), Some(0));
+        assert_eq!(selection.selected_id(), Some("api"));
+
+        assert_eq!(selection.move_by(1, &[]), None);
+        assert_eq!(selection.selected_id(), None);
+    }
+}

--- a/crates/ratatui-layout/src/table.rs
+++ b/crates/ratatui-layout/src/table.rs
@@ -1,0 +1,2081 @@
+//! Virtual table layout and app-owned cell rendering.
+//!
+//! `VirtualTable` is a two-dimensional counterpart to [`crate::list::VirtualList`]. It does not
+//! store rows, cells, styles, or cell widget state. The application owns the data and renders
+//! visible cells by row and column after the table computes the current visible regions.
+//!
+//! Use Ratatui's built-in table widget when rows are small, fully visible, and can be rendered
+//! directly. Use this module when pinned headers, two-axis scrolling, hit testing, or app-owned
+//! cell rendering need explicit frame-local data.
+//!
+//! # Types and traits
+//!
+//! - [`CellPosition`](crate::table::CellPosition) is the frame-local id for header and body cells.
+//! - [`VirtualTableState`](crate::table::VirtualTableState) stores selected cell plus row and
+//!   column scroll offsets.
+//! - [`TableItems`](crate::table::TableItems) is the trait for app-owned table data that can render
+//!   visible cells.
+//! - [`TableCellContext`](crate::table::TableCellContext) is passed to cell renderers with
+//!   interaction and visible-position metadata.
+//! - [`VisibleCell`](crate::table::VisibleCell) describes one header or body cell visible in the
+//!   current frame.
+//! - [`TableLayout`](crate::table::TableLayout) is the solved frame-local layout for visible cells,
+//!   hit testing, and scroll metrics.
+//! - [`VirtualTable`](crate::table::VirtualTable) is the reusable table configuration that computes
+//!   or renders a [`TableLayout`](crate::table::TableLayout).
+//!
+//! See [`crate::docs::virtualization`] for the broader virtualization model and
+//! [`crate::docs::interaction`] for how table cell ids can feed focus, pointer, and selection
+//! state.
+//!
+//! # Examples
+//!
+//! Render visible cells from app-owned data and keep the solved layout for hit testing:
+//!
+//! ```rust
+//! use ratatui_core::buffer::Buffer;
+//! use ratatui_core::layout::{Constraint, Rect};
+//! use ratatui_layout::table::{
+//!     CellPosition, TableCellContext, TableItems, VirtualTable, VirtualTableState,
+//! };
+//!
+//! struct Rows(&'static [[&'static str; 2]]);
+//! impl TableItems for Rows {
+//!     fn row_count(&self) -> usize {
+//!         self.0.len()
+//!     }
+//!     fn column_count(&self) -> usize {
+//!         2
+//!     }
+//!     fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+//! }
+//!
+//! let mut rows = Rows(&[["id", "name"], ["1", "Ada"]]);
+//! let mut state = VirtualTableState::default();
+//! let mut buffer = Buffer::empty(Rect::new(0, 0, 12, 3));
+//! let layout = VirtualTable::new([Constraint::Length(6), Constraint::Length(6)]).render(
+//!     buffer.area,
+//!     &mut buffer,
+//!     &mut state,
+//!     &mut rows,
+//! );
+//!
+//! assert_eq!(
+//!     layout.hit_test((7, 1)).unwrap().id,
+//!     CellPosition::body(0, 1)
+//! );
+//! ```
+
+use alloc::vec::Vec;
+
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::{Constraint, Layout, Position, Rect};
+
+use crate::participant::{RenderContext, RenderState};
+use crate::regions::{Hit, Region, Regions};
+use crate::scroll::ScrollMetrics;
+
+/// A table cell coordinate.
+///
+/// Use [`CellPosition`](crate::table::CellPosition) as the stable frame-local id for a virtual
+/// table cell. Header cells use `row: None`; body cells use `row: Some(index)`.
+///
+/// # Constructors
+///
+/// - [`CellPosition::body`](crate::table::CellPosition::body) creates a source body-cell id.
+/// - [`CellPosition::header`](crate::table::CellPosition::header) creates a pinned header-cell id.
+///
+/// # Examples
+///
+/// Use one id type for both pinned headers and scrollable body cells:
+///
+/// ```rust
+/// use ratatui_layout::table::{CellPosition, VirtualTableState};
+///
+/// let header = CellPosition::header(0);
+/// let body = CellPosition::body(3, 0);
+/// let mut state = VirtualTableState::default();
+/// state.select(Some(body));
+///
+/// assert_eq!(header.row, None);
+/// assert_eq!(
+///     state.selected(),
+///     Some(CellPosition {
+///         row: Some(3),
+///         column: 0
+///     })
+/// );
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct CellPosition {
+    /// Body row index, or `None` for a header cell.
+    pub row: Option<usize>,
+
+    /// Column index.
+    pub column: usize,
+}
+
+impl CellPosition {
+    /// Creates a body cell position.
+    ///
+    /// # Examples
+    ///
+    /// Store a selected source cell in table state:
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::{CellPosition, VirtualTableState};
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.select(Some(CellPosition::body(3, 2)));
+    ///
+    /// assert_eq!(
+    ///     state.selected(),
+    ///     Some(CellPosition {
+    ///         row: Some(3),
+    ///         column: 2
+    ///     })
+    /// );
+    /// ```
+    pub const fn body(row: usize, column: usize) -> Self {
+        Self {
+            row: Some(row),
+            column,
+        }
+    }
+
+    /// Creates a header cell position.
+    ///
+    /// # Examples
+    ///
+    /// Distinguish pinned header hits from body-cell hits:
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::CellPosition;
+    ///
+    /// let header = CellPosition::header(1);
+    ///
+    /// assert_eq!(header.row, None);
+    /// assert_eq!(header.column, 1);
+    /// ```
+    pub const fn header(column: usize) -> Self {
+        Self { row: None, column }
+    }
+}
+
+/// Persistent state for a virtual table.
+///
+/// Use [`VirtualTableState`](crate::table::VirtualTableState) next to the table's data. It stores
+/// selection plus vertical and horizontal scroll positions.
+/// [`VirtualTable`](crate::table::VirtualTable) clamps this state during layout.
+///
+/// # Selection
+///
+/// - [`VirtualTableState::selected`](crate::table::VirtualTableState::selected) reads the selected
+///   cell.
+/// - [`VirtualTableState::select`](crate::table::VirtualTableState::select) sets or clears the
+///   selected cell and asks layout to reveal it.
+/// - [`VirtualTableState::select_relative`](crate::table::VirtualTableState::select_relative) moves
+///   selection by row and column deltas and asks layout to reveal it.
+/// - [`VirtualTableState::select_without_scrolling`](crate::table::VirtualTableState::select_without_scrolling) sets selection for styling or commands without
+///   moving the viewport.
+/// - [`VirtualTableState::scroll_to_selected`](crate::table::VirtualTableState::scroll_to_selected)
+///   asks the next layout to reveal the selected cell.
+/// - [`VirtualTableState::scrolls_selected_into_view`](crate::table::VirtualTableState::scrolls_selected_into_view) reports which selection policy the next
+///   layout pass will use.
+///
+/// # Scrolling
+///
+/// - [`VirtualTableState::row_scroll`](crate::table::VirtualTableState::row_scroll) and
+///   [`VirtualTableState::set_row_scroll`](crate::table::VirtualTableState::set_row_scroll) read
+///   and write the first visible body row.
+/// - [`VirtualTableState::column_scroll`](crate::table::VirtualTableState::column_scroll) and
+///   [`VirtualTableState::set_column_scroll`](crate::table::VirtualTableState::set_column_scroll)
+///   read and write the first visible column.
+/// - [`VirtualTableState::scroll_rows_by`](crate::table::VirtualTableState::scroll_rows_by),
+///   [`VirtualTableState::scroll_columns_by`](crate::table::VirtualTableState::scroll_columns_by),
+///   and [`VirtualTableState::scroll_viewport_by`](crate::table::VirtualTableState::scroll_viewport_by)
+///   move the viewport without changing selection.
+///
+/// # Examples
+///
+/// Store two-axis table state between frames while rebuilding
+/// [`VirtualTable`](crate::table::VirtualTable) as a value:
+///
+/// ```rust
+/// use ratatui_layout::table::{CellPosition, VirtualTableState};
+///
+/// let mut state = VirtualTableState::default();
+/// state.select(Some(CellPosition::body(8, 3)));
+/// state.set_row_scroll(6);
+/// state.set_column_scroll(2);
+///
+/// assert_eq!(state.selected(), Some(CellPosition::body(8, 3)));
+/// assert_eq!((state.row_scroll(), state.column_scroll()), (6, 2));
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct VirtualTableState {
+    selected: Option<CellPosition>,
+    row_scroll: usize,
+    column_scroll: usize,
+    #[cfg_attr(feature = "serde", serde(default))]
+    scroll_selected_into_view: bool,
+}
+
+impl VirtualTableState {
+    /// Returns the selected body cell.
+    ///
+    /// # Examples
+    ///
+    /// Read the selected cell when routing a keyboard command:
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::{CellPosition, VirtualTableState};
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.select(Some(CellPosition::body(1, 0)));
+    ///
+    /// assert_eq!(state.selected(), Some(CellPosition::body(1, 0)));
+    /// ```
+    pub const fn selected(&self) -> Option<CellPosition> {
+        self.selected
+    }
+
+    /// Returns whether layout should keep the selected body cell visible.
+    ///
+    /// This flag lets callers distinguish keyboard/click selection from viewport-only scrolling.
+    /// Calling [`VirtualTableState::select`](crate::table::VirtualTableState::select) turns it on.
+    /// Calling
+    /// [`VirtualTableState::scroll_rows_by`](crate::table::VirtualTableState::scroll_rows_by),
+    /// [`VirtualTableState::scroll_columns_by`](crate::table::VirtualTableState::scroll_columns_by),
+    /// or
+    /// [`VirtualTableState::scroll_viewport_by`](crate::table::VirtualTableState::scroll_viewport_by) turns it off so wheel input can move the viewport
+    /// without snapping back to the selected cell.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::{CellPosition, VirtualTableState};
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.select(Some(CellPosition::body(4, 1)));
+    /// assert!(state.scrolls_selected_into_view());
+    ///
+    /// state.scroll_rows_by(1);
+    /// assert!(!state.scrolls_selected_into_view());
+    /// ```
+    pub const fn scrolls_selected_into_view(&self) -> bool {
+        self.scroll_selected_into_view
+    }
+
+    /// Sets the selected body cell.
+    ///
+    /// Selecting a body cell also asks the next layout pass to keep that cell visible. Use
+    /// [`VirtualTableState::select_without_scrolling`](crate::table::VirtualTableState::select_without_scrolling) when selection should be retained for
+    /// styling or commands but viewport-only input should not move back to it.
+    ///
+    /// # Examples
+    ///
+    /// Select the clicked cell after hit testing a previous table layout:
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::{CellPosition, VirtualTableState};
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.select(Some(CellPosition::body(2, 3)));
+    ///
+    /// assert_eq!(state.selected().unwrap().column, 3);
+    /// ```
+    pub const fn select(&mut self, selected: Option<CellPosition>) {
+        self.selected = selected;
+        self.scroll_selected_into_view = selected.is_some();
+    }
+
+    /// Moves selected body cell by signed row and column deltas.
+    ///
+    /// Use this for keyboard movement in source-index tables. The caller passes current row and
+    /// column counts because table state intentionally does not own app data or column policy.
+    /// Empty rows or columns clear selection. If no body cell is selected, the first movement
+    /// selects the top-left body cell. Movement is clamped to the table bounds and the next layout
+    /// pass will reveal the selected cell.
+    ///
+    /// This changes selection. Use
+    /// [`VirtualTableState::scroll_viewport_by`](crate::table::VirtualTableState::scroll_viewport_by)
+    /// for wheel or page scrolling that should move the viewport without changing the selected
+    /// cell.
+    ///
+    /// # Examples
+    ///
+    /// Move a selected cell without hand-writing row and column clamping:
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::{CellPosition, VirtualTableState};
+    ///
+    /// let mut state = VirtualTableState::default();
+    ///
+    /// assert_eq!(
+    ///     state.select_relative(1, 0, 3, 2),
+    ///     Some(CellPosition::body(0, 0))
+    /// );
+    /// assert_eq!(
+    ///     state.select_relative(1, 1, 3, 2),
+    ///     Some(CellPosition::body(1, 1))
+    /// );
+    /// assert_eq!(
+    ///     state.select_relative(99, 99, 3, 2),
+    ///     Some(CellPosition::body(2, 1))
+    /// );
+    /// ```
+    pub const fn select_relative(
+        &mut self,
+        row_delta: isize,
+        column_delta: isize,
+        row_count: usize,
+        column_count: usize,
+    ) -> Option<CellPosition> {
+        if row_count == 0 || column_count == 0 {
+            self.select(None);
+            return None;
+        }
+
+        let Some(current) = self.selected else {
+            let selected = CellPosition::body(0, 0);
+            self.select(Some(selected));
+            return Some(selected);
+        };
+        let row = match current.row {
+            Some(row) => clamp_index(offset_index(row, row_delta), row_count),
+            None => 0,
+        };
+        let column = clamp_index(offset_index(current.column, column_delta), column_count);
+        let selected = CellPosition::body(row, column);
+        self.select(Some(selected));
+        Some(selected)
+    }
+
+    /// Sets the selected body cell without asking layout to move the viewport.
+    ///
+    /// Use this when the selected record remains app state, but the user just scrolled the table
+    /// viewport. If the selected cell is still visible, renderers receive selected state. If it is
+    /// off-screen, the viewport stays where the scroll command put it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::{CellPosition, VirtualTableState};
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.select_without_scrolling(Some(CellPosition::body(8, 2)));
+    ///
+    /// assert_eq!(state.selected(), Some(CellPosition::body(8, 2)));
+    /// assert!(!state.scrolls_selected_into_view());
+    /// ```
+    pub const fn select_without_scrolling(&mut self, selected: Option<CellPosition>) {
+        self.selected = selected;
+        self.scroll_selected_into_view = false;
+    }
+
+    /// Asks the next layout pass to bring the current selected cell into view.
+    ///
+    /// This is useful after restoring selection without scrolling and then receiving keyboard input
+    /// that should reveal the selected cell. The exact row and column offsets are still solved by
+    /// [`VirtualTable::layout`](crate::table::VirtualTable::layout) because they depend on viewport
+    /// size and column constraints.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::{CellPosition, VirtualTableState};
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.select_without_scrolling(Some(CellPosition::body(12, 3)));
+    /// state.scroll_to_selected();
+    ///
+    /// assert!(state.scrolls_selected_into_view());
+    /// ```
+    pub const fn scroll_to_selected(&mut self) {
+        self.scroll_selected_into_view = self.selected.is_some();
+    }
+
+    /// Returns the first visible body row index.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::VirtualTableState;
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.set_row_scroll(10);
+    ///
+    /// assert_eq!(state.row_scroll(), 10);
+    /// ```
+    pub const fn row_scroll(&self) -> usize {
+        self.row_scroll
+    }
+
+    /// Sets the first visible body row index.
+    ///
+    /// # Examples
+    ///
+    /// Apply a page-down command before the next layout clamps the row offset:
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::VirtualTableState;
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.set_row_scroll(20);
+    ///
+    /// assert_eq!(state.row_scroll(), 20);
+    /// ```
+    pub const fn set_row_scroll(&mut self, row_scroll: usize) {
+        self.row_scroll = row_scroll;
+    }
+
+    /// Returns the first visible column index.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::VirtualTableState;
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.set_column_scroll(4);
+    ///
+    /// assert_eq!(state.column_scroll(), 4);
+    /// ```
+    pub const fn column_scroll(&self) -> usize {
+        self.column_scroll
+    }
+
+    /// Sets the first visible column index.
+    ///
+    /// # Examples
+    ///
+    /// Apply a horizontal scroll command before the next table layout clamps it:
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::VirtualTableState;
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.set_column_scroll(5);
+    ///
+    /// assert_eq!(state.column_scroll(), 5);
+    /// ```
+    pub const fn set_column_scroll(&mut self, column_scroll: usize) {
+        self.column_scroll = column_scroll;
+    }
+
+    /// Scrolls the body rows without changing the selected cell.
+    ///
+    /// This is the canonical vertical mouse-wheel helper for tables. It updates the desired first
+    /// body row and lets the next layout pass clamp the value to the current row count. It also
+    /// disables automatic selection reveal so the wheel moves only the viewport.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::{CellPosition, VirtualTableState};
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.select(Some(CellPosition::body(0, 0)));
+    /// state.scroll_rows_by(5);
+    ///
+    /// assert_eq!(state.selected(), Some(CellPosition::body(0, 0)));
+    /// assert_eq!(state.row_scroll(), 5);
+    /// assert!(!state.scrolls_selected_into_view());
+    /// ```
+    pub const fn scroll_rows_by(&mut self, delta: isize) {
+        self.row_scroll = offset_index(self.row_scroll, delta);
+        self.scroll_selected_into_view = false;
+    }
+
+    /// Scrolls visible columns without changing the selected cell.
+    ///
+    /// Use this for table UIs that support horizontal movement independent of selection. Callers
+    /// that do not want horizontal scroll can simply avoid routing horizontal wheel events to this
+    /// method.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::{CellPosition, VirtualTableState};
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.select(Some(CellPosition::body(2, 0)));
+    /// state.scroll_columns_by(2);
+    ///
+    /// assert_eq!(state.column_scroll(), 2);
+    /// assert!(!state.scrolls_selected_into_view());
+    /// ```
+    pub const fn scroll_columns_by(&mut self, delta: isize) {
+        self.column_scroll = offset_index(self.column_scroll, delta);
+        self.scroll_selected_into_view = false;
+    }
+
+    /// Scrolls rows and columns as a viewport operation without changing selection.
+    ///
+    /// This is a convenience for backends or widgets that report two-axis wheel deltas together.
+    /// It intentionally does not select a new cell.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_layout::table::{CellPosition, VirtualTableState};
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.select(Some(CellPosition::body(3, 1)));
+    /// state.scroll_viewport_by(4, 2);
+    ///
+    /// assert_eq!((state.row_scroll(), state.column_scroll()), (4, 2));
+    /// assert_eq!(state.selected(), Some(CellPosition::body(3, 1)));
+    /// ```
+    pub const fn scroll_viewport_by(&mut self, row_delta: isize, column_delta: isize) {
+        self.row_scroll = offset_index(self.row_scroll, row_delta);
+        self.column_scroll = offset_index(self.column_scroll, column_delta);
+        self.scroll_selected_into_view = false;
+    }
+}
+
+/// Externally owned cells rendered by a [`VirtualTable`](crate::table::VirtualTable).
+///
+/// Implement [`TableItems`](crate::table::TableItems) for application data or a small adapter.
+/// [`VirtualTable`](crate::table::VirtualTable) asks for dimensions and renders only visible
+/// header/body cells into assigned rectangles.
+///
+/// # Required methods
+///
+/// - [`TableItems::row_count`](crate::table::TableItems::row_count) returns the current source
+///   body-row count.
+/// - [`TableItems::column_count`](crate::table::TableItems::column_count) returns the current
+///   source column count.
+/// - [`TableItems::render_cell`](crate::table::TableItems::render_cell) renders one visible header
+///   or body cell into its assigned area.
+///
+/// # Examples
+///
+/// Implement the trait on app-owned records and render headers from `CellPosition::header`:
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::Rect;
+/// use ratatui_core::text::Line;
+/// use ratatui_core::widgets::Widget;
+/// use ratatui_layout::table::{CellPosition, TableCellContext, TableItems};
+///
+/// struct Rows(&'static [[&'static str; 2]]);
+///
+/// impl TableItems for Rows {
+///     fn row_count(&self) -> usize {
+///         self.0.len()
+///     }
+///
+///     fn column_count(&self) -> usize {
+///         2
+///     }
+///
+///     fn render_cell(
+///         &mut self,
+///         position: CellPosition,
+///         area: Rect,
+///         buf: &mut Buffer,
+///         _: TableCellContext,
+///     ) {
+///         let text = position
+///             .row
+///             .map(|row| self.0[row][position.column])
+///             .unwrap_or(["id", "name"][position.column]);
+///         Line::from(text).render(area, buf);
+///     }
+/// }
+/// ```
+pub trait TableItems {
+    /// Returns the number of body rows.
+    ///
+    /// # Examples
+    ///
+    /// Back a table with app-owned data rather than row widgets:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::table::{CellPosition, TableCellContext, TableItems};
+    ///
+    /// struct Rows(&'static [[&'static str; 2]]);
+    ///
+    /// impl TableItems for Rows {
+    ///     fn row_count(&self) -> usize {
+    ///         self.0.len()
+    ///     }
+    ///     fn column_count(&self) -> usize {
+    ///         2
+    ///     }
+    ///     fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+    /// }
+    ///
+    /// assert_eq!(Rows(&[["a", "b"]]).row_count(), 1);
+    /// ```
+    fn row_count(&self) -> usize;
+
+    /// Returns the number of columns.
+    ///
+    /// # Examples
+    ///
+    /// Report the source column count separately from the visible columns:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::table::{CellPosition, TableCellContext, TableItems};
+    ///
+    /// struct Rows;
+    ///
+    /// impl TableItems for Rows {
+    ///     fn row_count(&self) -> usize {
+    ///         10
+    ///     }
+    ///     fn column_count(&self) -> usize {
+    ///         4
+    ///     }
+    ///     fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+    /// }
+    ///
+    /// assert_eq!(Rows.column_count(), 4);
+    /// ```
+    fn column_count(&self) -> usize;
+
+    /// Renders a visible table cell.
+    ///
+    /// # Examples
+    ///
+    /// Render only the cells that [`VirtualTable::render`](crate::table::VirtualTable::render)
+    /// determined are visible:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_core::text::Line;
+    /// use ratatui_core::widgets::Widget;
+    /// use ratatui_layout::table::{CellPosition, TableCellContext, TableItems};
+    ///
+    /// struct Rows(&'static [[&'static str; 2]]);
+    ///
+    /// impl TableItems for Rows {
+    ///     fn row_count(&self) -> usize {
+    ///         self.0.len()
+    ///     }
+    ///     fn column_count(&self) -> usize {
+    ///         2
+    ///     }
+    ///     fn render_cell(
+    ///         &mut self,
+    ///         position: CellPosition,
+    ///         area: Rect,
+    ///         buf: &mut Buffer,
+    ///         _: TableCellContext,
+    ///     ) {
+    ///         let text = position
+    ///             .row
+    ///             .map(|row| self.0[row][position.column])
+    ///             .unwrap_or("header");
+    ///         Line::from(text).render(area, buf);
+    ///     }
+    /// }
+    /// ```
+    fn render_cell(
+        &mut self,
+        position: CellPosition,
+        area: Rect,
+        buf: &mut Buffer,
+        ctx: TableCellContext,
+    );
+}
+
+/// Render context for a visible table cell.
+///
+/// [`TableCellContext`](crate::table::TableCellContext) combines common
+/// [`RenderContext`](crate::participant::RenderContext) state with table-specific coordinates.
+/// It is passed to [`TableItems::render_cell`](crate::table::TableItems::render_cell) for visible
+/// cells only.
+///
+/// # Fields
+///
+/// - [`TableCellContext::render`](crate::table::TableCellContext::render) carries shared
+///   interaction flags such as selection.
+/// - [`TableCellContext::position`](crate::table::TableCellContext::position) is the source cell
+///   being rendered.
+/// - [`TableCellContext::visible_column`](crate::table::TableCellContext::visible_column) is the
+///   column's visible index after horizontal scrolling.
+/// - [`TableCellContext::visible_row`](crate::table::TableCellContext::visible_row) is the visible
+///   body row index, or `None` for headers.
+///
+/// # Examples
+///
+/// Render headers, selected cells, and scrolled body cells from the same context:
+///
+/// ```rust
+/// use ratatui_layout::participant::RenderContext;
+/// use ratatui_layout::table::{CellPosition, TableCellContext};
+///
+/// let context = TableCellContext {
+///     render: RenderContext::selected(true),
+///     position: CellPosition::body(12, 3),
+///     visible_column: 1,
+///     visible_row: Some(0),
+/// };
+///
+/// assert!(context.render.state.selected);
+/// assert_eq!(context.position, CellPosition::body(12, 3));
+/// assert_eq!(context.visible_row, Some(0));
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TableCellContext {
+    /// Common render context.
+    pub render: RenderContext,
+
+    /// Position of the cell in the source table.
+    pub position: CellPosition,
+
+    /// Column index among visible columns.
+    pub visible_column: usize,
+
+    /// Row index among visible body rows. Header cells use `None`.
+    pub visible_row: Option<usize>,
+}
+
+/// Metadata for a visible table cell.
+///
+/// Use [`VisibleCell`](crate::table::VisibleCell) for hit testing, diagnostics, focus target
+/// collections, or custom rendering outside the high-level
+/// [`VirtualTable::render`](crate::table::VirtualTable::render) method.
+///
+/// # Fields
+///
+/// - [`VisibleCell::position`](crate::table::VisibleCell::position) is the source header or body
+///   cell id.
+/// - [`VisibleCell::area`](crate::table::VisibleCell::area) is the terminal-space rectangle
+///   assigned to the cell.
+/// - [`VisibleCell::visible_column`](crate::table::VisibleCell::visible_column) is the visible
+///   column index after horizontal scrolling.
+/// - [`VisibleCell::visible_row`](crate::table::VisibleCell::visible_row) is the visible body row
+///   index, or `None` for headers.
+///
+/// # Examples
+///
+/// Build focus or pointer targets from the table cells visible in the current frame:
+///
+/// ```rust
+/// use ratatui_core::layout::Rect;
+/// use ratatui_layout::pointer::{PointerTarget, PointerTargets};
+/// use ratatui_layout::table::{CellPosition, VisibleCell};
+///
+/// let cell = VisibleCell {
+///     position: CellPosition::body(4, 2),
+///     area: Rect::new(10, 3, 8, 1),
+///     visible_column: 0,
+///     visible_row: Some(1),
+/// };
+/// let mouse = PointerTargets::new().target(PointerTarget::new(cell.position, cell.area));
+///
+/// assert_eq!(
+///     mouse.hit_test((11, 3)).unwrap().id,
+///     CellPosition::body(4, 2)
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct VisibleCell {
+    /// Source cell position.
+    pub position: CellPosition,
+
+    /// Assigned screen area.
+    pub area: Rect,
+
+    /// Column index among visible columns.
+    pub visible_column: usize,
+
+    /// Row index among visible body rows. Header cells use `None`.
+    pub visible_row: Option<usize>,
+}
+
+impl VisibleCell {
+    fn context(self, selected: bool) -> TableCellContext {
+        TableCellContext {
+            render: RenderContext {
+                state: RenderState {
+                    selected,
+                    ..RenderState::default()
+                },
+            },
+            position: self.position,
+            visible_column: self.visible_column,
+            visible_row: self.visible_row,
+        }
+    }
+}
+
+/// Solved table layout.
+///
+/// Use [`TableLayout`](crate::table::TableLayout) when code needs to inspect what a
+/// [`VirtualTable`](crate::table::VirtualTable) did during a frame:
+/// visible [`VisibleCell`](crate::table::VisibleCell) values, selected cell area, hit testing, and
+/// [`ScrollMetrics`](crate::scroll::ScrollMetrics).
+///
+/// # Fields and methods
+///
+/// - [`TableLayout::area`](crate::table::TableLayout::area) is the full terminal area assigned to
+///   the table.
+/// - [`TableLayout::header_area`](crate::table::TableLayout::header_area) is the pinned header area
+///   when headers are enabled and visible.
+/// - [`TableLayout::body_area`](crate::table::TableLayout::body_area) is the body viewport.
+/// - [`TableLayout::row_count`](crate::table::TableLayout::row_count) and
+///   [`TableLayout::column_count`](crate::table::TableLayout::column_count) are source dimensions.
+/// - [`TableLayout::row_scroll`](crate::table::TableLayout::row_scroll) and
+///   [`TableLayout::column_scroll`](crate::table::TableLayout::column_scroll) are clamped scroll
+///   offsets.
+/// - [`TableLayout::visible_cells`](crate::table::TableLayout::visible_cells) stores visible header
+///   and body cells in render order.
+/// - [`TableLayout::selected`](crate::table::TableLayout::selected) is the selected body cell when
+///   visible.
+/// - [`TableLayout::visible_positions`](crate::table::TableLayout::visible_positions) returns only
+///   visible cell ids for traversal or diagnostics.
+/// - [`TableLayout::cell_regions`](crate::table::TableLayout::cell_regions) converts visible cells
+///   into a generic [`Regions`](crate::regions::Regions).
+/// - [`TableLayout::hit_test`](crate::table::TableLayout::hit_test) maps terminal positions to
+///   [`CellPosition`](crate::table::CellPosition) values.
+/// - [`TableLayout::hit_position`](crate::table::TableLayout::hit_position) returns only the
+///   clicked cell position.
+/// - [`TableLayout::select_hit`](crate::table::TableLayout::select_hit) selects a clicked body cell
+///   in [`VirtualTableState`](crate::table::VirtualTableState).
+/// - [`TableLayout::vertical_metrics`](crate::table::TableLayout::vertical_metrics) and
+///   [`TableLayout::horizontal_metrics`](crate::table::TableLayout::horizontal_metrics) compute
+///   scrollbar data for app-owned scrollbars or status displays.
+///
+/// # Examples
+///
+/// Use the solved layout for routing and status chrome after rendering:
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::{Constraint, Rect};
+/// use ratatui_layout::table::{
+///     CellPosition, TableCellContext, TableItems, VirtualTable, VirtualTableState,
+/// };
+///
+/// struct Rows;
+/// impl TableItems for Rows {
+///     fn row_count(&self) -> usize {
+///         20
+///     }
+///     fn column_count(&self) -> usize {
+///         4
+///     }
+///     fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+/// }
+///
+/// let mut rows = Rows;
+/// let mut state = VirtualTableState::default();
+/// state.set_row_scroll(5);
+/// let mut buffer = Buffer::empty(Rect::new(0, 0, 16, 4));
+/// let layout = VirtualTable::new([Constraint::Length(4); 4]).render(
+///     buffer.area,
+///     &mut buffer,
+///     &mut state,
+///     &mut rows,
+/// );
+///
+/// assert_eq!(layout.vertical_metrics().offset, 5);
+/// assert_eq!(
+///     layout.hit_test((5, 1)).unwrap().id,
+///     CellPosition::body(5, 1)
+/// );
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TableLayout {
+    /// Full table area.
+    pub area: Rect,
+
+    /// Header area, if headers are enabled and visible.
+    pub header_area: Option<Rect>,
+
+    /// Body viewport area.
+    pub body_area: Rect,
+
+    /// Total body rows.
+    pub row_count: usize,
+
+    /// Total columns.
+    pub column_count: usize,
+
+    /// First visible body row.
+    pub row_scroll: usize,
+
+    /// First visible column.
+    pub column_scroll: usize,
+
+    /// Visible header and body cells.
+    pub visible_cells: Vec<VisibleCell>,
+
+    /// Visible selected cell, if any.
+    pub selected: Option<VisibleCell>,
+}
+
+impl TableLayout {
+    /// Returns source cell positions visible in this layout.
+    ///
+    /// Positions are returned in render order and include header cells when headers are enabled.
+    /// Use this when selection, diagnostics, or target construction only needs the ids that the
+    /// table made visible, not the full [`VisibleCell`](crate::table::VisibleCell) metadata.
+    ///
+    /// # Examples
+    ///
+    /// Build a visible-position list for keyboard traversal or diagnostics:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::table::{CellPosition, TableLayout, VisibleCell};
+    ///
+    /// let layout = TableLayout {
+    ///     area: Rect::new(0, 0, 8, 2),
+    ///     header_area: Some(Rect::new(0, 0, 8, 1)),
+    ///     body_area: Rect::new(0, 1, 8, 1),
+    ///     row_count: 1,
+    ///     column_count: 2,
+    ///     row_scroll: 0,
+    ///     column_scroll: 0,
+    ///     visible_cells: vec![
+    ///         VisibleCell {
+    ///             position: CellPosition::header(0),
+    ///             area: Rect::new(0, 0, 4, 1),
+    ///             visible_column: 0,
+    ///             visible_row: None,
+    ///         },
+    ///         VisibleCell {
+    ///             position: CellPosition::body(0, 0),
+    ///             area: Rect::new(0, 1, 4, 1),
+    ///             visible_column: 0,
+    ///             visible_row: Some(0),
+    ///         },
+    ///     ],
+    ///     selected: None,
+    /// };
+    ///
+    /// assert_eq!(
+    ///     layout.visible_positions().collect::<Vec<_>>(),
+    ///     [CellPosition::header(0), CellPosition::body(0, 0)]
+    /// );
+    /// ```
+    pub fn visible_positions(&self) -> impl Iterator<Item = CellPosition> + '_ {
+        self.visible_cells.iter().map(|cell| cell.position)
+    }
+
+    /// Converts visible cells into a generic region set keyed by
+    /// [`CellPosition`](crate::table::CellPosition).
+    ///
+    /// Use this when a virtual table needs to participate in APIs that understand
+    /// [`Regions`](crate::regions::Regions) rather than [`TableLayout`](crate::table::TableLayout).
+    /// The table layout remains the richer source of truth for pinned headers, scroll offsets,
+    /// visible row/column indexes, and scroll metrics; the returned
+    /// [`Regions`](crate::regions::Regions) value is the geometry projection used for generic
+    /// composition, pointer routing, or diagnostics.
+    ///
+    /// Use [`TableLayout::cells_regions`](crate::table::TableLayout::cells_regions) when outer
+    /// coordination code should route through domain ids instead of table coordinates.
+    ///
+    /// # Examples
+    ///
+    /// Convert visible cells into regions that can be merged into a frame snapshot:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::table::{CellPosition, TableLayout, VisibleCell};
+    ///
+    /// let layout = TableLayout {
+    ///     area: Rect::new(0, 0, 8, 2),
+    ///     header_area: Some(Rect::new(0, 0, 8, 1)),
+    ///     body_area: Rect::new(0, 1, 8, 1),
+    ///     row_count: 1,
+    ///     column_count: 2,
+    ///     row_scroll: 0,
+    ///     column_scroll: 0,
+    ///     visible_cells: vec![
+    ///         VisibleCell {
+    ///             position: CellPosition::header(0),
+    ///             area: Rect::new(0, 0, 4, 1),
+    ///             visible_column: 0,
+    ///             visible_row: None,
+    ///         },
+    ///         VisibleCell {
+    ///             position: CellPosition::body(0, 0),
+    ///             area: Rect::new(0, 1, 4, 1),
+    ///             visible_column: 0,
+    ///             visible_row: Some(0),
+    ///         },
+    ///     ],
+    ///     selected: None,
+    /// };
+    /// let plan = layout.cell_regions();
+    ///
+    /// assert_eq!(plan.hit_test((1, 1)).unwrap().id, CellPosition::body(0, 0));
+    /// ```
+    pub fn cell_regions(&self) -> Regions<CellPosition> {
+        self.cells_regions(core::convert::identity)
+    }
+
+    /// Converts visible cells into a generic region set with caller-chosen ids.
+    ///
+    /// Use this when a table renders by [`CellPosition`](crate::table::CellPosition) but the rest
+    /// of the app routes input through semantic ids. A release board might map
+    /// `CellPosition::body(row, column)` to a `(TaskId, FieldId)` pair, while keeping header
+    /// cells as sort actions. The mapper receives each visible source cell position in render
+    /// order.
+    ///
+    /// # Examples
+    ///
+    /// Project visible body cells into domain-specific ids:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::table::{CellPosition, TableLayout, VisibleCell};
+    ///
+    /// #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    /// enum Target {
+    ///     Header(usize),
+    ///     Cell { row: usize, column: usize },
+    /// }
+    ///
+    /// let layout = TableLayout {
+    ///     area: Rect::new(0, 0, 8, 2),
+    ///     header_area: Some(Rect::new(0, 0, 8, 1)),
+    ///     body_area: Rect::new(0, 1, 8, 1),
+    ///     row_count: 1,
+    ///     column_count: 2,
+    ///     row_scroll: 0,
+    ///     column_scroll: 0,
+    ///     visible_cells: vec![VisibleCell {
+    ///         position: CellPosition::body(0, 1),
+    ///         area: Rect::new(4, 1, 4, 1),
+    ///         visible_column: 1,
+    ///         visible_row: Some(0),
+    ///     }],
+    ///     selected: None,
+    /// };
+    /// let plan = layout.cells_regions(|position| match position.row {
+    ///     Some(row) => Target::Cell {
+    ///         row,
+    ///         column: position.column,
+    ///     },
+    ///     None => Target::Header(position.column),
+    /// });
+    ///
+    /// assert_eq!(
+    ///     plan.hit_test((5, 1)).unwrap().id,
+    ///     Target::Cell { row: 0, column: 1 }
+    /// );
+    /// ```
+    pub fn cells_regions<Id>(&self, mut id_for: impl FnMut(CellPosition) -> Id) -> Regions<Id> {
+        let regions: Vec<_> = self
+            .visible_cells
+            .iter()
+            .map(|cell| Region::new(id_for(cell.position), cell.area))
+            .collect();
+        Regions::from_regions(self.area, regions)
+    }
+
+    /// Returns the visible cell hit by the position.
+    ///
+    /// # Examples
+    ///
+    /// Route a previous-frame pointer position to a source table cell:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::table::{CellPosition, TableLayout, VisibleCell};
+    ///
+    /// let layout = TableLayout {
+    ///     area: Rect::new(0, 0, 8, 2),
+    ///     header_area: Some(Rect::new(0, 0, 8, 1)),
+    ///     body_area: Rect::new(0, 1, 8, 1),
+    ///     row_count: 1,
+    ///     column_count: 2,
+    ///     row_scroll: 0,
+    ///     column_scroll: 0,
+    ///     visible_cells: vec![VisibleCell {
+    ///         position: CellPosition::body(0, 1),
+    ///         area: Rect::new(4, 1, 4, 1),
+    ///         visible_column: 1,
+    ///         visible_row: Some(0),
+    ///     }],
+    ///     selected: None,
+    /// };
+    ///
+    /// assert_eq!(
+    ///     layout.hit_test((5, 1)).unwrap().id,
+    ///     CellPosition::body(0, 1)
+    /// );
+    /// ```
+    pub fn hit_test<P: Into<Position>>(&self, position: P) -> Option<Hit<CellPosition>> {
+        let position = position.into();
+        self.visible_cells
+            .iter()
+            .rev()
+            .find(|cell| cell.area.contains(position))
+            .map(|cell| Hit {
+                id: cell.position,
+                area: cell.area,
+                relative_x: position.x.saturating_sub(cell.area.x),
+                relative_y: position.y.saturating_sub(cell.area.y),
+            })
+    }
+
+    /// Returns the cell position hit by the terminal position.
+    ///
+    /// This is the common click path when an app only needs the header or body cell coordinate.
+    /// Use [`TableLayout::hit_test`](crate::table::TableLayout::hit_test) when the cell renderer
+    /// also needs local coordinates.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::table::{CellPosition, TableLayout, VisibleCell};
+    ///
+    /// let layout = TableLayout {
+    ///     area: Rect::new(0, 0, 8, 2),
+    ///     header_area: Some(Rect::new(0, 0, 8, 1)),
+    ///     body_area: Rect::new(0, 1, 8, 1),
+    ///     row_count: 1,
+    ///     column_count: 2,
+    ///     row_scroll: 0,
+    ///     column_scroll: 0,
+    ///     visible_cells: vec![VisibleCell {
+    ///         position: CellPosition::body(0, 1),
+    ///         area: Rect::new(4, 1, 4, 1),
+    ///         visible_column: 1,
+    ///         visible_row: Some(0),
+    ///     }],
+    ///     selected: None,
+    /// };
+    ///
+    /// assert_eq!(layout.hit_position((5, 1)), Some(CellPosition::body(0, 1)));
+    /// ```
+    pub fn hit_position<P: Into<Position>>(&self, position: P) -> Option<CellPosition> {
+        self.hit_test(position).map(|hit| hit.id)
+    }
+
+    /// Selects the body cell hit by the terminal position.
+    ///
+    /// Header hits and blank-space hits leave state unchanged and return `None`. This keeps
+    /// [`VirtualTableState`](crate::table::VirtualTableState) focused on body-cell selection while
+    /// still letting apps use
+    /// [`TableLayout::hit_position`](crate::table::TableLayout::hit_position) for header actions
+    /// such as sorting.
+    ///
+    /// # Examples
+    ///
+    /// Click a visible body cell and ask the next layout to reveal it:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::table::{CellPosition, TableLayout, VirtualTableState, VisibleCell};
+    ///
+    /// let layout = TableLayout {
+    ///     area: Rect::new(0, 0, 8, 2),
+    ///     header_area: Some(Rect::new(0, 0, 8, 1)),
+    ///     body_area: Rect::new(0, 1, 8, 1),
+    ///     row_count: 1,
+    ///     column_count: 2,
+    ///     row_scroll: 0,
+    ///     column_scroll: 0,
+    ///     visible_cells: vec![
+    ///         VisibleCell {
+    ///             position: CellPosition::header(1),
+    ///             area: Rect::new(4, 0, 4, 1),
+    ///             visible_column: 1,
+    ///             visible_row: None,
+    ///         },
+    ///         VisibleCell {
+    ///             position: CellPosition::body(0, 1),
+    ///             area: Rect::new(4, 1, 4, 1),
+    ///             visible_column: 1,
+    ///             visible_row: Some(0),
+    ///         },
+    ///     ],
+    ///     selected: None,
+    /// };
+    /// let mut state = VirtualTableState::default();
+    ///
+    /// assert_eq!(layout.select_hit((5, 0), &mut state), None);
+    /// assert_eq!(
+    ///     layout.select_hit((5, 1), &mut state),
+    ///     Some(CellPosition::body(0, 1))
+    /// );
+    /// assert_eq!(state.selected(), Some(CellPosition::body(0, 1)));
+    /// ```
+    pub fn select_hit<P: Into<Position>>(
+        &self,
+        position: P,
+        state: &mut VirtualTableState,
+    ) -> Option<CellPosition> {
+        let position = self.hit_position(position)?;
+        position.row?;
+        state.select(Some(position));
+        Some(position)
+    }
+
+    /// Returns vertical body scroll metrics.
+    ///
+    /// # Examples
+    ///
+    /// Build scrollbar data from the solved table body viewport:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::table::TableLayout;
+    ///
+    /// let layout = TableLayout {
+    ///     area: Rect::new(0, 0, 10, 5),
+    ///     header_area: None,
+    ///     body_area: Rect::new(0, 0, 10, 5),
+    ///     row_count: 20,
+    ///     column_count: 1,
+    ///     row_scroll: 4,
+    ///     column_scroll: 0,
+    ///     visible_cells: vec![],
+    ///     selected: None,
+    /// };
+    ///
+    /// assert_eq!(layout.vertical_metrics().offset, 4);
+    /// ```
+    pub fn vertical_metrics(&self) -> ScrollMetrics {
+        ScrollMetrics::new(
+            self.row_count as u32,
+            self.body_area.height,
+            self.row_scroll as u32,
+        )
+    }
+
+    /// Returns horizontal column scroll metrics.
+    ///
+    /// # Examples
+    ///
+    /// Build horizontal scrollbar data from visible column capacity:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Rect;
+    /// use ratatui_layout::table::{CellPosition, TableLayout, VisibleCell};
+    ///
+    /// let layout = TableLayout {
+    ///     area: Rect::new(0, 0, 10, 2),
+    ///     header_area: Some(Rect::new(0, 0, 10, 1)),
+    ///     body_area: Rect::new(0, 1, 10, 1),
+    ///     row_count: 1,
+    ///     column_count: 5,
+    ///     row_scroll: 0,
+    ///     column_scroll: 2,
+    ///     visible_cells: vec![
+    ///         VisibleCell {
+    ///             position: CellPosition::header(2),
+    ///             area: Rect::new(0, 0, 5, 1),
+    ///             visible_column: 0,
+    ///             visible_row: None,
+    ///         },
+    ///         VisibleCell {
+    ///             position: CellPosition::header(3),
+    ///             area: Rect::new(5, 0, 5, 1),
+    ///             visible_column: 1,
+    ///             visible_row: None,
+    ///         },
+    ///     ],
+    ///     selected: None,
+    /// };
+    ///
+    /// assert_eq!(layout.horizontal_metrics().offset, 2);
+    /// ```
+    pub fn horizontal_metrics(&self) -> ScrollMetrics {
+        ScrollMetrics::new(
+            self.column_count as u32,
+            self.visible_column_capacity() as u16,
+            self.column_scroll as u32,
+        )
+    }
+
+    fn visible_column_capacity(&self) -> usize {
+        self.visible_cells
+            .iter()
+            .filter(|cell| cell.position.row.is_none())
+            .count()
+            .max(
+                self.visible_cells
+                    .iter()
+                    .filter_map(|cell| cell.visible_row.map(|_| cell.visible_column + 1))
+                    .max()
+                    .unwrap_or_default(),
+            )
+    }
+}
+
+/// A virtualized table with app-owned cells.
+///
+/// Use `VirtualTable` for large or custom-rendered tables where the built-in table's ownership
+/// shape is too restrictive. It supports pinned headers, selected body cells, column-based
+/// horizontal scrolling, row virtualization, and visible-cell hit testing.
+///
+/// # Constructors and setters
+///
+/// - [`VirtualTable::new`](crate::table::VirtualTable::new) creates a table layout configuration
+///   from column constraints.
+/// - [`VirtualTable::row_height`](crate::table::VirtualTable::row_height) sets fixed body-row
+///   height.
+/// - [`VirtualTable::header_height`](crate::table::VirtualTable::header_height) sets pinned header
+///   height or hides headers with zero.
+/// - [`VirtualTable::scroll_padding`](crate::table::VirtualTable::scroll_padding) keeps space
+///   around the selected cell when possible.
+///
+/// # Layout and rendering
+///
+/// - [`VirtualTable::layout`](crate::table::VirtualTable::layout) computes
+///   [`TableLayout`](crate::table::TableLayout) and clamps
+///   [`VirtualTableState`](crate::table::VirtualTableState) without drawing.
+/// - [`VirtualTable::render`](crate::table::VirtualTable::render) computes layout, renders visible
+///   cells, and returns the layout.
+///
+/// # Examples
+///
+/// Rebuild the table layout each frame while storing only app-owned state:
+///
+/// ```rust
+/// use ratatui_core::buffer::Buffer;
+/// use ratatui_core::layout::{Constraint, Rect};
+/// use ratatui_layout::table::{
+///     CellPosition, TableCellContext, TableItems, VirtualTable, VirtualTableState,
+/// };
+///
+/// struct Rows;
+/// impl TableItems for Rows {
+///     fn row_count(&self) -> usize {
+///         3
+///     }
+///     fn column_count(&self) -> usize {
+///         2
+///     }
+///     fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+/// }
+///
+/// let mut rows = Rows;
+/// let mut state = VirtualTableState::default();
+/// state.select(Some(CellPosition::body(2, 1)));
+/// let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 3));
+/// let layout = VirtualTable::new([Constraint::Length(4), Constraint::Length(4)])
+///     .scroll_padding(1)
+///     .render(buffer.area, &mut buffer, &mut state, &mut rows);
+///
+/// assert_eq!(layout.selected.unwrap().position, CellPosition::body(2, 1));
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct VirtualTable {
+    columns: Vec<Constraint>,
+    row_height: u16,
+    header_height: u16,
+    scroll_padding: usize,
+}
+
+impl VirtualTable {
+    /// Creates a virtual table from column constraints.
+    ///
+    /// # Examples
+    ///
+    /// Compute visible table cells from ordinary Ratatui column constraints:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::table::{
+    ///     CellPosition, TableCellContext, TableItems, VirtualTable, VirtualTableState,
+    /// };
+    ///
+    /// struct Rows;
+    /// impl TableItems for Rows {
+    ///     fn row_count(&self) -> usize {
+    ///         2
+    ///     }
+    ///     fn column_count(&self) -> usize {
+    ///         2
+    ///     }
+    ///     fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+    /// }
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// let layout = VirtualTable::new([Constraint::Length(4), Constraint::Length(4)]).layout(
+    ///     Rect::new(0, 0, 8, 2),
+    ///     &mut state,
+    ///     &Rows,
+    /// );
+    ///
+    /// assert_eq!(layout.visible_cells[0].position, CellPosition::header(0));
+    /// ```
+    pub fn new<C>(columns: C) -> Self
+    where
+        C: IntoIterator,
+        C::Item: Into<Constraint>,
+    {
+        Self {
+            columns: columns.into_iter().map(Into::into).collect(),
+            row_height: 1,
+            header_height: 1,
+            scroll_padding: 0,
+        }
+    }
+
+    /// Sets the body row height.
+    ///
+    /// # Examples
+    ///
+    /// Use taller body rows when each record renders multiple terminal lines:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::table::{
+    ///     CellPosition, TableCellContext, TableItems, VirtualTable, VirtualTableState,
+    /// };
+    ///
+    /// struct Rows;
+    /// impl TableItems for Rows {
+    ///     fn row_count(&self) -> usize {
+    ///         1
+    ///     }
+    ///     fn column_count(&self) -> usize {
+    ///         1
+    ///     }
+    ///     fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+    /// }
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// let layout = VirtualTable::new([Constraint::Length(8)])
+    ///     .row_height(2)
+    ///     .layout(Rect::new(0, 0, 8, 3), &mut state, &Rows);
+    ///
+    /// assert_eq!(layout.visible_cells[1].area.height, 2);
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub fn row_height(mut self, row_height: u16) -> Self {
+        self.row_height = row_height.max(1);
+        self
+    }
+
+    /// Sets the pinned header height. Use zero to hide headers.
+    ///
+    /// # Examples
+    ///
+    /// Hide header cells for a body-only data grid:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::table::{
+    ///     CellPosition, TableCellContext, TableItems, VirtualTable, VirtualTableState,
+    /// };
+    ///
+    /// struct Rows;
+    /// impl TableItems for Rows {
+    ///     fn row_count(&self) -> usize {
+    ///         1
+    ///     }
+    ///     fn column_count(&self) -> usize {
+    ///         1
+    ///     }
+    ///     fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+    /// }
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// let layout = VirtualTable::new([Constraint::Length(8)])
+    ///     .header_height(0)
+    ///     .layout(Rect::new(0, 0, 8, 1), &mut state, &Rows);
+    ///
+    /// assert_eq!(layout.header_area, None);
+    /// assert_eq!(layout.visible_cells[0].position, CellPosition::body(0, 0));
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub const fn header_height(mut self, header_height: u16) -> Self {
+        self.header_height = header_height;
+        self
+    }
+
+    /// Sets row/column padding kept around the selected cell when possible.
+    ///
+    /// # Examples
+    ///
+    /// Keep context around a selected body cell when scrolling in both axes:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::table::{
+    ///     CellPosition, TableCellContext, TableItems, VirtualTable, VirtualTableState,
+    /// };
+    ///
+    /// struct Rows;
+    /// impl TableItems for Rows {
+    ///     fn row_count(&self) -> usize {
+    ///         10
+    ///     }
+    ///     fn column_count(&self) -> usize {
+    ///         5
+    ///     }
+    ///     fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+    /// }
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// state.select(Some(CellPosition::body(8, 4)));
+    /// VirtualTable::new([Constraint::Length(2); 5])
+    ///     .scroll_padding(1)
+    ///     .layout(Rect::new(0, 0, 4, 4), &mut state, &Rows);
+    ///
+    /// assert_eq!(state.row_scroll(), 7);
+    /// assert_eq!(state.column_scroll(), 2);
+    /// ```
+    #[must_use = "method returns the modified value"]
+    pub const fn scroll_padding(mut self, scroll_padding: usize) -> Self {
+        self.scroll_padding = scroll_padding;
+        self
+    }
+
+    /// Computes the table layout and clamps state.
+    ///
+    /// # Examples
+    ///
+    /// Compute a frame-local table layout for hit testing without rendering cells:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_layout::table::{
+    ///     CellPosition, TableCellContext, TableItems, VirtualTable, VirtualTableState,
+    /// };
+    ///
+    /// struct Rows;
+    /// impl TableItems for Rows {
+    ///     fn row_count(&self) -> usize {
+    ///         1
+    ///     }
+    ///     fn column_count(&self) -> usize {
+    ///         2
+    ///     }
+    ///     fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+    /// }
+    ///
+    /// let mut state = VirtualTableState::default();
+    /// let layout = VirtualTable::new([Constraint::Length(4), Constraint::Length(4)]).layout(
+    ///     Rect::new(0, 0, 8, 2),
+    ///     &mut state,
+    ///     &Rows,
+    /// );
+    ///
+    /// assert_eq!(
+    ///     layout.hit_test((5, 1)).unwrap().id,
+    ///     CellPosition::body(0, 1)
+    /// );
+    /// ```
+    pub fn layout<I: TableItems>(
+        self,
+        area: Rect,
+        state: &mut VirtualTableState,
+        items: &I,
+    ) -> TableLayout {
+        let row_count = items.row_count();
+        let column_count = items.column_count().min(self.columns.len());
+        Self::clamp_selection(state, row_count, column_count);
+        if state.scroll_selected_into_view {
+            self.scroll_to_selection(state, row_count, column_count, area);
+        }
+
+        let areas = self.areas(area);
+        state.row_scroll = clamp_start(
+            state.row_scroll,
+            row_count,
+            visible_rows(areas.body, self.row_height),
+        );
+        let column_scroll = state.column_scroll.min(column_count);
+        state.column_scroll = clamp_start(
+            column_scroll,
+            column_count,
+            visible_columns(area, &self.columns[column_scroll..column_count]),
+        );
+
+        let visible_cells = self.visible_cells(areas, state, row_count, column_count);
+        let selected = state.selected.and_then(|selected| {
+            visible_cells
+                .iter()
+                .find(|cell| cell.position == selected)
+                .copied()
+        });
+
+        TableLayout {
+            area,
+            header_area: areas.header,
+            body_area: areas.body,
+            row_count,
+            column_count,
+            row_scroll: state.row_scroll,
+            column_scroll: state.column_scroll,
+            visible_cells,
+            selected,
+        }
+    }
+
+    /// Computes and renders the table.
+    ///
+    /// # Examples
+    ///
+    /// Render visible cells and keep the layout for the next input event:
+    ///
+    /// ```rust
+    /// use ratatui_core::buffer::Buffer;
+    /// use ratatui_core::layout::{Constraint, Rect};
+    /// use ratatui_core::text::Line;
+    /// use ratatui_core::widgets::Widget;
+    /// use ratatui_layout::table::{
+    ///     CellPosition, TableCellContext, TableItems, VirtualTable, VirtualTableState,
+    /// };
+    ///
+    /// struct Rows(&'static [[&'static str; 2]]);
+    /// impl TableItems for Rows {
+    ///     fn row_count(&self) -> usize {
+    ///         self.0.len()
+    ///     }
+    ///     fn column_count(&self) -> usize {
+    ///         2
+    ///     }
+    ///     fn render_cell(
+    ///         &mut self,
+    ///         position: CellPosition,
+    ///         area: Rect,
+    ///         buf: &mut Buffer,
+    ///         _: TableCellContext,
+    ///     ) {
+    ///         let text = position
+    ///             .row
+    ///             .map(|row| self.0[row][position.column])
+    ///             .unwrap_or("header");
+    ///         Line::from(text).render(area, buf);
+    ///     }
+    /// }
+    ///
+    /// let mut rows = Rows(&[["a", "b"]]);
+    /// let mut state = VirtualTableState::default();
+    /// let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 2));
+    /// let layout = VirtualTable::new([Constraint::Length(4), Constraint::Length(4)]).render(
+    ///     buffer.area,
+    ///     &mut buffer,
+    ///     &mut state,
+    ///     &mut rows,
+    /// );
+    ///
+    /// assert_eq!(layout.visible_cells.len(), 4);
+    /// ```
+    pub fn render<I: TableItems>(
+        self,
+        area: Rect,
+        buf: &mut Buffer,
+        state: &mut VirtualTableState,
+        items: &mut I,
+    ) -> TableLayout {
+        let layout = self.layout(area, state, items);
+        for cell in layout.visible_cells.iter().copied() {
+            let selected = state.selected == Some(cell.position);
+            items.render_cell(cell.position, cell.area, buf, cell.context(selected));
+        }
+        layout
+    }
+
+    fn clamp_selection(state: &mut VirtualTableState, row_count: usize, column_count: usize) {
+        if let Some(selected) = state.selected {
+            state.selected = selected.row.filter(|row| *row < row_count).and_then(|row| {
+                (selected.column < column_count).then_some(CellPosition::body(row, selected.column))
+            });
+            if state.selected.is_none() {
+                state.scroll_selected_into_view = false;
+            }
+        }
+    }
+
+    fn scroll_to_selection(
+        &self,
+        state: &mut VirtualTableState,
+        row_count: usize,
+        column_count: usize,
+        area: Rect,
+    ) {
+        let Some(selected) = state
+            .selected
+            .and_then(|position| position.row.map(|row| (row, position.column)))
+        else {
+            return;
+        };
+        let areas = self.areas(area);
+        let rows = visible_rows(areas.body, self.row_height);
+        let columns = visible_columns(
+            area,
+            &self.columns[state.column_scroll.min(column_count)..column_count],
+        );
+        state.row_scroll = scroll_to_index(
+            state.row_scroll,
+            selected.0,
+            row_count,
+            rows,
+            self.scroll_padding,
+        );
+        state.column_scroll = scroll_to_index(
+            state.column_scroll,
+            selected.1,
+            column_count,
+            columns,
+            self.scroll_padding,
+        );
+    }
+
+    fn areas(&self, area: Rect) -> TableAreas {
+        if self.header_height == 0 || area.height == 0 {
+            return TableAreas {
+                header: None,
+                body: area,
+            };
+        }
+
+        let header_height = self.header_height.min(area.height);
+        let header = Rect::new(area.x, area.y, area.width, header_height);
+        let body = Rect::new(
+            area.x,
+            area.y.saturating_add(header_height),
+            area.width,
+            area.height.saturating_sub(header_height),
+        );
+        TableAreas {
+            header: Some(header),
+            body,
+        }
+    }
+
+    fn visible_cells(
+        &self,
+        areas: TableAreas,
+        state: &VirtualTableState,
+        row_count: usize,
+        column_count: usize,
+    ) -> Vec<VisibleCell> {
+        let mut cells = Vec::new();
+        let columns = self.visible_column_areas(areas.body, state.column_scroll, column_count);
+        if let Some(header) = areas.header {
+            cells.extend(columns.iter().copied().map(|column| VisibleCell {
+                position: CellPosition::header(column.index),
+                area: Rect::new(column.area.x, header.y, column.area.width, header.height),
+                visible_column: column.visible_index,
+                visible_row: None,
+            }));
+        }
+
+        let rows = visible_rows(areas.body, self.row_height);
+        let last_row = state.row_scroll.saturating_add(rows).min(row_count);
+        for (visible_row, row) in (state.row_scroll..last_row).enumerate() {
+            let y = areas
+                .body
+                .y
+                .saturating_add((visible_row as u16).saturating_mul(self.row_height));
+            let height = self.row_height.min(areas.body.bottom().saturating_sub(y));
+            cells.extend(columns.iter().copied().map(|column| VisibleCell {
+                position: CellPosition::body(row, column.index),
+                area: Rect::new(column.area.x, y, column.area.width, height),
+                visible_column: column.visible_index,
+                visible_row: Some(visible_row),
+            }));
+        }
+        cells
+    }
+
+    fn visible_column_areas(
+        &self,
+        area: Rect,
+        column_scroll: usize,
+        column_count: usize,
+    ) -> Vec<VisibleColumn> {
+        let constraints = &self.columns[column_scroll..column_count];
+        Layout::horizontal(constraints.iter().copied())
+            .split(area)
+            .iter()
+            .copied()
+            .enumerate()
+            .take_while(|(_, area)| area.width > 0)
+            .map(|(visible_index, area)| VisibleColumn {
+                index: column_scroll + visible_index,
+                visible_index,
+                area,
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TableAreas {
+    header: Option<Rect>,
+    body: Rect,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct VisibleColumn {
+    index: usize,
+    visible_index: usize,
+    area: Rect,
+}
+
+fn visible_rows(area: Rect, row_height: u16) -> usize {
+    if row_height == 0 {
+        return 0;
+    }
+    usize::from(area.height / row_height)
+}
+
+fn visible_columns(area: Rect, constraints: &[Constraint]) -> usize {
+    Layout::horizontal(constraints.iter().copied())
+        .split(area)
+        .iter()
+        .filter(|area| area.width > 0)
+        .count()
+}
+
+fn clamp_start(start: usize, len: usize, visible: usize) -> usize {
+    if len <= visible {
+        0
+    } else {
+        start.min(len - visible)
+    }
+}
+
+fn scroll_to_index(
+    start: usize,
+    selected: usize,
+    len: usize,
+    visible: usize,
+    padding: usize,
+) -> usize {
+    if visible == 0 || len <= visible {
+        return 0;
+    }
+
+    let padding = padding.min(visible.saturating_sub(1) / 2);
+    if selected < start.saturating_add(padding) {
+        return selected.saturating_sub(padding);
+    }
+
+    let padded_end = start.saturating_add(visible).saturating_sub(padding + 1);
+    if selected > padded_end {
+        return selected.saturating_add(padding + 1).saturating_sub(visible);
+    }
+
+    start
+}
+
+const fn offset_index(index: usize, delta: isize) -> usize {
+    if delta.is_negative() {
+        index.saturating_sub(delta.unsigned_abs())
+    } else {
+        index.saturating_add(delta as usize)
+    }
+}
+
+const fn clamp_index(index: usize, len: usize) -> usize {
+    if index >= len { len - 1 } else { index }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use ratatui_core::layout::Constraint;
+
+    use super::*;
+
+    struct EmptyTable {
+        rows: usize,
+        columns: usize,
+    }
+
+    impl TableItems for EmptyTable {
+        fn row_count(&self) -> usize {
+            self.rows
+        }
+
+        fn column_count(&self) -> usize {
+            self.columns
+        }
+
+        fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+    }
+
+    #[test]
+    fn lays_out_pinned_headers_and_body_cells() {
+        let table = VirtualTable::new([Constraint::Length(4), Constraint::Length(6)]);
+        let mut state = VirtualTableState::default();
+        let layout = table.layout(
+            Rect::new(0, 0, 10, 3),
+            &mut state,
+            &EmptyTable {
+                rows: 2,
+                columns: 2,
+            },
+        );
+
+        assert_eq!(layout.header_area, Some(Rect::new(0, 0, 10, 1)));
+        assert_eq!(layout.visible_cells.len(), 6);
+        assert_eq!(layout.visible_cells[0].position, CellPosition::header(0));
+        assert_eq!(layout.visible_cells[2].position, CellPosition::body(0, 0));
+    }
+
+    #[test]
+    fn keeps_selected_cell_visible() {
+        let table = VirtualTable::new([Constraint::Length(2); 5]).scroll_padding(1);
+        let mut state = VirtualTableState::default();
+        state.select(Some(CellPosition::body(8, 4)));
+
+        let layout = table.layout(
+            Rect::new(0, 0, 4, 4),
+            &mut state,
+            &EmptyTable {
+                rows: 10,
+                columns: 5,
+            },
+        );
+
+        assert_eq!(state.row_scroll(), 7);
+        assert_eq!(state.column_scroll(), 2);
+        assert_eq!(layout.selected.unwrap().position, CellPosition::body(8, 4));
+    }
+
+    #[test]
+    fn relative_selection_clamps_to_table_bounds() {
+        let mut state = VirtualTableState::default();
+
+        assert_eq!(
+            state.select_relative(1, 0, 3, 2),
+            Some(CellPosition::body(0, 0))
+        );
+        assert!(state.scrolls_selected_into_view());
+        assert_eq!(
+            state.select_relative(1, 1, 3, 2),
+            Some(CellPosition::body(1, 1))
+        );
+        assert_eq!(
+            state.select_relative(99, 99, 3, 2),
+            Some(CellPosition::body(2, 1))
+        );
+        assert_eq!(
+            state.select_relative(-99, -99, 3, 2),
+            Some(CellPosition::body(0, 0))
+        );
+        assert_eq!(state.select_relative(1, 0, 0, 2), None);
+        assert_eq!(state.selected(), None);
+    }
+
+    #[test]
+    fn row_scroll_does_not_snap_back_to_selection() {
+        let table = VirtualTable::new([Constraint::Length(2); 5]).scroll_padding(1);
+        let mut state = VirtualTableState::default();
+        state.select(Some(CellPosition::body(0, 0)));
+        state.scroll_rows_by(6);
+
+        let layout = table.layout(
+            Rect::new(0, 0, 4, 4),
+            &mut state,
+            &EmptyTable {
+                rows: 10,
+                columns: 5,
+            },
+        );
+
+        assert_eq!(state.selected(), Some(CellPosition::body(0, 0)));
+        assert_eq!(state.row_scroll(), 6);
+        assert_eq!(layout.selected, None);
+    }
+
+    #[test]
+    fn hit_test_returns_cell_position() {
+        let table = VirtualTable::new([Constraint::Length(4), Constraint::Length(4)]);
+        let mut state = VirtualTableState::default();
+        let layout = table.layout(
+            Rect::new(0, 0, 8, 2),
+            &mut state,
+            &EmptyTable {
+                rows: 1,
+                columns: 2,
+            },
+        );
+
+        assert_eq!(
+            layout.hit_test((5, 1)).unwrap().id,
+            CellPosition::body(0, 1)
+        );
+    }
+
+    #[test]
+    fn cell_plan_preserves_visible_cell_geometry() {
+        let table = VirtualTable::new([Constraint::Length(4), Constraint::Length(4)]);
+        let mut state = VirtualTableState::default();
+        let layout = table.layout(
+            Rect::new(0, 0, 8, 2),
+            &mut state,
+            &EmptyTable {
+                rows: 1,
+                columns: 2,
+            },
+        );
+        let plan = layout.cell_regions();
+
+        assert_eq!(plan.area(), Rect::new(0, 0, 8, 2));
+        assert_eq!(plan.hit_test((1, 0)).unwrap().id, CellPosition::header(0));
+        assert_eq!(plan.hit_test((5, 1)).unwrap().id, CellPosition::body(0, 1));
+    }
+
+    #[test]
+    fn cells_plan_maps_positions_to_app_ids() {
+        let table = VirtualTable::new([Constraint::Length(4), Constraint::Length(4)]);
+        let mut state = VirtualTableState::default();
+        let layout = table.layout(
+            Rect::new(0, 0, 8, 2),
+            &mut state,
+            &EmptyTable {
+                rows: 1,
+                columns: 2,
+            },
+        );
+        let plan = layout.cells_regions(|position| match position.row {
+            Some(row) => ("body", row, position.column),
+            None => ("header", 0, position.column),
+        });
+
+        assert_eq!(plan.hit_test((1, 0)).unwrap().id, ("header", 0, 0));
+        assert_eq!(plan.hit_test((5, 1)).unwrap().id, ("body", 0, 1));
+    }
+
+    #[test]
+    fn select_hit_selects_body_cells_but_not_headers() {
+        let table = VirtualTable::new([Constraint::Length(4), Constraint::Length(4)]);
+        let mut state = VirtualTableState::default();
+        let layout = table.layout(
+            Rect::new(0, 0, 8, 2),
+            &mut state,
+            &EmptyTable {
+                rows: 1,
+                columns: 2,
+            },
+        );
+
+        assert_eq!(layout.select_hit((5, 0), &mut state), None);
+        assert_eq!(state.selected(), None);
+        assert_eq!(
+            layout.select_hit((5, 1), &mut state),
+            Some(CellPosition::body(0, 1))
+        );
+        assert_eq!(state.selected(), Some(CellPosition::body(0, 1)));
+    }
+}

--- a/crates/ratatui-layout/src/text_input.rs
+++ b/crates/ratatui-layout/src/text_input.rs
@@ -1,0 +1,334 @@
+//! Text-input coordination without choosing a text widget.
+//!
+//! Text entry needs several small pieces to agree: edit commands mutate the string, the cursor
+//! state moves through character positions, a rendered field provides a focus and pointer target,
+//! and the terminal cursor should land inside the editable text. This module packages those
+//! mechanics while leaving labels, borders, validation, masking, and styling to the app or widget.
+//!
+//! # Types
+//!
+//! - [`TextEdit`](crate::text_input::TextEdit) is a rendering-agnostic edit command.
+//! - [`TextInputState`](crate::text_input::TextInputState) owns the persistent cursor state for one
+//!   editable string.
+//! - [`TextInput`](crate::text_input::TextInput) describes the current frame's target id, prefix
+//!   width, focus order, and z-order.
+//! - [`TextInputLayout`](crate::text_input::TextInputLayout) exposes the field area, editable area,
+//!   cursor request, and frame snapshot.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use ratatui_core::layout::Rect;
+//! use ratatui_layout::text_input::{TextEdit, TextInput, TextInputState};
+//!
+//! let mut value = String::from("ops");
+//! let mut state = TextInputState::at_end(&value);
+//! state.apply(TextEdit::Insert('!'), &mut value);
+//! let input = TextInput::new("owner").prefix_width(7);
+//! let layout = input.layout(Rect::new(0, 0, 20, 1), state, true);
+//!
+//! assert_eq!(value, "ops!");
+//! assert_eq!(layout.edit_area().x, 7);
+//! assert_eq!(layout.cursor_request().position.x, 11);
+//! ```
+
+use alloc::string::String;
+
+use ratatui_core::layout::{Position, Rect};
+
+use crate::cursor::{CursorRequest, CursorRequests};
+use crate::frame::{FrameSnapshot, FrameTargets};
+use crate::input::TextFieldState;
+
+/// Edit command understood by [`TextInputState`](crate::text_input::TextInputState).
+///
+/// This enum is deliberately backend-agnostic. An app maps crossterm, termwiz, or custom key
+/// events into these commands, then calls
+/// [`TextInputState::apply`](crate::text_input::TextInputState::apply) to mutate the string and
+/// cursor together.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum TextEdit {
+    /// Insert one character at the cursor.
+    Insert(char),
+    /// Remove the character before the cursor.
+    Backspace,
+    /// Remove the character at the cursor.
+    Delete,
+    /// Move the cursor one character left.
+    Left,
+    /// Move the cursor one character right.
+    Right,
+    /// Move the cursor to the start of the string.
+    Home,
+    /// Move the cursor to the end of the string.
+    End,
+}
+
+/// Persistent cursor state for one editable string.
+///
+/// [`TextInputState`](crate::text_input::TextInputState) wraps
+/// [`TextFieldState`](crate::input::TextFieldState) with a command-level API. The app still owns
+/// the text value so validation, persistence, undo, and domain conversion stay in application code.
+/// Store one state per editable value.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TextInputState {
+    field: TextFieldState,
+}
+
+impl TextInputState {
+    /// Creates a cursor state at the start of the text.
+    pub const fn new() -> Self {
+        Self {
+            field: TextFieldState::new(),
+        }
+    }
+
+    /// Creates a cursor state at the end of an existing value.
+    ///
+    /// This is useful when opening an edit dialog and placing the cursor after the current text.
+    pub fn at_end(value: &str) -> Self {
+        Self {
+            field: TextFieldState::at_end(value),
+        }
+    }
+
+    /// Returns the underlying cursor state.
+    ///
+    /// Use this when interoperating with lower-level helpers that already accept
+    /// [`TextFieldState`](crate::input::TextFieldState).
+    pub const fn field(&self) -> &TextFieldState {
+        &self.field
+    }
+
+    /// Returns mutable access to the underlying cursor state.
+    ///
+    /// This keeps escape hatches local for apps that need custom text movement or validation.
+    pub const fn field_mut(&mut self) -> &mut TextFieldState {
+        &mut self.field
+    }
+
+    /// Returns the current cursor position in characters.
+    pub const fn cursor(self) -> usize {
+        self.field.cursor()
+    }
+
+    /// Clamps the cursor to the current value length.
+    ///
+    /// Call this after replacing the entire text value from validation, paste handling, or external
+    /// application state.
+    pub fn clamp_to(&mut self, value: &str) {
+        self.field.clamp_to(value);
+    }
+
+    /// Applies an edit command to the value and cursor.
+    ///
+    /// The command operates on Rust `char` boundaries. It does not implement grapheme clusters,
+    /// masking, or horizontal scrolling; those concerns belong in a richer text widget built on top
+    /// of this state helper.
+    pub fn apply(&mut self, edit: TextEdit, value: &mut String) {
+        match edit {
+            TextEdit::Insert(character) => self.field.insert_char(value, character),
+            TextEdit::Backspace => self.field.backspace(value),
+            TextEdit::Delete => self.field.delete(value),
+            TextEdit::Left => self.field.move_left(),
+            TextEdit::Right => self.field.move_right(value),
+            TextEdit::Home => self.field.move_home(),
+            TextEdit::End => self.field.move_end(value),
+        }
+    }
+}
+
+/// Frame-local layout policy for a single-line text input.
+///
+/// [`TextInput`](crate::text_input::TextInput) identifies the field, reserves optional prefix
+/// columns for a label, and produces focus, pointer, and cursor data for the current frame. It does
+/// not render the label or text and does not own the edited string.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct TextInput<Id = usize> {
+    id: Id,
+    prefix_width: u16,
+    focus_order: u16,
+    z: u16,
+}
+
+impl<Id> TextInput<Id> {
+    /// Creates text-input layout policy for one app-owned id.
+    pub const fn new(id: Id) -> Self {
+        Self {
+            id,
+            prefix_width: 0,
+            focus_order: 0,
+            z: 0,
+        }
+    }
+
+    /// Reserves columns before the editable text.
+    ///
+    /// Use this when a field renders a label such as `owner:` before the editable value. Cursor
+    /// placement and pointer-to-cursor conversion happen inside the editable area after the prefix.
+    #[must_use = "method returns the modified text input"]
+    pub const fn prefix_width(mut self, prefix_width: u16) -> Self {
+        self.prefix_width = prefix_width;
+        self
+    }
+
+    /// Sets the focus order assigned to the field.
+    #[must_use = "method returns the modified text input"]
+    pub const fn focus_order(mut self, focus_order: u16) -> Self {
+        self.focus_order = focus_order;
+        self
+    }
+
+    /// Sets the z-order assigned to the field target.
+    #[must_use = "method returns the modified text input"]
+    pub const fn z(mut self, z: u16) -> Self {
+        self.z = z;
+        self
+    }
+
+    /// Solves the editable area and creates frame-local input targets.
+    ///
+    /// When `focused` is true, the returned frame includes a cursor request based on the current
+    /// cursor state and prefix width.
+    pub fn layout(self, area: Rect, state: TextInputState, focused: bool) -> TextInputLayout<Id>
+    where
+        Id: Copy,
+    {
+        let edit_area = Rect {
+            x: area.x.saturating_add(self.prefix_width).min(area.right()),
+            width: area.width.saturating_sub(self.prefix_width),
+            ..area
+        };
+        let mut frame = FrameTargets::new(area, self.focus_order)
+            .z(self.z)
+            .region(self.id, area);
+        let cursor_request = state
+            .field
+            .cursor_request_after_prefix(area, self.prefix_width);
+        if focused {
+            frame = frame.cursor(CursorRequests::new().request(cursor_request));
+        }
+        TextInputLayout {
+            id: self.id,
+            area,
+            edit_area,
+            cursor_request,
+            frame,
+        }
+    }
+}
+
+/// Solved frame-local data for one [`TextInput`](crate::text_input::TextInput).
+///
+/// Use this value to render text into
+/// [`TextInputLayout::edit_area`](crate::text_input::TextInputLayout::edit_area), store
+/// [`TextInputLayout::frame`](crate::text_input::TextInputLayout::frame) for routing, place the
+/// terminal cursor, and map pointer positions back to cursor indexes.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct TextInputLayout<Id = usize> {
+    id: Id,
+    area: Rect,
+    edit_area: Rect,
+    cursor_request: CursorRequest,
+    frame: FrameSnapshot<Id>,
+}
+
+impl<Id> TextInputLayout<Id> {
+    /// Returns the field id.
+    pub const fn id(&self) -> &Id {
+        &self.id
+    }
+
+    /// Returns the whole field area, including any label prefix.
+    pub const fn area(&self) -> Rect {
+        self.area
+    }
+
+    /// Returns the editable text area after the label prefix.
+    pub const fn edit_area(&self) -> Rect {
+        self.edit_area
+    }
+
+    /// Returns the cursor request computed for the editable text.
+    ///
+    /// The request is available even when the field is not focused. Only focused layouts add it to
+    /// the returned frame snapshot.
+    pub const fn cursor_request(&self) -> &CursorRequest {
+        &self.cursor_request
+    }
+
+    /// Returns the frame snapshot for focus, pointer, and cursor routing.
+    pub const fn frame(&self) -> &FrameSnapshot<Id> {
+        &self.frame
+    }
+
+    /// Places the cursor from a pointer position inside the editable area.
+    ///
+    /// This maps terminal columns to character positions using one column per `char`. A richer text
+    /// widget can replace this with width-aware or grapheme-aware logic while still using the same
+    /// field target and cursor state.
+    pub fn place_cursor_from_position(
+        &self,
+        position: impl Into<Position>,
+        value: &str,
+        state: &mut TextInputState,
+    ) -> bool {
+        let position = position.into();
+        if !self.edit_area.contains(position) {
+            return false;
+        }
+        let local_x = position.x.saturating_sub(self.edit_area.x) as usize;
+        let cursor = local_x.min(value.chars().count());
+        state.field.set_cursor(cursor, value);
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+
+    use ratatui_core::layout::Rect;
+
+    use super::{TextEdit, TextInput, TextInputState};
+
+    #[test]
+    fn applies_text_edits_to_value_and_cursor() {
+        let mut value = String::from("ab");
+        let mut state = TextInputState::at_end(&value);
+
+        state.apply(TextEdit::Insert('c'), &mut value);
+        state.apply(TextEdit::Left, &mut value);
+        state.apply(TextEdit::Backspace, &mut value);
+
+        assert_eq!(value, "ac");
+        assert_eq!(state.cursor(), 1);
+    }
+
+    #[test]
+    fn input_layout_accounts_for_prefix_width() {
+        let value = String::from("owner");
+        let state = TextInputState::at_end(&value);
+        let layout =
+            TextInput::new("field")
+                .prefix_width(7)
+                .layout(Rect::new(0, 0, 20, 1), state, true);
+
+        assert_eq!(layout.edit_area(), Rect::new(7, 0, 13, 1));
+        assert_eq!(layout.cursor_request().position.x, 12);
+    }
+
+    #[test]
+    fn pointer_position_places_cursor_in_edit_area() {
+        let value = String::from("abcd");
+        let mut state = TextInputState::new();
+        let layout =
+            TextInput::new("field")
+                .prefix_width(2)
+                .layout(Rect::new(0, 0, 10, 1), state, false);
+
+        assert!(layout.place_cursor_from_position((5, 0), &value, &mut state));
+        assert_eq!(state.cursor(), 3);
+    }
+}

--- a/crates/ratatui-layout/src/viewport.rs
+++ b/crates/ratatui-layout/src/viewport.rs
@@ -1,0 +1,262 @@
+//! Generic viewport layout.
+//!
+//! A [`Viewport`](crate::viewport::Viewport) maps a visible terminal rectangle onto a larger
+//! content size. It clamps the caller's desired offset and returns the visible content-space
+//! rectangle. It does not render content and does not create scrollbars; callers use the returned
+//! [`ViewportLayout`](crate::viewport::ViewportLayout) to drive their own rendering and scrollbar
+//! state.
+//!
+//! Use direct rendering when all content fits. Use this module when a render pass needs clamped
+//! content-space coordinates that can also drive app-owned scrollbars or status text.
+//! Ratatui widgets or direct buffer rendering remain simpler when there is no larger content-space
+//! model to preserve between input events.
+//!
+//! # Types
+//!
+//! - [`ViewportState`](crate::viewport::ViewportState) stores the desired content offset between
+//!   frames.
+//! - [`Viewport`](crate::viewport::Viewport) stores the content size for one layout pass and clamps
+//!   the state.
+//! - [`ViewportLayout`](crate::viewport::ViewportLayout) is the solved frame-local value: screen
+//!   viewport, content size, clamped offset, and visible content-space rectangle.
+//!
+//! See [`crate::docs::virtualization`] for the broader viewport, list, table, and scroll-metrics
+//! model.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use ratatui_core::layout::{Position, Rect, Size};
+//! use ratatui_layout::viewport::{Viewport, ViewportState};
+//!
+//! let mut state = ViewportState::new(Position::new(50, 10));
+//! let layout = Viewport::new(Size::new(100, 40)).layout(Rect::new(0, 0, 20, 5), &mut state);
+//!
+//! assert_eq!(layout.offset, Position::new(50, 10));
+//! assert_eq!(layout.visible_content, Rect::new(50, 10, 20, 5));
+//! ```
+
+use ratatui_core::layout::{Position, Rect, Size};
+
+/// Scroll state for a rectangular viewport.
+///
+/// Use [`ViewportState`](crate::viewport::ViewportState) when user input can request scroll
+/// positions that may later become invalid. The user can press right or down before content size is
+/// known; [`Viewport::layout`](crate::viewport::Viewport::layout) clamps the stored offset once the
+/// current viewport and content size are available.
+///
+/// # Constructor
+///
+/// - [`ViewportState::new`](crate::viewport::ViewportState::new) creates state with a desired
+///   content offset.
+///
+/// # Examples
+///
+/// ```rust
+/// use ratatui_core::layout::{Position, Rect, Size};
+/// use ratatui_layout::viewport::{Viewport, ViewportState};
+///
+/// let mut state = ViewportState::new(Position::new(99, 99));
+/// Viewport::new(Size::new(20, 10)).layout(Rect::new(0, 0, 5, 5), &mut state);
+///
+/// assert_eq!(state.offset, Position::new(15, 5));
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ViewportState {
+    /// The desired content offset.
+    pub offset: Position,
+}
+
+impl ViewportState {
+    /// Creates viewport state with the given offset.
+    ///
+    /// # Examples
+    ///
+    /// Store a user-requested offset before the next frame knows current content bounds:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::Position;
+    /// use ratatui_layout::viewport::ViewportState;
+    ///
+    /// let state = ViewportState::new(Position::new(10, 3));
+    ///
+    /// assert_eq!(state.offset, Position::new(10, 3));
+    /// ```
+    pub const fn new(offset: Position) -> Self {
+        Self { offset }
+    }
+}
+
+/// A generic scroll viewport layout helper.
+///
+/// Use [`Viewport`](crate::viewport::Viewport) when a widget has larger logical content than
+/// visible screen space but the widget still renders that content itself.
+/// [`Viewport`](crate::viewport::Viewport) does not draw text, scrollbars, or clipping buffers; it
+/// answers which content-space rectangle should be visible and clamps the
+/// [`ViewportState`](crate::viewport::ViewportState).
+///
+/// # Constructors and solving
+///
+/// - [`Viewport::new`](crate::viewport::Viewport::new) creates a viewport helper for a full logical
+///   content size.
+/// - [`Viewport::layout`](crate::viewport::Viewport::layout) clamps
+///   [`ViewportState`](crate::viewport::ViewportState) and returns
+///   [`ViewportLayout`](crate::viewport::ViewportLayout) for rendering and scroll metrics.
+///
+/// # Examples
+///
+/// Use a viewport when input changes a logical content offset before rendering:
+///
+/// ```rust
+/// use ratatui_core::layout::{Position, Rect, Size};
+/// use ratatui_layout::scroll::ScrollMetrics;
+/// use ratatui_layout::viewport::{Viewport, ViewportState};
+///
+/// let mut state = ViewportState::new(Position::new(30, 10));
+/// let layout = Viewport::new(Size::new(100, 40)).layout(Rect::new(0, 0, 20, 5), &mut state);
+/// let horizontal = ScrollMetrics::horizontal(&layout);
+///
+/// assert_eq!(layout.visible_content, Rect::new(30, 10, 20, 5));
+/// assert_eq!(horizontal.offset, 30);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct Viewport {
+    content_size: Size,
+}
+
+impl Viewport {
+    /// Creates a viewport for content of the given size.
+    ///
+    /// # Examples
+    ///
+    /// Describe a content canvas larger than the terminal viewport:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Position, Rect, Size};
+    /// use ratatui_layout::viewport::{Viewport, ViewportState};
+    ///
+    /// let mut state = ViewportState::new(Position::new(5, 0));
+    /// let layout = Viewport::new(Size::new(100, 20)).layout(Rect::new(0, 0, 20, 5), &mut state);
+    ///
+    /// assert_eq!(layout.visible_content.x, 5);
+    /// ```
+    pub const fn new(content_size: Size) -> Self {
+        Self { content_size }
+    }
+
+    /// Solves the viewport and clamps the state offset.
+    ///
+    /// If the content is smaller than the viewport on an axis, that axis is clamped to zero. The
+    /// returned [`ViewportLayout::visible_content`](crate::viewport::ViewportLayout::visible_content) is expressed in content coordinates, not screen
+    /// coordinates.
+    ///
+    /// # Examples
+    ///
+    /// Convert a terminal viewport into the content-space rectangle to render:
+    ///
+    /// ```rust
+    /// use ratatui_core::layout::{Position, Rect, Size};
+    /// use ratatui_layout::viewport::{Viewport, ViewportState};
+    ///
+    /// let mut state = ViewportState::new(Position::new(30, 5));
+    /// let layout = Viewport::new(Size::new(80, 30)).layout(Rect::new(0, 0, 20, 10), &mut state);
+    ///
+    /// assert_eq!(layout.viewport, Rect::new(0, 0, 20, 10));
+    /// assert_eq!(layout.visible_content, Rect::new(30, 5, 20, 10));
+    /// ```
+    pub fn layout(self, area: Rect, state: &mut ViewportState) -> ViewportLayout {
+        let max_x = self.content_size.width.saturating_sub(area.width);
+        let max_y = self.content_size.height.saturating_sub(area.height);
+        let offset = Position::new(state.offset.x.min(max_x), state.offset.y.min(max_y));
+        state.offset = offset;
+
+        let visible_width = area
+            .width
+            .min(self.content_size.width.saturating_sub(offset.x));
+        let visible_height = area
+            .height
+            .min(self.content_size.height.saturating_sub(offset.y));
+        let visible_content = Rect::new(offset.x, offset.y, visible_width, visible_height);
+
+        ViewportLayout {
+            viewport: area,
+            content_size: self.content_size,
+            offset,
+            visible_content,
+        }
+    }
+}
+
+/// Solved viewport metadata.
+///
+/// Use [`ViewportLayout`](crate::viewport::ViewportLayout) after solving a
+/// [`Viewport`](crate::viewport::Viewport) to render only the visible content slice or
+/// to report scroll state. For example, a custom canvas can use
+/// [`ViewportLayout::visible_content`](crate::viewport::ViewportLayout::visible_content) to decide
+/// which world rows to draw while a separate scrollbar uses
+/// [`ViewportLayout::content_size`](crate::viewport::ViewportLayout::content_size) and
+/// [`ViewportLayout::offset`](crate::viewport::ViewportLayout::offset).
+///
+/// # Fields
+///
+/// - [`ViewportLayout::viewport`](crate::viewport::ViewportLayout::viewport) is the terminal-space
+///   area being drawn.
+/// - [`ViewportLayout::content_size`](crate::viewport::ViewportLayout::content_size) is the full
+///   logical content size.
+/// - [`ViewportLayout::offset`](crate::viewport::ViewportLayout::offset) is the clamped
+///   content-space origin.
+/// - [`ViewportLayout::visible_content`](crate::viewport::ViewportLayout::visible_content) is the
+///   content-space rectangle visible through the viewport.
+///
+/// # Examples
+///
+/// Render code can compare screen-space and content-space rectangles from one value:
+///
+/// ```rust
+/// use ratatui_core::layout::{Position, Rect, Size};
+/// use ratatui_layout::viewport::{Viewport, ViewportState};
+///
+/// let mut state = ViewportState::new(Position::new(5, 2));
+/// let layout = Viewport::new(Size::new(30, 10)).layout(Rect::new(1, 1, 10, 4), &mut state);
+///
+/// assert_eq!(layout.viewport, Rect::new(1, 1, 10, 4));
+/// assert_eq!(layout.visible_content, Rect::new(5, 2, 10, 4));
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ViewportLayout {
+    /// The visible viewport area.
+    pub viewport: Rect,
+    /// The full scrollable content size.
+    pub content_size: Size,
+    /// The clamped content offset.
+    pub offset: Position,
+    /// The content-space rectangle visible in the viewport.
+    pub visible_content: Rect,
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+    use ratatui_core::layout::{Position, Rect, Size};
+
+    use super::*;
+
+    #[test]
+    fn clamps_offset_to_content_bounds() {
+        let mut state = ViewportState::new(Position::new(99, 99));
+        let layout = Viewport::new(Size::new(10, 8)).layout(Rect::new(0, 0, 4, 3), &mut state);
+
+        assert_eq!(state.offset, Position::new(6, 5));
+        assert_eq!(layout.visible_content, Rect::new(6, 5, 4, 3));
+    }
+
+    #[test]
+    fn clamps_offset_to_zero_when_content_fits() {
+        let mut state = ViewportState::new(Position::new(1, 1));
+        Viewport::new(Size::new(2, 2)).layout(Rect::new(0, 0, 4, 3), &mut state);
+
+        assert_eq!(state.offset, Position::ORIGIN);
+    }
+}

--- a/crates/ratatui-layout/use-cases/0001-command-toolbar-routing.md
+++ b/crates/ratatui-layout/use-cases/0001-command-toolbar-routing.md
@@ -1,0 +1,347 @@
+# 0001 Ordered Action Surfaces
+
+## User Story
+
+An app exposes a small ordered set of actions or choices as visible UI. The surface might look like
+a footer command strip, a toolbar, a dialog button row, a menu, a tab bar, a radio group, or a
+segmented control. The app still renders ordinary Ratatui widgets, but keyboard focus, mouse input,
+disabled state, selection, and activation must all agree on the same app-level ids.
+
+The app can render labels, icons, brackets, tabs, or buttons however it wants. The stable concern is
+coordination: a visible ordered action id must carry enough frame-local data that the next input
+event can route back to the same app action.
+
+## Concrete App Shapes
+
+### Footer Command Strip
+
+A task board has a footer:
+
+```text
+commands  e edit    r run    m mark done    ? help
+```
+
+The app needs `MarkDone` to stay visible but disabled when no task is selected. Keyboard shortcuts
+can activate commands directly, Tab can move through visible command targets, and mouse clicks can
+activate the command under the pointer.
+
+The app-specific command id is probably an enum:
+
+```rust
+enum Command {
+    Edit,
+    Run,
+    MarkDone,
+    Help,
+}
+```
+
+The command strip needs an ordered layout, disabled-state policy, focus targets, mouse targets, and
+activation routing. Labels, styles, shortcuts, and command effects stay app-owned.
+
+### Toolbar
+
+A database console has a top toolbar:
+
+```text
+[ connect ] [ refresh ] [ explain ] [ export ]
+```
+
+Some commands depend on connection state or query selection. The toolbar may be rendered with
+bordered buttons, but the same coordination problem applies:
+
+- disabled commands remain visible;
+- focus traversal skips disabled commands;
+- hover styling uses the command id;
+- click routing uses previous-frame regions;
+- command execution stays in the app.
+
+A toolbar may reserve larger fixed widths, use icons, or live in a page header. Those rendering
+choices stay outside the primitive model.
+
+### Dialog Button Row
+
+A modal edit dialog has a button row:
+
+```text
+[ cancel ] [ save ]
+```
+
+The row is still an ordered action surface, but the local navigation policy may differ:
+
+- Left and Right move between buttons.
+- Enter activates the focused button.
+- Escape activates `Cancel`.
+- `Save` may be disabled until the form is valid.
+
+This case shows why "global focus movement" and "local action-row movement" are separate concerns.
+The app might use a page-level `FocusState` to focus the button row, then a `ButtonRow` or similar
+local state to focus one button inside the row.
+
+### Menu
+
+A file picker or editor has a menu:
+
+```text
+file
+  new
+  open
+  save
+  save as
+```
+
+The same ordered action concept can render top to bottom. A menu may also have nested submenus,
+separators, accelerators, and disabled items. Those are rendering and menu policy details. The core
+frame-local data are familiar:
+
+- visible item ids in traversal order;
+- rectangles for hit testing;
+- disabled items that remain visible;
+- focus or hover movement through enabled items;
+- activation of the focused or clicked item.
+
+Menus make orientation a layout policy. The same action-surface model needs to cover horizontal
+toolbars, vertical menus, and eventually grid-like command palettes.
+
+### Tab Bar
+
+A log viewer has tabs:
+
+```text
+all | errors | warnings | deploys
+```
+
+Tabs are ordered action ids, but activation changes a persistent selected tab. Disabled state is
+less common, while selection is central. Arrow keys may move focus without activating, or they may
+activate immediately depending on the app's policy.
+
+The important distinction:
+
+- focus is "where keyboard input is currently aimed";
+- selection is "which tab controls the visible content";
+- activation is "the user committed a tab change."
+
+The crate needs to coordinate these states without collapsing them into one overloaded value.
+
+### Segmented Control
+
+A release board has a compact mode selector:
+
+```text
+queued | running | blocked | done
+```
+
+This is tab-like, but it is usually embedded in another pane and may sit outside the main page Tab
+order. It still wants:
+
+- ordered ids;
+- selected id;
+- mouse hit testing;
+- optional focus traversal;
+- app-owned rendering.
+
+This case pressures the design to avoid assuming every ordered action surface is globally focusable.
+
+### Radio Group
+
+A settings dialog has a radio-style choice:
+
+```text
+( ) compact
+(*) comfortable
+( ) spacious
+```
+
+Radio groups share the selected-value shape with tab bars and segmented controls. The selected
+value has a different meaning: it is form state. Activating another option changes the pending form
+value. Focus may move between options without changing the selected value, or the app may choose
+immediate selection on arrow movement.
+
+This case reinforces the state split:
+
+- focus is the option that receives keyboard interaction;
+- selection is the app-owned value;
+- activation is the user committing a choice;
+- disabled options can remain visible and unselectable.
+
+The crate needs to expose enough data for either radio policy without deciding the policy itself.
+
+## Core Necessity
+
+All of these shapes need the same irreducible frame-local model:
+
+1. The app owns an ordered list of action ids.
+1. The render pass assigns each visible id a rectangle.
+1. The render pass records whether each visible id is enabled.
+1. The render pass may record whether each id is focusable or mouseable.
+1. Rendering uses those same ids to choose visual state.
+1. The next keyboard or mouse event routes through data from the previous frame.
+1. The app owns activation effects.
+
+The core crate concern is therefore:
+
+> Given a visible ordered set of app action ids, produce consistent geometry, focus targets, mouse
+> targets, disabled behavior, selection hooks, and activation routing for the next event.
+
+## Primitive Boundary
+
+These concerns belong to the app or to a higher-level widget crate:
+
+- labels, icons, shortcut text, and styling;
+- whether the surface renders as tabs, footer text, bordered buttons, or compact segments;
+- whether the surface is horizontal, vertical, or grid-like;
+- command execution side effects;
+- crossterm or backend-specific event types;
+- validation rules that decide whether a command is enabled;
+- retained children or a retained toolbar widget.
+
+## Current Crate Path
+
+The current crate has no `ActionSurface` widget. It solves this with smaller frame-local
+primitives:
+
+- `Row::named`, `Column::named`, and `Grid::layout` assign rectangles to app-owned ids.
+- `Regions` and `Region` preserve visible geometry, render order, clipping, and z-order.
+- `FrameTargets::from_regions` derives layout, focus, and pointer data from the same solved regions.
+- `RegionTargets::disabled`, `RegionTargets::focusable`, and
+  `RegionTargets::mouseable` keep visible, enabled, focusable, and mouseable policy separate.
+- `FocusState::ensure_visible` repairs stale focus against the current frame with an explicit
+  `FocusFallback`.
+- `SelectionState` keeps selected values separate from focus, hover, and activation.
+- `ButtonRow` handles local left/right focus inside dialogs.
+
+### Command Strip With Current Primitives
+
+Start by naming layout regions with app command ids:
+
+```rust
+let commands = [
+    (Command::Edit, Constraint::Length(8)),
+    (Command::Run, Constraint::Length(6)),
+    (Command::MarkDone, Constraint::Length(12)),
+    (Command::Help, Constraint::Length(6)),
+];
+let command_regions = Row::named(commands)
+    .spacing(1)
+    .regions(area);
+```
+
+The same regions produce frame-local routing data:
+
+```rust
+let frame = FrameTargets::from_regions(command_regions, COMMAND_FOCUS)
+    .disabled(|command| !app.is_enabled(command))
+    .build();
+
+app.focus.ensure_visible(&frame.focus, FocusFallback::First);
+app.previous_frame = frame;
+```
+
+Disabled commands remain renderable in `frame.layout`, while click, hover, and focus traversal skip
+disabled targets.
+
+### Rendering State From The Same Ids
+
+Rendering still belongs to the app. The crate gives stable ids and areas; the app chooses labels,
+shortcut text, and styles:
+
+```rust
+for region in frame.layout.regions() {
+    let focused = app.focus.focused() == Some(region.id);
+    let selected = app.selection.is_selected(region.id);
+    let enabled = app.is_enabled(region.id);
+    render_command(frame, region.id, region.area, focused, selected, enabled);
+}
+```
+
+The same ids can render footer text, toolbar buttons, tabs, or radio rows.
+
+### Pointer And Focus Policy
+
+Some surfaces are mouseable but not page-focusable:
+
+```rust
+let frame = FrameTargets::from_regions(command_regions, STATUS_FILTER_FOCUS)
+    .focusable(|_| false)
+    .build();
+```
+
+Some surfaces are focusable but only partly mouseable:
+
+```rust
+let frame = FrameTargets::from_regions(command_regions, FORM_FOCUS)
+    .mouseable(|id| matches!(id, FieldTarget::EditButton(_)))
+    .build();
+```
+
+`route_position` remains available for broad geometry queries. Click, hover, and wheel routing use
+explicit mouse targets when a pointer target collection exists.
+
+### Orientation As Layout Policy
+
+Orientation comes from layout:
+
+```rust
+let toolbar = Row::named(toolbar_commands)
+    .spacing(1)
+    .regions(toolbar_area);
+let menu = Column::named(menu_items).regions(menu_area);
+```
+
+Both values can feed `FrameTargets::from_regions`; geometry and key policy provide the difference.
+
+### Selection And Activation
+
+Tabs, segmented controls, and radio groups need selected values. `SelectionState` keeps selection
+separate from focus:
+
+```rust
+if let Some(hit) = app.previous_frame.route_click(position) {
+    app.selection.select(hit.id);
+    app.activate(hit.id);
+}
+```
+
+A tab bar may select on arrow movement; a radio group may wait until Enter. That remains app
+policy.
+
+### Dialog Button Rows
+
+`ButtonRow` remains useful for dialog buttons. Page-level `FocusState` can focus the row as a
+whole while `ButtonRowState` chooses the button inside it.
+
+## Remaining Design Questions
+
+The remaining gaps are above region-to-frame construction:
+
+1. A reusable action description could pair id, width, enabled state, shortcut text, and label
+   without turning into a retained widget.
+1. A future `ActionSurface` could wrap `Row`, `Column`, or `Grid` for command strips, menus, tabs,
+   segmented controls, and radio groups while still returning ordinary `FrameSnapshot` data.
+1. Local roving focus helpers could expose ordered enabled ids for menus, tab bars, and radio
+   groups without forcing every surface into page-level `FocusTargets`.
+1. Selection adapters could make "focus moves only" and "focus movement selects immediately"
+   policies easier to express at the call site.
+1. A higher-level widget crate could provide default rendering for buttons, tabs, menu items, and
+   radio rows while this crate stays focused on geometry and frame-local coordination.
+
+## Validation Checklist
+
+Any proposed primitive for this use case needs to support:
+
+- enum ids for app commands;
+- stable render order;
+- fixed widths and fill widths;
+- hidden actions removed from layout;
+- disabled actions visible but skipped by focus and mouse activation;
+- focus movement that can be global or local depending on the app;
+- selection distinct from focus;
+- mouse hover and click routing through previous-frame-local data;
+- a non-focusable segmented control;
+- a vertical menu using the same routing model as a horizontal toolbar;
+- a radio group where selected value is form state;
+- a dialog button row with Cancel and Save;
+- app-owned labels, styling, shortcuts, and command effects.
+
+If an API cannot explain at least the footer strip, toolbar, button row, menu, tab bar, radio
+group, and segmented control without special cases, it is probably too narrow.

--- a/crates/ratatui-layout/use-cases/0002-modal-dialog-coordination.md
+++ b/crates/ratatui-layout/use-cases/0002-modal-dialog-coordination.md
@@ -1,0 +1,347 @@
+# 0002 Modal Dialog Coordination
+
+## User Story
+
+An app opens a raised surface over the current screen. The page behind it remains visible, but input
+belongs to the dialog until the user dismisses it or completes the dialog action.
+
+The dialog might contain a confirmation prompt, a help overlay, a picker, a details preview, or a
+form. Those contents matter to the app, but the dialog coordination problem is narrower: place the
+frontmost region, keep routing local to it, and make the next event use the same regions the user
+just saw.
+
+## Concrete App Shapes
+
+### Confirmation Prompt
+
+A release dashboard asks before cancelling a deployment:
+
+```text
+cancel deployment?
+
+[ no ]  [ yes, cancel ]
+```
+
+The app needs the prompt to sit above the board, route clicks to the visible buttons, and make
+Escape or `No` dismiss the prompt. It may also dismiss when the user clicks outside the prompt, or
+it may intentionally ignore outside clicks. There may be no editable fields at all.
+
+### Help Overlay
+
+A complex inspector opens a help overlay with command descriptions. It needs to clear and draw above
+the page, capture `Esc`, and route scroll events inside the help text if the content is long.
+
+This is a dialog even though it has no form state and no Save button.
+
+### Picker Dialog
+
+A file picker, command picker, or connection picker shows a filtered list over the current page. It
+needs a raised region, focused rows, mouse hit testing, and either Enter or click activation. The
+selected value belongs to the app; the dialog only contributes visible routing data.
+
+### Form Dialog
+
+An edit dialog places fields and Save/Cancel buttons inside the same raised region. This combines
+dialog coordination with the separate form-editing use case. The dialog owns the overlay behavior;
+the form owns edit buffers, text cursors, validation, and submit/cancel policy.
+
+## Core Necessity
+
+All modal dialogs need the same frame-local mechanics:
+
+1. Compute an outer region that visually sits above the page.
+1. Compute an inner region for content without forcing a retained widget tree.
+1. Record z-order so pointer routing agrees with the visual stack.
+1. Keep keyboard focus inside the dialog while it is open.
+1. Route mouse clicks, hover, and scroll to frontmost dialog targets.
+1. Decide what a click outside the dialog means by checking for a negative hit or routing through an
+   explicit backdrop target.
+1. Optionally request a terminal cursor from the active child control.
+1. Return one frame-local artifact that the parent app stores for the next input event.
+
+The contents of the dialog can still be ordinary Ratatui rendering. The crate should coordinate
+regions and input data, not decide whether the dialog is a form, picker, help view, or prompt.
+
+## Current Crate Path
+
+Use [`Container`](../src/container.rs) and [`Padding`](../src/container.rs) to derive the outer
+dialog region and the inner content region. The app can render `Clear` and a Ratatui `Block` into
+the outer region, then render any content into the inner region.
+
+```rust
+use ratatui_core::layout::Rect;
+use ratatui_layout::{Container, Padding};
+
+let outer = Rect::new(10, 4, 52, 10);
+let dialog = Container::<()>::new()
+    .padding(Padding::new(2, 2, 2, 1))
+    .layout(outer);
+
+assert_eq!(dialog.outer, outer);
+assert!(dialog.inner.width < dialog.outer.width);
+```
+
+Use [`Column`](../src/linear.rs), [`Row`](../src/linear.rs), or
+[`Overlay`](../src/overlay.rs) to produce named content regions. Enum ids are usually the clearest
+choice because the app will match on them when handling focus, activation, or dismissal.
+
+```rust
+use ratatui_core::layout::{Constraint, Rect};
+use ratatui_layout::Row;
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+enum PromptAction {
+    No,
+    YesCancel,
+}
+
+let prompt_buttons = [
+    (PromptAction::No, Constraint::Length(8)),
+    (PromptAction::YesCancel, Constraint::Length(14)),
+];
+let buttons = Row::named(prompt_buttons)
+    .spacing(2)
+    .regions(Rect::new(12, 10, 36, 1));
+```
+
+Use [`FrameTargets`](../src/frame.rs) or [`FrameSnapshot`](../src/frame.rs) to return the data the
+dialog produced. The z value is what makes the modal route before the page behind it.
+
+```rust
+use ratatui_core::layout::{Constraint, Rect};
+use ratatui_layout::{FrameTargets, Row};
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+enum PromptAction {
+    No,
+    YesCancel,
+}
+
+let prompt_buttons = [
+    (PromptAction::No, Constraint::Length(8)),
+    (PromptAction::YesCancel, Constraint::Length(14)),
+];
+let buttons = Row::named(prompt_buttons).regions(Rect::new(12, 10, 30, 1));
+
+let frame = FrameTargets::from_regions(buttons, 100).z(20).build();
+
+assert_eq!(frame.mouse.hit_test((13, 10)).unwrap().id, PromptAction::No);
+```
+
+Clicking outside the dialog is its own policy decision. A modal confirmation might dismiss, a
+destructive form might ignore the click, and a picker might clear hover without closing. If the app
+routes against the dialog frame before the page behind it, a negative hit means the click missed the
+dialog.
+
+```rust
+use ratatui_core::layout::{Constraint, Rect};
+use ratatui_layout::{FrameTargets, Row};
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+enum PromptAction {
+    No,
+    YesCancel,
+}
+
+let prompt_buttons = [
+    (PromptAction::No, Constraint::Length(8)),
+    (PromptAction::YesCancel, Constraint::Length(14)),
+];
+let buttons = Row::named(prompt_buttons).regions(Rect::new(12, 10, 30, 1));
+let frame = FrameTargets::from_regions(buttons, 100).z(20).build();
+
+assert!(frame.route_click((2, 2)).is_none());
+
+// The app decides whether that negative hit dismisses the dialog or is ignored.
+```
+
+When the app wants outside clicks to be routed explicitly, add a backdrop target behind the dialog's
+child targets. Region targets still win inside the dialog because they are added after the whole-region
+mouse target.
+
+```rust
+use ratatui_core::layout::{Constraint, Rect};
+use ratatui_layout::{FrameTargets, Row};
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+enum PromptAction {
+    No,
+    YesCancel,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+enum DialogTarget {
+    Backdrop,
+    Button(PromptAction),
+}
+
+let screen = Rect::new(0, 0, 80, 24);
+let prompt_buttons = [
+    (PromptAction::No, Constraint::Length(8)),
+    (PromptAction::YesCancel, Constraint::Length(14)),
+];
+let buttons = Row::named(prompt_buttons).regions(Rect::new(12, 10, 30, 1));
+
+let frame = FrameTargets::new(screen, 100)
+    .z(20)
+    .mouse_region(DialogTarget::Backdrop, screen)
+    .build_focusable(buttons.regions().iter().copied(), DialogTarget::Button);
+
+assert_eq!(frame.route_click((2, 2)).unwrap().id, DialogTarget::Backdrop);
+assert_eq!(
+    frame.route_click((13, 10)).unwrap().id,
+    DialogTarget::Button(PromptAction::No),
+);
+```
+
+Use [`FocusTargets::from_regions`](../src/focus.rs) when every planned dialog region should
+participate in keyboard traversal.
+
+```rust
+use ratatui_core::layout::{Constraint, Rect};
+use ratatui_layout::{FocusFallback, FocusTargets, FocusState, Row};
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+enum DialogButton {
+    Cancel,
+    Confirm,
+}
+
+let dialog_buttons = [
+    (DialogButton::Cancel, Constraint::Length(10)),
+    (DialogButton::Confirm, Constraint::Length(10)),
+];
+let buttons = Row::named(dialog_buttons).regions(Rect::new(0, 0, 22, 1));
+
+let focus_plan = FocusTargets::from_regions(buttons.regions().iter().copied());
+let mut focus = FocusState::default();
+
+focus.ensure_visible(&focus_plan, FocusFallback::First);
+```
+
+Use [`CursorRequests`](../src/cursor.rs) only when a child control needs the terminal cursor. A
+confirmation prompt or help overlay may never request one. A form field inside the dialog can
+contribute one cursor request, and the parent app can apply the final cursor after all frame snapshots
+are merged.
+
+## Coordination Data Analysis
+
+A dialog does not always need every coordination type. The useful bundle depends on what the dialog
+contains and how outside interaction should behave.
+
+| Shape               | Layout | Mouse | Focus | Selection | Cursor | Aggregate |
+| ------------------- | ------ | ----- | ----- | --------- | ------ | --------- |
+| Confirmation prompt | yes    | yes   | maybe | no        | no     | maybe     |
+| Help overlay        | yes    | maybe | no    | no        | no     | maybe     |
+| Picker dialog       | yes    | yes   | maybe | yes       | no     | maybe     |
+| Form dialog         | yes    | maybe | yes   | maybe     | yes    | maybe     |
+
+The common dialog data are geometry, z-order, and routing boundary. Focus, selection, and cursor
+data come from the dialog contents. This is why the dialog primitive should stay smaller than a
+form primitive.
+
+For a prompt, the simple shape can be a button layout plus a backdrop target:
+
+```rust
+let frame = FrameTargets::new(screen, 100)
+    .z(20)
+    .mouse_region(DialogTarget::Backdrop, screen)
+    .build_focusable(buttons.regions().iter().copied(), DialogTarget::Button);
+let clicked = frame.route_click(position);
+```
+
+For a help overlay, the useful data may be only the outer region and a scroll target:
+
+```rust
+let frame = FrameSnapshot::new(screen)
+    .scroll_region(DialogTarget::HelpText, help_area);
+```
+
+For a form dialog, the dialog shell and the form contents can remain separate:
+
+```rust
+let dialog = FrameSnapshot::new(screen).mouse_target(backdrop);
+let form = render_form_fields().map_id(DialogTarget::Form);
+let frame = dialog.merge(form);
+```
+
+The examples above are intentionally different. A single dialog helper should not force all three
+shapes to carry focus, selection, and cursor requests when they do not need them.
+
+Runnable examples:
+
+- `cargo run -p ratatui-layout --example modal_prompt`
+- `cargo run -p ratatui-layout --example container_dialog`
+- `cargo run -p ratatui-layout --example frame_snapshot`
+
+## What This Validates
+
+The crate already covers the dialog mechanics without defining a dialog widget:
+
+- container layout separates the modal shell from ordinary Ratatui rendering;
+- named regions make rendered regions routeable by app-owned ids;
+- z-order lets the dialog win pointer routing over the page behind it;
+- negative hits and backdrop targets make outside-click behavior explicit instead of accidental;
+- focus target collections and focus state keep keyboard input local while the dialog is open;
+- frame snapshots give the parent app one artifact to store after rendering and use for the next event;
+- cursor requests remain optional child data rather than a dialog requirement.
+
+The useful design pressure is to make overlay coordination explicit and repeatable without deciding
+what the dialog contains.
+
+## Simplicity Check
+
+The current pieces cover the core dialog mechanics:
+
+- `Container` gives outer and inner regions without owning rendering.
+- `Row`, `Column`, and `Overlay` produce child regions with app-owned ids.
+- `FrameTargets` builds aligned layout, mouse, and focus target data when a child set needs them.
+- `FrameSnapshot::new`, `FrameSnapshot::mouse_target`, and `FrameSnapshot::scroll_region` support dialog-level
+  data that are not tied to child regions.
+- `FrameSnapshot::merge` lets the shell and contents stay separate.
+- `route_click` returning `None` is enough for negative-hit outside-click behavior when the app does
+  not want an explicit backdrop id.
+
+The rough spots are call-site shape and naming, not missing capability. A small helper may be worth
+exploring if examples keep repeating the same shell code. The `modal_prompt` example currently has
+to compute a container, build named button regions, add a backdrop target, apply a high z value, and
+merge that data by hand:
+
+```rust
+let shell = ModalShell::new(screen, dialog_area)
+    .z(20)
+    .backdrop(DialogTarget::Backdrop)
+    .layout();
+let frame = shell.frame().merge(content_frame);
+```
+
+That helper would be useful only if it stays narrow:
+
+- compute outer, inner, and clipping areas;
+- apply a z value consistently;
+- optionally add a backdrop mouse target;
+- merge child data into the dialog coordinate space.
+
+It should not own buttons, fields, validation, submit/cancel behavior, or focus policy for every
+dialog. Those belong to ordered action surfaces, form editing, picker/list selection, or the app.
+
+## Related Use Cases
+
+- [`0001 Ordered Action Surfaces`](0001-command-toolbar-routing.md) covers the button row shape used
+  by prompts and dialogs.
+- [`0009 Form Editing`](0009-form-editing.md) covers text fields, edit buffers, validation, and
+  save/cancel policy that may appear inside a dialog.
+- [`0008 Mouse Overlays And Disabled Targets`](0008-mouse-overlays-and-disabled-targets.md) covers
+  overlapping pointer targets and disabled controls in more detail.
+
+## Remaining Design Questions
+
+Keep dialog coordination separate from form semantics. The remaining questions are dialog-level:
+
+- whether there should be a small helper for "raised modal frame with inner content area";
+- how focus trapping should be represented when the page still has a previous frame snapshot;
+- whether outside-click behavior needs a helper or should remain an ordinary negative-hit/backdrop
+  routing pattern;
+- how scroll regions inside dialogs should compose with page scroll regions behind them;
+- whether dismissal policy should remain app-specific or get a tiny route helper;
+- how much frame-snapshot construction can be wrapped before it hides useful app decisions.

--- a/crates/ratatui-layout/use-cases/0003-filtered-record-selection.md
+++ b/crates/ratatui-layout/use-cases/0003-filtered-record-selection.md
@@ -1,0 +1,182 @@
+# 0003 Filtered Record Selection
+
+## User Story
+
+An app displays domain records: tasks, log streams, database rows, releases, issues, or files. The
+user can filter, sort, or scroll the visible list. Commands should operate on the selected record,
+not on whichever visible row happens to occupy the same index after filtering.
+
+This is the point where a widget-local selected index stops being enough. The app needs a stable
+record id for commands and details panes, while rendering still needs the selected visible position.
+
+## Concrete App Shapes
+
+### Filtered Task List
+
+A task board toggles between all tasks and blocked tasks. If `DOC-004` is selected and the blocked
+filter hides it, the app should choose an explicit fallback, usually the first visible blocked task.
+If no tasks are visible, selection should clear.
+
+### Sorted Database Rows
+
+A database browser sorts rows by different columns. The selected row should stay attached to the
+same primary key when its visible position changes.
+
+### Search Results
+
+A search pane updates visible results on every keystroke. The selected result should stay selected
+while it remains visible, fall back predictably when it disappears, and never accidentally point at
+a different record just because that record moved into the same index.
+
+### Virtualized Record View
+
+A large list or table may render only a visible window. The app still needs commands to operate on a
+durable id, while row highlighting, keyboard movement, and hit testing use visible positions.
+
+## Core Necessity
+
+Filtered record selection needs two identities for one selected thing:
+
+1. The app owns a durable selected id, such as a task id, file path, database primary key, or record
+   handle.
+1. The current frame owns a visible position, such as a row index or cell coordinate.
+1. Filtering, sorting, and virtualization can change the visible position without changing the
+   durable id.
+1. If the durable id is no longer visible, the app needs an explicit fallback.
+1. If no visible ids exist, selection should clear.
+1. Mouse wheel scrolling should move the viewport, not the selected record.
+
+This use case is mostly persistent selection state plus a visible-id bridge. It should not require
+a full `FrameSnapshot`.
+
+## Current Crate Path
+
+Use [`VisibleSelection`](../src/selection.rs) when selection must keep both a durable id and a
+visible index. The common case is a visible slice of durable ids:
+
+```rust
+use ratatui_layout::VisibleSelection;
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct TaskId(u16);
+
+let mut selection = VisibleSelection::new();
+let visible_ids = [TaskId(1), TaskId(2), TaskId(3)];
+
+selection.sync_ids(&visible_ids);
+assert_eq!(selection.position(), Some(0));
+assert_eq!(selection.selected_id(), Some(TaskId(1)));
+```
+
+Use [`VisibleSelection::sync_ids`](../src/selection.rs) after filtering or sorting changes the
+visible ids. It preserves the current selected id when possible and falls back to the first visible
+id when the old selection is gone.
+
+```rust
+use ratatui_layout::VisibleSelection;
+
+let mut selection = VisibleSelection::new();
+selection.select_visible(1, "docs");
+
+let filtered_ids = ["api"];
+selection.sync_ids(&filtered_ids);
+
+assert_eq!(selection.position(), Some(0));
+assert_eq!(selection.selected_id(), Some("api"));
+```
+
+Use [`VisibleSelection::select_index`](../src/selection.rs) after a click or hit test has resolved
+to a visible row index.
+
+```rust
+use ratatui_layout::VisibleSelection;
+
+let visible_ids = ["api", "docs"];
+let mut selection = VisibleSelection::new();
+
+selection.select_index(1, &visible_ids);
+
+assert_eq!(selection.selected_id(), Some("docs"));
+```
+
+Use [`VisibleSelection::move_by`](../src/selection.rs) for keyboard movement through visible ids.
+When nothing visible is selected yet, the first movement selects the first visible id. Later
+movement applies the requested offset, clamps at the first and last visible id, and clears selection
+when no ids are visible.
+
+```rust
+use ratatui_layout::VisibleSelection;
+
+let visible_ids = ["api", "docs", "ops"];
+let mut selection = VisibleSelection::new();
+
+selection.move_by(1, &visible_ids);
+assert_eq!(selection.selected_id(), Some("api"));
+
+selection.move_by(1, &visible_ids);
+assert_eq!(selection.selected_id(), Some("docs"));
+
+selection.move_by(99, &visible_ids);
+assert_eq!(selection.selected_id(), Some("ops"));
+```
+
+Keep [`VisibleSelection::sync`](../src/selection.rs) and
+[`VisibleSelection::select_position`](../src/selection.rs) for custom projections. They are still
+the right tool when the visible position is not a simple `usize` index into an id slice.
+
+Runnable examples:
+
+- `cargo run -p ratatui-layout --example visible_selection_filter`
+- `cargo run -p ratatui-layout --example visible_selection_virtual_list`
+- `cargo run -p ratatui-layout --example selection_modes`
+- `cargo run -p ratatui-layout --example virtual_list`
+
+## Coordination Data Analysis
+
+Filtered record selection does not usually need an aggregate frame snapshot.
+
+| Shape                   | Layout | Mouse | Focus | Selection | Cursor | Aggregate |
+| ----------------------- | ------ | ----- | ----- | --------- | ------ | --------- |
+| Filtered task list      | maybe  | maybe | no    | yes       | no     | no        |
+| Sorted database rows    | maybe  | maybe | no    | yes       | no     | no        |
+| Search results          | maybe  | maybe | maybe | yes       | no     | maybe     |
+| Virtualized record view | yes    | maybe | no    | yes       | no     | maybe     |
+
+The central state is selection, not layout. Layout, mouse, focus, or virtual list data may help the
+view render or route input, but the selected record id should not be hidden inside that data.
+
+## What This Validates
+
+The crate now covers the common visible-id path directly:
+
+- durable selected ids remain separate from visible indexes;
+- visible-id slices can repair stale selection after filtering;
+- keyboard movement can operate over visible ids without manually clamping indexes;
+- click selection can select by visible index while storing the durable id;
+- the closure-based APIs remain available for custom projections.
+
+The important design pressure is keeping selection app-owned. The crate can help bridge visible
+positions to durable ids, but it should not decide filtering, sorting, fallback policy beyond the
+simple first-visible default, or command behavior.
+
+## Related Use Cases
+
+- [`0010 Frame Snapshots`](0010-frame-snapshots.md) explains why this use case mostly needs
+  persistent state rather than a full `FrameSnapshot`.
+- [`0005 Virtual List Row Rendering`](0005-virtual-list-row-rendering.md) covers virtualized row
+  layout when visible rows are expensive or variable height.
+- [`0006 Virtual Table Inspection`](0006-virtual-table-inspection.md) covers two-axis visible
+  positions and selected cells.
+- [`0004 Multi-Pane Scroll Routing`](0004-multi-pane-scroll-routing.md) covers wheel routing that
+  should not move selection.
+
+## Remaining Design Questions
+
+The current helpers are intentionally narrow. Possible future pressure:
+
+- a configurable fallback other than first visible id, such as nearest previous visible id;
+- range selection for shift-click or shift-arrow workflows;
+- stable record-id helpers for `VirtualList` and `VirtualTable` examples;
+- a small adapter from visible row/cell hit tests into durable record ids.
+
+Those should be validated with more examples before adding a broader record-selection abstraction.

--- a/crates/ratatui-layout/use-cases/0004-multi-pane-scroll-routing.md
+++ b/crates/ratatui-layout/use-cases/0004-multi-pane-scroll-routing.md
@@ -1,0 +1,179 @@
+# 0004 Multi-Pane Scroll Routing
+
+## User Story
+
+An app has several scrollable panes: a project tree, task table, log pane, details pane, or help
+overlay. Mouse-wheel input should scroll the pane under the pointer, including blank space. It
+should not change the selected item unless the user explicitly moves selection.
+
+This is common in dashboards and inspectors where selection drives details while the user scans
+nearby content.
+
+## Concrete App Shapes
+
+### Release Inspector
+
+A release board has a project tree on the left, a task table in the center, and a details log on the
+right. Wheel input over each pane should move only that pane's viewport. The selected task remains
+the selected task.
+
+### Log Viewer
+
+A split log viewer shows build output and service logs side by side. The pointer may be over blank
+space below the last visible line, but wheel input should still route to the pane the user is
+looking at.
+
+### Help Overlay
+
+A modal help overlay may contain long text. Wheel input inside the overlay should scroll help text,
+not the page behind it. Wheel input outside the overlay might dismiss, be ignored, or route to a
+backdrop policy, depending on the app.
+
+### Virtual Table
+
+A large table may scroll vertically and horizontally. Wheel input should adjust viewport offsets.
+Selection should move only on keyboard navigation, row clicks, or explicit activation.
+
+## Core Necessity
+
+Multi-pane scroll routing needs four separate decisions:
+
+1. Which pane rectangle was visible in the last frame?
+1. Which pane should receive wheel input at the pointer position?
+1. How does that pane update its viewport offset?
+1. Which selection state, if any, remains unchanged?
+
+The important split is that mouse-wheel routing is pointer routing plus viewport state. Selection is
+not part of the normal wheel path.
+
+## Current Crate Path
+
+Use [`FrameSnapshot::scroll_region`](../src/frame.rs) or
+[`FrameTargets::mouse_region`](../src/frame.rs) to register whole-pane wheel targets. Whole-region
+targets make blank pane space interactive, so wheel input does not depend on hitting a visible row.
+
+```rust
+use ratatui_core::layout::Rect;
+use ratatui_layout::FrameSnapshot;
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+enum Pane {
+    BuildLog,
+    Details,
+}
+
+let screen = Rect::new(0, 0, 80, 24);
+let details = Rect::new(40, 1, 39, 22);
+let frame = FrameSnapshot::new(screen).scroll_region(Pane::Details, details);
+
+assert_eq!(frame.route_scroll((45, 20)).unwrap().id, Pane::Details);
+```
+
+Use [`FrameSnapshot::route_scroll`](../src/frame.rs) on the next event. The input handler should route
+the pointer position through the previous frame, then update the pane's viewport offset.
+
+```rust
+use ratatui_core::layout::Rect;
+use ratatui_layout::FrameSnapshot;
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+enum Pane {
+    BuildLog,
+}
+
+let frame = FrameSnapshot::new(Rect::new(0, 0, 40, 10))
+    .scroll_region(Pane::BuildLog, Rect::new(0, 0, 40, 10));
+let hit = frame.route_scroll((5, 9)).unwrap();
+
+assert_eq!(hit.id, Pane::BuildLog);
+```
+
+Use [`ScrollMetrics`](../src/scroll.rs) for simple fixed-height panes. It clamps the requested
+offset, reports scrollbar/status math, and now exposes
+[`ScrollMetrics::visible_range`](../src/scroll.rs) for slicing app-owned rows.
+
+```rust
+use ratatui_layout::ScrollMetrics;
+
+let rows = ["queued", "running", "blocked", "done"];
+let metrics = ScrollMetrics::new(rows.len() as u32, 2, 10);
+
+assert_eq!(metrics.offset, 2);
+assert_eq!(&rows[metrics.visible_range()], &["blocked", "done"]);
+```
+
+When the pane is virtualized, use the state type that belongs to that virtualized view.
+[`VirtualListState::scroll_viewport_by`](../src/list.rs) and
+[`VirtualTableState::scroll_viewport_by`](../src/table.rs) move the viewport without changing
+selection.
+
+```rust
+use ratatui_layout::list::VirtualListState;
+
+let mut state = VirtualListState::default();
+state.select(Some(10));
+state.scroll_viewport_by(3);
+
+assert_eq!(state.selected(), Some(10));
+```
+
+Runnable examples:
+
+- `cargo run -p ratatui-layout --example pointer_only_scroll_region`
+- `cargo run -p ratatui-layout --example scroll_regions`
+- `cargo run -p ratatui-layout --example visible_selection_virtual_list`
+- `cargo run -p ratatui-layout --example table_inspector`
+- `cargo run -p ratatui-layout --example viewport`
+
+## Coordination Data Analysis
+
+Scroll routing does not require a full frame aggregate for every pane, but it often benefits from
+one at page boundaries because layout, mouse regions, and scroll metrics are derived together.
+
+| Shape           | Layout | Mouse | Focus | Selection | Cursor | Aggregate |
+| --------------- | ------ | ----- | ----- | --------- | ------ | --------- |
+| Split log panes | maybe  | yes   | no    | no        | no     | maybe     |
+| Details pane    | yes    | yes   | maybe | no        | no     | maybe     |
+| Help overlay    | yes    | yes   | no    | no        | no     | maybe     |
+| Virtual list    | yes    | maybe | no    | maybe     | no     | maybe     |
+| Virtual table   | yes    | maybe | no    | maybe     | no     | maybe     |
+
+The central frame value is the mouse region for the pane. Layout and metrics help render scroll
+status. Focus is useful only when keyboard scrolling should target the focused pane. Selection is
+persistent app state and should stay out of wheel routing unless the app intentionally couples the
+two.
+
+## What This Validates
+
+The crate now covers the common scroll-routing path:
+
+- whole-pane mouse targets route wheel events over blank space;
+- previous-frame routing keeps input aligned with what the user just saw;
+- `ScrollMetrics::visible_range` removes repeated slice math from simple line panes;
+- virtual list and table states already separate viewport scrolling from selection movement;
+- pane ids remain app-owned enums, strings, or other stable ids.
+
+The important design pressure is keeping scrolling explicit without forcing every pane into
+`VirtualList` or `VirtualTable`. Simple text panes should remain simple.
+
+## Related Use Cases
+
+- [`0003 Filtered Record Selection`](0003-filtered-record-selection.md) explains why wheel input
+  should not silently move durable selection.
+- [`0005 Virtual List Row Rendering`](0005-virtual-list-row-rendering.md) covers row virtualization
+  when simple fixed-height slicing is not enough.
+- [`0006 Virtual Table Inspection`](0006-virtual-table-inspection.md) covers two-axis table
+  scrolling and cell selection.
+- [`0010 Frame Snapshots`](0010-frame-snapshots.md) explains when scroll routing needs a
+  full `FrameSnapshot` and when a smaller pointer target collection is enough.
+
+## Remaining Design Questions
+
+The current model is enough for common panes, but two possible helpers may become useful:
+
+- a small one-axis `ScrollState` for simple fixed-height panes if examples keep storing bare offsets;
+- a pane bundle that pairs a scroll region, metrics, and a clamped offset without becoming a
+  scrollbar widget.
+
+Both should wait for more examples. The current narrow improvement is `ScrollMetrics::visible_range`
+plus examples that keep selection and wheel scrolling separate.

--- a/crates/ratatui-layout/use-cases/0005-virtual-list-row-rendering.md
+++ b/crates/ratatui-layout/use-cases/0005-virtual-list-row-rendering.md
@@ -1,0 +1,252 @@
+# 0005 Virtual List Row Rendering
+
+## User Story
+
+An app displays many rows, or rows whose height depends on terminal width. The app owns the row
+data and wants custom row rendering. Rendering every row every frame is wasteful, and ordinary
+selected-index widgets do not expose enough visible-row data for hit testing, clipping, and scroll
+status.
+
+Examples include file trees, issue lists, search results, log entries, release tasks, and command
+pickers.
+
+## Concrete App Shapes
+
+### Variable-Height Issue List
+
+An issue tracker renders rows with titles, labels, and wrapped summaries. Row height depends on the
+final pane width. The list needs to measure at that width, render only visible row slices, and keep
+the selected issue visible during keyboard movement.
+
+### Tree Browser
+
+A file tree or project tree flattens expanded nodes into visible rows. Expansion state and stable
+node ids belong to the app. The virtual list only needs source row indexes, row heights, selection
+styling, and hit testing for the rows visible this frame.
+
+### Search Results
+
+A search pane can rebuild visible rows after each query change. The app may keep durable record
+selection separately, while `VirtualListState` keeps the visible source index used for row styling
+and viewport reveal.
+
+### Long Log Pane
+
+A log pane may use fixed-height rows and no selection at all. It still benefits from viewport
+scrolling, visible-row data, and scroll metrics, but should not pay for a retained row widget tree.
+
+## Core Necessity
+
+Virtual list rendering needs a narrow contract between the app and the list:
+
+1. The app owns the row data and any stable row ids.
+1. The list asks the app how many source rows exist.
+1. The list asks how tall each row is at the final width.
+1. The list computes which row slices are visible for the current viewport.
+1. The list calls the app renderer only for visible slices.
+1. The returned layout remains available for hit testing, scroll status, and diagnostics.
+1. Keyboard selection and mouse-wheel scrolling stay separate.
+
+The list should not own row widgets, tree semantics, filtering, sorting, or durable record ids.
+
+## Current Crate Path
+
+Implement [`ListItems`](../src/list.rs) for an app-owned row adapter. The adapter supplies row count,
+row measurement, and row rendering. Rendering receives [`ListItemContext`](../src/list.rs), which
+tells the row whether it is selected and whether the visible slice is clipped.
+
+```rust
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::text::Line;
+use ratatui_core::widgets::Widget;
+use ratatui_layout::list::{ListItemContext, ListItems};
+use ratatui_layout::MeasureContext;
+
+struct Rows(&'static [&'static str]);
+
+impl ListItems for Rows {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn height_for_width(&self, index: usize, width: u16, _: MeasureContext) -> u16 {
+        self.0[index].len().div_ceil(width.max(1) as usize).max(1) as u16
+    }
+
+    fn render_item(&mut self, index: usize, area: Rect, buf: &mut Buffer, _: ListItemContext) {
+        Line::from(self.0[index]).render(area, buf);
+    }
+}
+```
+
+Use [`VirtualListState`](../src/list.rs) as persistent list state. It stores source-index selection
+and line-aware scroll position. [`VirtualListState::select_relative`](../src/list.rs) handles common
+keyboard movement without repeated index clamping in the app.
+
+```rust
+use ratatui_layout::list::VirtualListState;
+
+let mut state = VirtualListState::default();
+
+assert_eq!(state.select_relative(1, 4), Some(0));
+assert_eq!(state.select_relative(1, 4), Some(1));
+assert_eq!(state.select_relative(99, 4), Some(3));
+```
+
+Use [`VirtualListState::scroll_viewport_by`](../src/list.rs) for mouse-wheel or page scrolling that
+should not move selection.
+
+```rust
+use ratatui_layout::list::{ScrollPosition, VirtualListState};
+
+let mut state = VirtualListState::default();
+state.select(Some(5));
+state.set_scroll(ScrollPosition::new(1, 0));
+state.scroll_viewport_by(2);
+
+assert_eq!(state.selected(), Some(5));
+assert_eq!(state.scroll(), ScrollPosition::new(3, 0));
+```
+
+Use [`VirtualList::render`](../src/list.rs) for the normal path. It computes layout, renders only
+visible rows, mutates state to clamp scroll/selection, and returns [`ListLayout`](../src/list.rs) so
+the next input event can hit test against the rows the user just saw.
+
+```rust
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_layout::list::{ListItemContext, ListItems, VirtualList, VirtualListState};
+use ratatui_layout::MeasureContext;
+
+struct Rows;
+
+impl ListItems for Rows {
+    fn len(&self) -> usize { 3 }
+    fn height_for_width(&self, _: usize, _: u16, _: MeasureContext) -> u16 { 1 }
+    fn render_item(&mut self, _: usize, _: Rect, _: &mut Buffer, _: ListItemContext) {}
+}
+
+let mut rows = Rows;
+let mut state = VirtualListState::default();
+let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 2));
+let layout = VirtualList::new().render(buffer.area, &mut buffer, &mut state, &mut rows);
+
+assert_eq!(layout.visible_indices().collect::<Vec<_>>(), vec![0, 1]);
+```
+
+Use [`ListLayout::hit_index`](../src/list.rs) when a click only needs the row index. Use
+[`ListLayout::hit_test`](../src/list.rs) when the row also needs local coordinates, such as a tree
+row that treats the disclosure marker differently from the label. Filtered or sorted lists can use
+[`ListLayout::select_hit`](../src/list.rs) to move from a click to a durable id stored in
+[`VisibleSelection`](../src/selection.rs).
+
+```rust
+use ratatui_core::layout::Rect;
+use ratatui_layout::VisibleSelection;
+use ratatui_layout::list::{ListLayout, ScrollPosition, VisibleItem};
+
+let ids = ["api", "docs"];
+let layout = ListLayout {
+    viewport: Rect::new(0, 0, 10, 2),
+    item_count: ids.len(),
+    content_height: 2,
+    scroll_offset: 0,
+    scroll: ScrollPosition::default(),
+    visible_items: vec![
+        VisibleItem {
+            index: 0,
+            area: Rect::new(0, 0, 10, 1),
+            full_height: 1,
+            y_offset: 0,
+            clipped_top: false,
+            clipped_bottom: false,
+        },
+        VisibleItem {
+            index: 1,
+            area: Rect::new(0, 1, 10, 1),
+            full_height: 1,
+            y_offset: 0,
+            clipped_top: false,
+            clipped_bottom: false,
+        },
+    ],
+    selected: None,
+};
+let mut selection = VisibleSelection::new();
+
+layout.select_hit((2, 1), &mut selection, &ids);
+assert_eq!(selection.selected_id(), Some("docs"));
+```
+
+Use [`ListLayout::row_regions`](../src/list.rs) or
+[`ListLayout::rows_regions`](../src/list.rs) when the visible rows need to join generic layout,
+pointer, or frame coordination code. `ListLayout` keeps the full virtual-list data; the row
+`Regions` value is the geometry projection.
+
+Use [`ListHeightCache`](../src/list.rs) when measurement is expensive and row heights can be reused
+across frames. The cache remains explicit app state so invalidation stays visible when rows or width
+change.
+
+Runnable examples:
+
+- `cargo run -p ratatui-layout --example virtual_list`
+- `cargo run -p ratatui-layout --example visible_selection_virtual_list`
+- `cargo run -p ratatui-layout --example tree_browser`
+
+## Coordination Data Analysis
+
+Virtual lists produce richer data than a generic region set. A row has a source index, visible
+area, measured full height, clipped-line offset, and selected state. That is why `ListLayout` exists
+beside `Regions`.
+
+| Shape                | Layout | Mouse | Focus | Selection | Cursor | Aggregate |
+| -------------------- | ------ | ----- | ----- | --------- | ------ | --------- |
+| Variable-height list | yes    | maybe | no    | maybe     | no     | maybe     |
+| Tree browser         | yes    | maybe | no    | yes       | no     | maybe     |
+| Search results       | yes    | maybe | maybe | yes       | no     | maybe     |
+| Log pane             | yes    | maybe | no    | no        | no     | maybe     |
+
+The central frame value is `ListLayout`. Mouse data are needed only when the app wants clicks or
+wheel routing over the pane. Focus is usually outside the list unless the app treats a pane as a
+keyboard-focus target. Selection can be a source index in `VirtualListState`, a durable id in
+`VisibleSelection`, or both.
+
+## What This Validates
+
+The crate now covers the common virtual-list path:
+
+- app-owned row adapters measure and render rows without retained row widgets;
+- row measurement happens after final width is known;
+- only visible row slices render;
+- layout exposes visible row metadata and hit testing;
+- keyboard selection can move through source indexes with `select_relative`;
+- viewport scrolling can move without changing selection;
+- visible rows can be projected into `Regions` when a frame needs geometry interop;
+- click handling can use row indexes directly or bridge to durable ids;
+- durable record ids remain outside `VirtualListState` when the app needs them.
+
+The important design pressure is preserving ownership boundaries. `VirtualList` should make the
+viewport math reliable, but it should not become a list widget framework.
+
+## Related Use Cases
+
+- [`0003 Filtered Record Selection`](0003-filtered-record-selection.md) covers durable record ids
+  when source indexes are not enough.
+- [`0004 Multi-Pane Scroll Routing`](0004-multi-pane-scroll-routing.md) covers wheel routing to
+  pane regions, including blank space.
+- [`0006 Virtual Table Inspection`](0006-virtual-table-inspection.md) covers the two-axis version
+  of this problem.
+- [`0010 Frame Snapshots`](0010-frame-snapshots.md) explains why virtual lists often return a
+  derived layout value instead of forcing everything through `FrameSnapshot`.
+
+## Remaining Design Questions
+
+The current model is enough for variable-height row rendering. Possible future pressure:
+
+- range selection for shift-click or shift-arrow list workflows;
+- a durable-id adapter that pairs `ListLayout` hit tests with `VisibleSelection`;
+- stronger cache invalidation helpers if examples keep clearing `ListHeightCache` manually;
+- a pane-level helper that pairs a virtual list layout with a whole-pane scroll region.
+
+Those should be validated through examples before adding broader list abstractions.

--- a/crates/ratatui-layout/use-cases/0006-virtual-table-inspection.md
+++ b/crates/ratatui-layout/use-cases/0006-virtual-table-inspection.md
@@ -1,0 +1,213 @@
+# 0006 Virtual Table Inspection
+
+## User Story
+
+An app displays a table that can be larger than the terminal in both directions. The app owns the
+records and cell rendering, but it needs frame-local data for pinned headers, selected cells, mouse
+hit testing, visible-cell diagnostics, and row or column scroll status.
+
+Examples include database browsers, metric grids, trace inspectors, test matrices, release boards,
+and spreadsheet-like admin tools.
+
+## Concrete App Shapes
+
+### Database Browser
+
+A database browser shows many rows and enough columns that only part of the schema fits on screen.
+The app wants pinned column headers, keyboard movement by cell, a details pane for the selected
+record, and status text that reports row and column offsets.
+
+### Release Board
+
+A release board is row-oriented: each row is a task or change request, and each column is a field.
+Horizontal scrolling may be disabled by app policy even though the table primitive can support it.
+Commands usually operate on the selected row, while clicks still need to identify the exact cell.
+
+### Test Matrix
+
+A test matrix is genuinely two-dimensional. Rows are platforms, columns are checks, and the selected
+cell is the meaningful unit. Pinned headers help the user keep context while row and column
+scrolling move independently.
+
+### Trace Inspector
+
+A trace inspector may show spans, timing, status, owner, and metadata columns. It can render only
+visible cells from app-owned records, route header clicks to sort commands, and route body clicks to
+selection or details.
+
+## Core Necessity
+
+Virtual table rendering needs a narrow contract between the app and the table:
+
+1. The app owns records, field definitions, and any durable ids.
+1. The table asks the app how many body rows and columns exist.
+1. The table computes pinned header cells, visible body cells, row scroll, and column scroll.
+1. The table calls the app renderer only for visible cells.
+1. The returned layout remains available for hit testing, scroll metrics, and diagnostics.
+1. Keyboard selection and viewport scrolling stay separate.
+1. Header hits and body-cell selection stay distinguishable.
+
+The table should not own row records, schema metadata, sort behavior, durable row ids, or command
+semantics.
+
+## Current Crate Path
+
+Implement [`TableItems`](../src/table.rs) for an app-owned adapter. The adapter supplies row count,
+column count, and cell rendering. Rendering receives [`TableCellContext`](../src/table.rs), which
+tells the renderer whether the cell is selected and where it sits among visible rows and columns.
+
+```rust
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::text::Line;
+use ratatui_core::widgets::Widget;
+use ratatui_layout::table::{CellPosition, TableCellContext, TableItems};
+
+struct Rows(&'static [[&'static str; 2]]);
+
+impl TableItems for Rows {
+    fn row_count(&self) -> usize {
+        self.0.len()
+    }
+
+    fn column_count(&self) -> usize {
+        2
+    }
+
+    fn render_cell(
+        &mut self,
+        position: CellPosition,
+        area: Rect,
+        buf: &mut Buffer,
+        _: TableCellContext,
+    ) {
+        let text = position
+            .row
+            .map(|row| self.0[row][position.column])
+            .unwrap_or("header");
+        Line::from(text).render(area, buf);
+    }
+}
+```
+
+Use [`VirtualTableState`](../src/table.rs) as persistent table state. It stores body-cell selection
+and row/column scroll offsets. [`VirtualTableState::select_relative`](../src/table.rs) handles
+common keyboard movement without repeated row and column clamping in the app.
+
+```rust
+use ratatui_layout::table::{CellPosition, VirtualTableState};
+
+let mut state = VirtualTableState::default();
+
+assert_eq!(state.select_relative(1, 0, 3, 2), Some(CellPosition::body(0, 0)));
+assert_eq!(state.select_relative(1, 1, 3, 2), Some(CellPosition::body(1, 1)));
+assert_eq!(state.select_relative(99, 99, 3, 2), Some(CellPosition::body(2, 1)));
+```
+
+Use [`VirtualTableState::scroll_rows_by`](../src/table.rs),
+[`VirtualTableState::scroll_columns_by`](../src/table.rs), or
+[`VirtualTableState::scroll_viewport_by`](../src/table.rs) for wheel and page scrolling that should
+not move selection. Apps that do not want horizontal scroll can simply avoid routing input to the
+column helpers.
+
+Use [`VirtualTable::render`](../src/table.rs) for the normal path. It computes layout, renders only
+visible cells, mutates state to clamp scroll/selection, and returns [`TableLayout`](../src/table.rs)
+so the next input event can route through the cells the user just saw.
+
+```rust
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::{Constraint, Rect};
+use ratatui_layout::table::{
+    CellPosition, TableCellContext, TableItems, VirtualTable, VirtualTableState,
+};
+
+struct Rows;
+
+impl TableItems for Rows {
+    fn row_count(&self) -> usize { 2 }
+    fn column_count(&self) -> usize { 2 }
+    fn render_cell(&mut self, _: CellPosition, _: Rect, _: &mut Buffer, _: TableCellContext) {}
+}
+
+let mut rows = Rows;
+let mut state = VirtualTableState::default();
+let mut buffer = Buffer::empty(Rect::new(0, 0, 8, 2));
+let layout = VirtualTable::new([Constraint::Length(4), Constraint::Length(4)])
+    .render(buffer.area, &mut buffer, &mut state, &mut rows);
+
+assert_eq!(layout.hit_position((5, 1)), Some(CellPosition::body(0, 1)));
+```
+
+Use [`TableLayout::select_hit`](../src/table.rs) when a click should select a body cell. Use
+[`TableLayout::hit_position`](../src/table.rs) when the app also needs header hits for sorting or
+column actions. Use [`TableLayout::hit_test`](../src/table.rs) when local pointer coordinates
+matter.
+
+Use [`TableLayout::cell_regions`](../src/table.rs) or [`TableLayout::cells_regions`](../src/table.rs)
+when visible cells need to join generic layout, pointer, or frame coordination code. `TableLayout`
+keeps the full table data; the cell `Regions` value is the geometry projection.
+
+Runnable examples:
+
+- `cargo run -p ratatui-layout --example table_inspector`
+- `cargo run -p ratatui-layout --example frame_snapshot`
+
+## Coordination Data Analysis
+
+Virtual tables produce richer data than a generic region set. A visible cell has a source
+`CellPosition`, area, visible row, visible column, selected state, and header/body meaning. That is
+why `TableLayout` exists beside `Regions`.
+
+| Shape            | Layout | Mouse | Focus | Selection | Cursor | Frame |
+| ---------------- | ------ | ----- | ----- | --------- | ------ | ----- |
+| Database browser | yes    | maybe | no    | yes       | no     | maybe |
+| Release board    | yes    | maybe | maybe | yes       | no     | maybe |
+| Test matrix      | yes    | maybe | no    | yes       | no     | maybe |
+| Trace inspector  | yes    | maybe | maybe | yes       | no     | maybe |
+
+The central frame value is `TableLayout`. Mouse data are needed only when the app wants clicks or
+wheel routing over the table region. Focus is usually pane-level unless the app treats individual
+cells as focus targets. Selection can be a source [`CellPosition`](../src/table.rs), a durable row id
+owned by the app, or a pair such as `(RecordId, FieldId)`.
+
+## What This Validates
+
+The crate now covers the common virtual-table path:
+
+- app-owned cell adapters render cells without retained cell widgets;
+- pinned headers and body cells share one typed coordinate model;
+- only visible cells render;
+- keyboard selection can move through row and column indexes with `select_relative`;
+- viewport scrolling can move rows or columns without changing selection;
+- body-cell clicks can update table selection with `select_hit`;
+- header hits remain available for sort or column commands;
+- visible cells can be projected into `Regions` when a frame needs geometry interop;
+- scroll metrics can drive status text or app-owned scrollbars.
+
+The important design pressure is preserving app policy. `VirtualTable` should make row, column, and
+viewport math reliable, but it should not decide whether a release board supports horizontal scroll
+or whether commands operate on a row, a cell, or a stable record id.
+
+## Related Use Cases
+
+- [`0003 Filtered Record Selection`](0003-filtered-record-selection.md) covers durable record ids
+  when source positions are not enough.
+- [`0004 Multi-Pane Scroll Routing`](0004-multi-pane-scroll-routing.md) covers wheel routing to pane
+  regions, including blank space.
+- [`0005 Virtual List Row Rendering`](0005-virtual-list-row-rendering.md) covers the one-axis
+  version of this problem.
+- [`0010 Frame Snapshots`](0010-frame-snapshots.md) explains why virtual tables often return a
+  derived layout value instead of forcing everything through `FrameSnapshot`.
+
+## Remaining Design Questions
+
+The current model is enough for fixed-height virtual tables with pinned headers. Possible future
+pressure:
+
+- variable-height table rows;
+- pinned leading columns;
+- durable-id helpers that pair `CellPosition` with `(RecordId, FieldId)`;
+- table range selection for spreadsheet-like workflows;
+- a pane-level helper that pairs a table layout with whole-table scroll regions.
+
+Those should be validated through examples before adding broader table abstractions.

--- a/crates/ratatui-layout/use-cases/0007-component-frame-composition.md
+++ b/crates/ratatui-layout/use-cases/0007-component-frame-composition.md
@@ -1,0 +1,195 @@
+# 0007 Component Frame Composition
+
+## User Story
+
+An app is large enough to split into components: navigation pane, work queue, details pane, command
+strip, and modal overlays. Each component renders ordinary Ratatui widgets and owns local helper
+state, but the parent needs one combined record of layout regions, focus targets, mouse targets, and
+cursor requests from the whole screen.
+
+The app does not want a retained widget tree. It wants immediate-mode rendering with explicit data
+returned from each render pass and stored for the next input event.
+
+## Concrete App Shapes
+
+### Multi-Pane Inspector
+
+A project inspector has a tree pane, a table or list pane, a details pane, and a command strip. Each
+pane has different rendering and input policy, but tab traversal and mouse routing must work across
+the whole page.
+
+### Modal Overlay
+
+A dialog renders above the base page. Its targets need higher z-order, its focus targets should
+temporarily dominate traversal, and its cursor request should win when an editable field is active.
+The base page still exists underneath, but the frame-local data used for input should match what the
+user can interact with.
+
+### Nested Viewport
+
+A child component renders a scrollable region in local coordinates. The parent places that child
+inside a clipped pane. Only visible child targets should be merged into the parent frame, and local
+coordinates need to become terminal coordinates before the next mouse event is routed.
+
+### Focused Text Input
+
+A command input or form field computes a cursor position while rendering. If the input is a child
+component, the cursor request may be local to that child and must be translated with the rest of the
+child frame-local data.
+
+## Core Necessity
+
+Component frame composition needs a narrow contract between children and parent:
+
+1. A child renders ordinary widgets into the area the parent assigns.
+1. The child returns frame-local data for only what it rendered.
+1. The child may use local ids that are meaningful only inside that component.
+1. The child may compute local geometry before the parent places it on screen.
+1. The parent maps child ids into app-level ids.
+1. The parent translates and clips child data to the actual screen region.
+1. The parent merges child data in render order and stores the result for the next event.
+
+The component boundary should not require a retained widget tree, callback registry, app-wide trait,
+or semantic action type before examples prove those shapes.
+
+## Current Crate Path
+
+Return [`FrameSnapshot`](../src/frame.rs) from component render methods when a child produces several
+coordination data together. Use smaller values directly when a component only needs one concern.
+
+```rust
+use ratatui_core::layout::Rect;
+use ratatui_layout::{FrameSnapshot, FrameTargets, Region};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum RowTarget {
+    Row(usize),
+}
+
+fn render_child(area: Rect) -> FrameSnapshot<RowTarget> {
+    let local = Rect::new(0, 0, area.width, area.height);
+    let rows = [
+        Region::new(RowTarget::Row(0), Rect::new(1, 1, local.width - 2, 1)),
+        Region::new(RowTarget::Row(1), Rect::new(1, 2, local.width - 2, 1)),
+    ];
+
+    FrameTargets::new(local, 0).build_focusable(rows, |id| id)
+}
+```
+
+Map child-local ids into an app-level routing enum before merging. This keeps each component's
+local id model small while giving the parent one type for focus, mouse, and layout routing.
+
+```rust
+use ratatui_core::layout::Rect;
+use ratatui_layout::{FrameSnapshot, Regions, Region};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum AppTarget {
+    Project(usize),
+}
+
+let project_regions = Regions::from_regions(
+    Rect::new(0, 0, 10, 1),
+    [Region::new(0, Rect::new(0, 0, 10, 1))],
+);
+let child = FrameSnapshot::from_layout(project_regions).map_id(AppTarget::Project);
+
+assert_eq!(child.route_position((1, 0)).unwrap().id, AppTarget::Project(0));
+```
+
+Place local child data after the parent solves the child area. [`FrameSnapshot::place_child`](../src/frame.rs)
+combines the common sequence: translate to the area's origin, clip to the area, then merge. It moves
+layout, focus, mouse, and cursor requests together.
+
+```rust
+use ratatui_core::layout::{Position, Rect};
+use ratatui_layout::{CursorRequests, CursorRequest, FrameSnapshot, Regions, Region};
+
+let input_regions = Regions::from_regions(
+    Rect::new(0, 0, 8, 1),
+    [Region::new("input", Rect::new(0, 0, 8, 1))],
+);
+let input_cursor = CursorRequests::new().request(CursorRequest::visible(Position::new(2, 0)));
+let child = FrameSnapshot::from_layout(input_regions).cursor(input_cursor);
+
+let input_area = Rect::new(4, 2, 8, 1);
+let parent = FrameSnapshot::new(Rect::new(0, 0, 20, 4)).place_child(child, input_area);
+
+assert_eq!(parent.route_position((5, 2)).unwrap().id, "input");
+assert_eq!(
+    parent.cursor.final_cursor(),
+    Some(CursorRequest::visible(Position::new(6, 2)))
+);
+```
+
+Store the merged frame after rendering and route the next event through it.
+
+```rust
+use ratatui_core::layout::Rect;
+use ratatui_layout::FrameSnapshot;
+
+let previous_frame = FrameSnapshot::<&str>::new(Rect::new(0, 0, 20, 4))
+    .scroll_region("details", Rect::new(0, 0, 20, 4));
+
+assert_eq!(previous_frame.route_scroll((10, 3)).unwrap().id, "details");
+```
+
+Runnable examples:
+
+- `cargo run -p ratatui-layout --example component_frames`
+- `cargo run -p ratatui-layout --example frame_snapshot`
+
+## Coordination Data Analysis
+
+Component composition is the strongest case for an aggregate frame value. The parent often needs to
+move several value types across the same boundary at once.
+
+| Shape                | Layout | Mouse | Focus | Selection | Cursor | Frame |
+| -------------------- | ------ | ----- | ----- | --------- | ------ | ----- |
+| Multi-pane inspector | yes    | yes   | yes   | app-owned | maybe  | yes   |
+| Modal overlay        | yes    | yes   | yes   | maybe     | maybe  | yes   |
+| Nested viewport      | yes    | maybe | maybe | maybe     | maybe  | yes   |
+| Focused text input   | yes    | maybe | yes   | no        | yes    | yes   |
+
+Selection remains app state. `FrameSnapshot` tells the app which target was visible and routed; the
+app decides whether that target means selecting a row, opening a dialog, scrolling a pane, editing
+text, or running a command.
+
+## What This Validates
+
+The crate now covers the common component-frame path:
+
+- children can render ordinary widgets and return `FrameSnapshot` values;
+- child-local ids can be mapped into a parent routing enum;
+- child-local layout, focus, mouse, and cursor requests can be translated together;
+- child data can be clipped before the parent stores them for input;
+- child frames can be placed with a solved screen area instead of manually passing offsets;
+- parent frames can merge child data in render order;
+- a middle-sized example shows the pattern without a component trait.
+
+The important design pressure is keeping the boundary explicit. Returning `FrameSnapshot` is useful
+because it collects data. It should not force a component trait, semantic action enum, or retained
+tree until several examples prove the same shape.
+
+## Related Use Cases
+
+- [`0001 Command Toolbar Routing`](0001-command-toolbar-routing.md) covers a compact component that
+  returns aligned layout, focus, and pointer data.
+- [`0002 Modal Dialog Coordination`](0002-modal-dialog-coordination.md) covers overlays and
+  negative hit testing.
+- [`0004 Multi-Pane Scroll Routing`](0004-multi-pane-scroll-routing.md) covers pane-level mouse
+  regions and wheel routing.
+- [`0009 Form Editing`](0009-form-editing.md) covers cursor placement and field editing.
+- [`0010 Frame Snapshots`](0010-frame-snapshots.md) compares when an aggregate frame is useful
+  and when smaller values are enough.
+
+## Remaining Design Questions
+
+The current model is enough for explicit child-to-parent composition. Possible future pressure:
+
+- a `UiComponent` trait once examples converge on the same render signature;
+- a semantic outcome or action type once examples repeatedly return commands from rendering;
+- modal stack helpers if multiple overlay examples repeat the same z-order and focus policy.
+
+Those should be validated through examples before adding a broader component layer.

--- a/crates/ratatui-layout/use-cases/0008-mouse-overlays-and-disabled-targets.md
+++ b/crates/ratatui-layout/use-cases/0008-mouse-overlays-and-disabled-targets.md
@@ -1,0 +1,169 @@
+# 0008 Pointer Overlays And Disabled Targets
+
+## User Story
+
+An app has pointer-sensitive regions that can overlap: a popup over a table, a command palette over
+an editor, a tooltip over a row, or a modal dialog over a page. Some controls are visible but
+disabled. The app needs hover, press/release matching, local coordinates, and z-order-aware hit
+testing without depending on one terminal backend.
+
+This is where simple layout hit testing is not enough. Layout can say which rectangle contains a
+position, but pointer routing also needs disabled policy, overlay priority, and state that survives
+from press to release.
+
+## Concrete App Shapes
+
+### Popup Over Content
+
+A popup is drawn above an editor or table. Clicks inside the popup should route to popup controls
+even when the base content also contains that position. Clicks outside may route to the base content
+or close the popup, depending on the app policy.
+
+### Disabled Command
+
+A toolbar or dialog button is visible but disabled because validation failed or a background task is
+running. The button still needs disabled styling, but hover and click routing should skip it.
+
+### Hoverable Row Or Cell
+
+A table row, tree item, or grid cell changes style on hover and uses target-local coordinates to
+interpret which subregion was clicked.
+
+### Press And Release Activation
+
+A user presses on one target and releases on another. The app should not treat that as activation.
+This is common for buttons, menus, palette items, and clickable rows.
+
+## Core Necessity
+
+Pointer overlay routing needs a narrow pointer-specific contract:
+
+1. Rendering produces pointer targets for visible regions.
+1. Each target records id, area, disabled state, and z-order.
+1. Hit testing chooses the topmost enabled target under a terminal position.
+1. The hit carries local coordinates so controls do not recompute their origin.
+1. Persistent state stores hover and pressed ids between backend events.
+1. Press/release matching only activates when both phases hit the same target.
+1. Backend event types stay at the app edge.
+
+Focus and selection may react to a routed pointer hit, but they are not owned by pointer routing.
+
+## Current Crate Path
+
+Use [`PointerTarget`](../src/pointer.rs) when a visible region has pointer-specific behavior such as
+disabled state, z-order, or an interactive area that does not exactly match a layout region.
+
+```rust
+use ratatui_core::layout::Rect;
+use ratatui_layout::{PointerTargets, PointerTarget};
+
+let targets = PointerTargets::from_targets([
+    PointerTarget::new("editor", Rect::new(0, 0, 30, 8)),
+    PointerTarget::new("palette", Rect::new(4, 2, 12, 3)).z(10),
+]);
+
+assert_eq!(targets.hit_test((5, 3)).unwrap().id, "palette");
+```
+
+Disabled targets remain visible data but do not win real routing:
+
+```rust
+use ratatui_core::layout::Rect;
+use ratatui_layout::{PointerTargets, PointerTarget};
+
+let targets = PointerTargets::from_targets([
+    PointerTarget::new("fallback", Rect::new(0, 0, 10, 1)),
+    PointerTarget::new("disabled-save", Rect::new(0, 0, 10, 1))
+        .z(5)
+        .disabled(true),
+]);
+
+assert_eq!(targets.hit_test((1, 0)).unwrap().id, "fallback");
+```
+
+Use [`PointerState`](../src/pointer.rs) with [`PointerPhase`](../src/pointer.rs) after converting a
+backend mouse event into a position and phase. The backend-specific part is still only the
+conversion at the app edge.
+
+```rust
+use ratatui_core::layout::Rect;
+use ratatui_layout::{PointerTargets, PointerState, PointerTarget, PointerPhase};
+
+let targets = PointerTargets::from_targets([
+    PointerTarget::new("open", Rect::new(0, 0, 6, 1)),
+    PointerTarget::new("save", Rect::new(6, 0, 6, 1)),
+]);
+let mut mouse = PointerState::default();
+
+mouse.route(&targets, (1, 0), PointerPhase::Press);
+assert!(mouse.route(&targets, (7, 0), PointerPhase::Release).is_none());
+
+mouse.route(&targets, (7, 0), PointerPhase::Press);
+assert_eq!(
+    mouse.route(&targets, (7, 0), PointerPhase::Release)
+        .unwrap()
+        .id,
+    "save"
+);
+```
+
+Runnable examples:
+
+- `cargo run -p ratatui-layout --example pointer_targets`
+- `cargo run -p ratatui-layout --example grid_palette`
+- `cargo run -p ratatui-layout --example frame_snapshot`
+
+## Coordination Data Analysis
+
+Mouse overlays are mostly a pointer-target problem. Layout data may help derive target rectangles,
+but focus, selection, and frame aggregation should remain optional reactions.
+
+| Shape                        | Layout | Mouse | Focus | Selection | Cursor | Frame |
+| ---------------------------- | ------ | ----- | ----- | --------- | ------ | ----- |
+| Popup over content           | maybe  | yes   | maybe | no        | no     | maybe |
+| Disabled command             | maybe  | yes   | maybe | no        | no     | maybe |
+| Hoverable row or cell        | maybe  | yes   | no    | maybe     | no     | no    |
+| Press/release activation     | no     | yes   | no    | no        | no     | no    |
+| Whole-pane wheel routing     | maybe  | yes   | maybe | no        | no     | maybe |
+
+This use case argues for keeping [`PointerTargets`](../src/pointer.rs) ergonomic on its own. An app
+should not need a full [`FrameSnapshot`](../src/frame.rs) just to route a hover or button click.
+
+## What This Validates
+
+The crate now covers the common mouse-overlay path:
+
+- targets carry pointer-specific z-order and disabled state;
+- hit testing prefers the topmost enabled target and returns local coordinates;
+- pointer target collections can be mapped, translated, clipped, and merged for child components;
+- persistent state tracks hover and press across events;
+- `PointerPhase` lets examples centralize hover, press, and release transitions without importing
+  crossterm or another backend into the crate.
+
+The important boundary is that `PointerPhase` is intentionally small. It does not model scroll
+direction, buttons, modifiers, drag payloads, double-click policy, or backend event lifetimes.
+
+## Related Use Cases
+
+- [`0001 Command Toolbar Routing`](0001-command-toolbar-routing.md) covers ordered action surfaces
+  that often derive mouse targets from regions.
+- [`0002 Modal Dialog Coordination`](0002-modal-dialog-coordination.md) covers overlay/backdrop
+  behavior and outside-click policy.
+- [`0004 Multi-Pane Scroll Routing`](0004-multi-pane-scroll-routing.md) covers whole-pane mouse
+  regions for wheel routing.
+- [`0007 Component Frame Composition`](0007-component-frame-composition.md) covers mapping and
+  placing child-local pointer data inside larger frame snapshots.
+- [`0010 Frame Snapshots`](0010-frame-snapshots.md) explains why a mouse-only surface should
+  not be forced through a full frame aggregate.
+
+## Remaining Design Questions
+
+The current model is enough for ordinary hover, click, disabled controls, and overlays. Possible
+future pressure:
+
+- drag phases if examples need pointer capture and continuous movement after press;
+- button/modifier policy if examples need different behavior for left, right, or shifted clicks;
+- outside-click helpers if modal and popup examples repeat the same negative-hit behavior;
+- scroll phase helpers if wheel routing repeats more than the current pane-region pattern.
+
+Those should be driven by examples rather than by mirroring a specific terminal backend.

--- a/crates/ratatui-layout/use-cases/0009-form-editing.md
+++ b/crates/ratatui-layout/use-cases/0009-form-editing.md
@@ -1,0 +1,215 @@
+# 0009 Form Editing
+
+## User Story
+
+An app lets the user edit a small set of values. The form might live in a modal dialog, a side pane,
+a settings page, or an inline editor. The app owns the domain object and usually owns a temporary
+edit buffer so changes can be saved, cancelled, or validated before they affect durable state.
+
+The form coordination problem is about fields and edit state, not about whether the form is modal.
+It needs field ids, text cursors, focus traversal, validation policy, buttons or commands, and
+cursor placement for the active field.
+
+## Concrete App Shapes
+
+### Inline Row Editor
+
+A table row expands into editable fields for title and owner. The page remains interactive outside
+the row, but the focused field still needs text editing and terminal cursor placement.
+
+### Settings Page
+
+A settings page edits a group of values and enables Apply only when pending values differ from the
+saved configuration. The form is not a dialog, but it still has field focus, disabled buttons, and
+validation state.
+
+### Connection Profile Editor
+
+A database client edits host, port, username, and database name. The edit buffer may be loaded from
+a selected profile, discarded with Cancel, or saved back to the profile list.
+
+### Modal Edit Form
+
+A modal edit dialog combines this use case with dialog coordination. The dialog supplies the raised
+region and routing boundary; the form supplies field ids, edit buffers, text cursor state, and
+submit/cancel behavior.
+
+## Core Necessity
+
+Form editing needs a different set of data than modal dialogs:
+
+1. The app owns current values and pending values.
+1. Each editable field owns text cursor state.
+1. The render pass assigns each visible field a rectangle.
+1. Focus traversal moves through visible fields and commands.
+1. Text input edits the focused field's pending value.
+1. The focused text field requests terminal cursor placement.
+1. Validation can mark fields or commands as disabled without hiding them.
+1. Save, Apply, Reset, and Cancel remain app-owned actions.
+
+The crate should reduce repeated field coordination and cursor math. It should not own domain data,
+validation rules, or submit side effects.
+
+## Current Crate Path
+
+Use [`Column`](../src/linear.rs), [`Row`](../src/linear.rs), and named regions to give each field and
+command an app-owned id. Enum ids are usually the clearest because the app will match on them when
+editing values or applying commands.
+
+```rust
+use ratatui_core::layout::{Constraint, Rect};
+use ratatui_layout::Column;
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+enum Field {
+    Title,
+    Owner,
+    Status,
+}
+
+let field_rows = [
+    (Field::Title, Constraint::Length(1)),
+    (Field::Owner, Constraint::Length(1)),
+    (Field::Status, Constraint::Length(1)),
+];
+let fields = Column::named(field_rows)
+    .spacing(1)
+    .regions(Rect::new(2, 2, 40, 5));
+```
+
+Use [`FocusTargets::from_regions`](../src/focus.rs) when every visible field should participate in
+traversal. Use a custom [`FocusTargets`](../src/focus.rs) when commands, disabled fields, or non-visual
+ordering need more policy.
+
+```rust
+use ratatui_core::layout::{Constraint, Rect};
+use ratatui_layout::Column;
+use ratatui_layout::{FocusFallback, FocusTargets, FocusState};
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+enum Field {
+    Title,
+    Owner,
+}
+
+let field_rows = [
+    (Field::Title, Constraint::Length(1)),
+    (Field::Owner, Constraint::Length(1)),
+];
+let fields = Column::named(field_rows).regions(Rect::new(0, 0, 20, 2));
+
+let focus_plan = FocusTargets::from_regions(fields.regions().iter().copied());
+let mut focus = FocusState::default();
+
+focus.ensure_visible(&focus_plan, FocusFallback::First);
+focus.next(&focus_plan);
+```
+
+Use [`TextFieldState`](../src/input.rs) beside each editable string. The helper owns the character
+cursor and canonical single-line editing operations. The string stays in the app's pending edit
+buffer.
+
+```rust
+use ratatui_core::layout::{Position, Rect};
+use ratatui_layout::TextFieldState;
+
+let mut title = String::from("deplo");
+let mut title_field = TextFieldState::at_end(&title);
+
+title_field.insert_char(&mut title, 'y');
+assert_eq!(title, "deploy");
+
+let area = Rect::new(4, 8, 30, 1);
+let prefix_width = "title: ".len() as u16;
+let request = title_field.cursor_request_after_prefix(area, prefix_width);
+assert_eq!(request.position, Position::new(17, 8));
+```
+
+Use [`ButtonRow`](../src/input.rs) for local left/right movement across a form command row. The row
+does not decide what Save or Cancel means; it only tracks which visible command is focused.
+
+```rust
+use ratatui_layout::ButtonRow;
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum FormCommand {
+    Cancel,
+    Save,
+}
+
+let mut buttons = ButtonRow::new([FormCommand::Cancel, FormCommand::Save]);
+buttons.move_next();
+
+assert_eq!(buttons.focused_id(), Some(FormCommand::Save));
+```
+
+Use [`CursorRequests`](../src/cursor.rs) to collect the cursor request produced by the focused field.
+The parent app can merge that request with other frame-local data before applying the final
+terminal cursor.
+
+Runnable examples:
+
+- `cargo run -p ratatui-layout --example form_dialog`
+- `cargo run -p ratatui-layout --example profile_editor`
+- `cargo run -p ratatui-layout --example cursor_request`
+
+## Coordination Data Analysis
+
+Form editing is a mixed concern, but the reusable parts are small. A form needs layout and focus for
+field traversal, cursor requests for focused text fields, and app-owned state for pending values.
+Mouse and frame aggregation depend on where the form lives.
+
+| Shape                     | Layout | Mouse | Focus | Selection | Cursor | Frame |
+| ------------------------- | ------ | ----- | ----- | --------- | ------ | ----- |
+| Inline row editor         | yes    | maybe | yes   | maybe     | yes    | maybe |
+| Settings page             | yes    | maybe | yes   | maybe     | yes    | maybe |
+| Connection profile editor | yes    | maybe | yes   | no        | yes    | maybe |
+| Modal edit form           | yes    | yes   | yes   | maybe     | yes    | yes   |
+| Command button row        | yes    | maybe | yes   | maybe     | no     | maybe |
+
+This argues for small helpers rather than a single `Form` type. [`TextFieldState`](../src/input.rs)
+should make editing a string and placing the cursor boring. [`ButtonRow`](../src/input.rs) should
+make horizontal command focus boring. The app should still own validation, save/cancel effects, and
+the pending edit buffer.
+
+## What This Validates
+
+The crate already covers the small reusable pieces of form editing:
+
+- named layout regions keep field rendering and input routing aligned;
+- focus state remains app-owned and is repaired against visible fields;
+- text field state owns cursor/edit mechanics without owning field values;
+- cursor request helpers remove repeated terminal coordinate arithmetic;
+- button rows handle local command movement without defining submit semantics.
+
+The `form_dialog` example follows the smallest path directly: fields are solved as named regions,
+focus is repaired against the visible field regions, text editing goes through `TextFieldState`, and
+the focused field emits a cursor request from its label prefix.
+
+The `profile_editor` example exercises the same pieces in a fuller settings-form shape. It keeps a
+saved profile separate from a pending draft, validates the draft, disables Save when the draft is
+invalid or unchanged, and combines vertical field traversal with horizontal button movement.
+
+The useful design pressure is to make form code read as a workflow over pending values, not as a
+mix of index bookkeeping and cursor math.
+
+## Related Use Cases
+
+- [`0002 Modal Dialog Coordination`](0002-modal-dialog-coordination.md) covers the raised overlay
+  surface that can contain a form.
+- [`0001 Ordered Action Surfaces`](0001-command-toolbar-routing.md) covers Save/Cancel button rows,
+  segmented controls, and radio-like choices.
+- [`0003 Filtered Record Selection`](0003-filtered-record-selection.md) covers stable selected
+  records that may be loaded into an edit buffer.
+- [`0010 Frame Snapshots`](0010-frame-snapshots.md) explains why field state, frame-local data, and
+  app-owned pending values should stay separate.
+
+## Remaining Design Questions
+
+The current model is enough for small single-line forms. Do not add a full form abstraction yet.
+Several choices still need more examples:
+
+- how validation errors should reserve space, affect focus, and disable Save;
+- whether submit/cancel semantics belong in reusable helpers or stay app-specific;
+- how multiline fields, completions, and horizontally clipped text should request the cursor;
+- whether field labels, value spans, and cursor prefixes need a small helper or should stay local.

--- a/crates/ratatui-layout/use-cases/0010-frame-snapshots.md
+++ b/crates/ratatui-layout/use-cases/0010-frame-snapshots.md
@@ -1,0 +1,300 @@
+# 0010 Frame Snapshots
+
+## User Story
+
+An app author is building one visible surface at a time: a command strip, modal dialog, list, table,
+scroll pane, picker, or form. Each surface needs some frame-local data from rendering, but rarely
+needs every value the crate can produce.
+
+The author needs a way to ask:
+
+- Which data does this surface produce during render?
+- Which persistent state does the app keep between frames?
+- Which data need to be stored for the next input event?
+- When should a component return a full `FrameSnapshot` instead of a smaller value such as
+  `Regions` or `PointerTargets`?
+
+This is the broader coordination question behind the previous use cases. The crate should make it
+normal to compose only the data a surface needs.
+
+## Vocabulary
+
+### Frame-Local Data
+
+Frame-local data is produced by rendering or layout and usually describes what was visible in one
+frame. It is safe to rebuild every draw and store for the next event.
+
+Current frame-value types include:
+
+- `Regions`: visible regions, clipping, z-order, and layout hit testing.
+- `FocusTargets`: keyboard traversal targets visible in the current frame.
+- `PointerTargets`: pointer targets visible in the current frame.
+- `CursorRequests`: terminal cursor requests produced during rendering.
+- `FrameSnapshot`: an aggregate when several frame-local values should travel together.
+
+Several `*Layout` values are also frame-local data even though they are not named `Plan`:
+
+- `ContainerLayout`: outer area, inner area, clipping boundary, and optional child region.
+- `GridLayout`: row areas, column areas, and typed cell regions.
+- `ListLayout`: visible rows, content height, selection position, and list hit testing.
+- `TableLayout`: visible cells, pinned headers, table hit testing, and scroll metrics.
+- `ViewportLayout`: clamped viewport offset and visible content area.
+
+### Persistent State
+
+State survives across frames and belongs to the app or to small app-owned helpers. It is the input
+to the next render pass, not the visible data produced by that render pass.
+
+Current persistent state types include:
+
+- `FocusState`: the focused app id.
+- `PointerState`: hover and pressed ids.
+- `SelectionState` and `VisibleSelection`: selected ids and visible-position bridges.
+- `TextFieldState` and `ButtonRowState`: small control-local state.
+- `ViewportState`, `VirtualListState`, and `VirtualTableState`: viewport and selection state for
+  scrolling views.
+
+### Context
+
+Context is already a narrower term in the crate. `MeasureContext`, `RenderContext`,
+`ListItemContext`, and `TableCellContext` are inputs passed down while measuring or rendering
+external content.
+
+That makes `Context` a poor name for the cross-cutting output of a frame. The useful phrase here is
+`frame-local data`: concrete output produced during render and optionally stored for input routing.
+
+## Data Selection Matrix
+
+The current use cases can be described by which data they naturally need. `maybe` means the need is
+policy-dependent or only appears in one common variant.
+
+| Use case                  | Layout | Mouse | Focus | Selection | Cursor | Frame |
+| ------------------------- | ------ | ----- | ----- | --------- | ------ | ----- |
+| Ordered action surface    | yes    | maybe | maybe | maybe     | no     | maybe |
+| Modal dialog              | yes    | yes   | maybe | no        | maybe  | maybe |
+| Filtered record selection | maybe  | maybe | no    | yes       | no     | no    |
+| Multi-pane scroll routing | yes    | yes   | maybe | no        | no     | maybe |
+| Virtual list              | yes    | maybe | no    | maybe     | no     | maybe |
+| Virtual table             | yes    | maybe | no    | maybe     | no     | maybe |
+| Component composition     | yes    | maybe | maybe | app-owned | maybe  | yes   |
+| Mouse overlays            | yes    | yes   | no    | no        | no     | maybe |
+| Form editing              | yes    | maybe | yes   | maybe     | yes    | maybe |
+
+The matrix suggests two design rules:
+
+1. The smaller value types should remain first-class. `PointerTargets` alone should feel as normal
+   as a `FrameSnapshot` when a surface only routes pointer input.
+1. Aggregation should be convenient without becoming mandatory. `FrameSnapshot` is a carrying case
+   for several values, not a declaration that every surface has layout, mouse, focus, selection, and
+   cursor behavior.
+
+## Composition Shapes
+
+### One Value
+
+A surface can return only one value when that is enough:
+
+```rust
+let mouse = PointerTargets::new().region(Pane::Details, details_area);
+app.previous_details_mouse = mouse;
+```
+
+This is appropriate for simple hover/click routing, one scrollable pane, or a component that does
+not participate in page focus.
+
+### Several Independent Facts
+
+A surface can store data separately when that keeps ownership clearer:
+
+```rust
+app.previous_focus = FocusTargets::from_regions(fields.regions().iter().copied());
+app.previous_mouse = PointerTargets::from_targets(rendered_buttons);
+```
+
+This works well for small examples and for apps where focus and pointer routing are handled by
+separate modules.
+
+### Aggregate Boundary
+
+A surface should return `FrameSnapshot` when a component boundary would otherwise return several values
+that share ids and coordinates:
+
+```rust
+let frame = FrameSnapshot::from_layout(layout)
+    .focus(focus)
+    .mouse(mouse)
+    .cursor(cursor);
+```
+
+The aggregate is useful at boundaries: parent components can map ids, translate coordinates, clip
+hidden child data, and merge children without knowing how each child internally built its data.
+
+### Derived Layout Plus State
+
+Virtualized views often produce a rich layout value and update persistent state separately:
+
+```rust
+let layout = list.layout(area, items, &mut state);
+let metrics = ScrollMetrics::from_list(&layout);
+```
+
+This shape keeps viewport math and visible-row data together while leaving selection and scroll
+state app-owned.
+
+## Cross-Use-Case Analysis
+
+### 0001 Ordered Action Surfaces
+
+Action surfaces often need layout, mouse, focus, disabled policy, and optional selection. They do
+not need cursor requests. `FrameTargets::from_regions` fits because it derives aligned layout,
+mouse, and focus target data from one ordered region list.
+
+The gap is not the value model. The gap is an optional action-surface helper that can pair id, label,
+width, enabled state, shortcut, and orientation while still returning ordinary values.
+
+### 0002 Modal Dialog Coordination
+
+Dialogs need layout and z-order. Most dialogs need pointer data because outside-click behavior and
+frontmost routing matter. Focus is policy-dependent: a prompt with two buttons needs focus, a help
+overlay may only capture Escape and scroll. Cursor data are child-dependent and should remain
+optional.
+
+The current pieces cover the model, but the call sites are a little too manual:
+
+- `Container` computes outer and inner areas.
+- `Row`, `Column`, or `Overlay` values child regions.
+- `FrameTargets` can build child routing data.
+- `FrameSnapshot::scroll_region` or `FrameTargets::mouse_region` can add a backdrop target.
+- `FrameSnapshot::route_click` can produce a negative hit when no backdrop is used.
+
+The `modal_prompt` example proves those pieces are enough for a small confirmation dialog: it
+renders a page behind the prompt, traps focus in the prompt buttons, routes clicks through an
+explicit backdrop target, and leaves form state out of the dialog model.
+
+The missing abstraction, if one appears, is likely a small modal-shell helper, not a form helper:
+outer area, inner area, z value, optional backdrop id, and a child frame merge. That helper should
+not own fields, buttons, validation, or submit behavior.
+
+### 0003 Filtered Record Selection
+
+This use case is mostly persistent selection state plus a visible-id bridge. It may use region data
+for rendering and pointer data for click selection, but the central problem is not a frame aggregate.
+
+The common visible-id path now has direct helpers. Any remaining gap is around richer fallback
+policies, range selection, or adapters from virtualized hit tests into durable record ids.
+
+### 0004 Multi-Pane Scroll Routing
+
+Scroll routing needs pointer data for whole-pane regions and layout or metrics for rendering status.
+Focus is optional: some panes are keyboard-scrollable, others only scroll under the pointer.
+
+The current pieces work for common panes. `ScrollMetrics::visible_range` covers simple fixed-height
+line panes, while `VirtualListState` and `VirtualTableState` cover virtualized views. A small
+non-virtual `ScrollState` may still be useful if examples keep storing bare offsets.
+
+### 0005 Virtual List Row Rendering
+
+Virtual lists produce a derived `ListLayout`, not just a generic `Regions`. Mouse data are
+needed only when the app wants row clicks or wheel regions. Selection state is app-owned and should
+remain distinct from viewport scrolling.
+
+`VirtualListState::select_relative` now covers common keyboard movement over source indexes, while
+`VirtualListState::scroll_viewport_by` keeps wheel scrolling separate from selection. This use case
+validates having rich layout outputs in addition to generic values.
+
+### 0006 Virtual Table Inspection
+
+Tables need a richer layout output than a generic region list: visible cells, header/body positions,
+two-axis metrics, and hit testing. Selection is persistent state; pointer data are optional depending
+on whether clicks are enabled.
+
+`VirtualTableState::select_relative` now covers common keyboard movement over source cell
+positions. `TableLayout::cell_regions` and `TableLayout::cells_regions` let apps project visible cells
+into generic layout or mouse coordination when needed, while `TableLayout::select_hit` keeps
+body-cell click selection separate from header actions.
+
+This use case argues against forcing everything through `FrameSnapshot`. A table can expose
+`TableLayout` and let the app decide which frame-local data to derive.
+
+### 0007 Component Frame Composition
+
+This is the strongest `FrameSnapshot` use case. The parent component needs to merge child data,
+translate local coordinates, clip hidden regions, and preserve cursor request order.
+
+`component_frames` now shows a middle-sized version of that boundary: children return local
+`FrameSnapshot` values, the parent maps ids into one app enum, places the child frames with solved
+screen areas, and stores the merged snapshot for input. Cursor requests translate and clip with the
+rest of the child data, which matters for focused text inputs inside panes.
+
+The aggregate exists for this boundary. It should stay optional for smaller components.
+
+### 0008 Mouse Overlays And Disabled Targets
+
+This use case can be solved entirely with `PointerTargets` and `PointerState`. Layout data may be useful
+for rendering, but pointer routing should not require focus or selection.
+
+`PointerPhase` now covers the backend-agnostic hover, press, and release transition that examples
+were repeating. Backends still convert their own event kinds at the app edge, and scroll, drag,
+buttons, and modifiers remain app policy until examples prove a narrower helper.
+
+This use case is the clearest reminder that smaller values must remain ergonomic. A hoverable row,
+disabled button, or popup target should not require a full `FrameSnapshot`.
+
+### 0009 Form Editing
+
+Forms combine layout, focus, cursor, and app-owned edit buffers. Mouse data are optional, and
+selection depends on whether the form has radio groups, segmented choices, or list-like fields.
+
+`form_dialog` demonstrates the small-piece path directly: named field regions, focus repair,
+`TextFieldState` for edit mechanics, and cursor requests derived from the focused field's label
+prefix. `profile_editor` adds a saved value, pending draft, validation status, disabled Save
+command, and mixed vertical-field/horizontal-command focus. A broad form abstraction would likely
+hide too many app decisions too early. Better candidates are narrow helpers around
+validation-to-disabled-command wiring if more examples repeat that shape.
+
+## Review Outcome
+
+The current crate has the right conceptual pieces. The main risk is presentation: a reader should
+not infer that `FrameSnapshot` is the normal return type for every surface.
+
+The use-case review led to three concrete documentation and example decisions:
+
+- Keep "Choosing what to store" in the crate root as the concept-level explanation of frame-local data,
+  persistent state, derived layouts, metrics, and render contexts.
+- Teach the same aggregate-vs-smaller-value rule from `docs::frame_snapshots`, where readers already
+  arrive when they see `FrameSnapshot`.
+- Add `pointer_only_scroll_region` because the existing `scroll_regions` example used
+  `FrameSnapshot` for a shape that can be shown with `PointerTargets` alone.
+
+The other small-value examples already exist under clearer names:
+
+| Shape                 | Example                      | Demonstrates                         |
+| --------------------- | ---------------------------- | ------------------------------------ |
+| Mouse-only scroll     | `pointer_only_scroll_region` | wheel routing with `PointerTargets`  |
+| Focus-only fields     | `focus_traversal`            | `FocusTargets` and `FocusState`      |
+| Selection without agg | `selection_modes`            | selection outside values             |
+| Backdrop without form | `modal_prompt`               | shell data separate from form        |
+| Child aggregate       | `component_frames`           | where `FrameSnapshot` earns its keep |
+
+Do not add bundle helpers yet. The repeated patterns are real, but they still carry app policy:
+
+- modal shells decide backdrop behavior, escape behavior, focus trap policy, and child ownership;
+- action surfaces decide labels, shortcuts, orientation, selection, and enabled state;
+- field rows decide validation, labels, cursor prefixes, and edit-buffer ownership;
+- scroll panes decide whether wheel, keyboard focus, selection, and virtualization are coupled.
+
+Those may become helpers later, but the next proof should come from examples where the same
+coordination machinery appears again with the same policy boundaries.
+
+## Review Questions
+
+When reviewing a new primitive or example, ask:
+
+1. Which frame-local data does this surface actually produce?
+1. Which persistent state does the app own?
+1. Does the example use `FrameSnapshot` because a boundary benefits from aggregation, or only
+   because it is available?
+1. Could a smaller value make the example clearer?
+1. Does a helper reduce repeated coordination, or does it hide a policy the app should make?
+1. Are derived layouts such as `ListLayout` or `TableLayout` more appropriate than generic values?
+1. Is the word `Context` being used only for callback inputs rather than frame outputs?

--- a/crates/ratatui-layout/use-cases/0011-nested-event-routing-and-focus-scopes.md
+++ b/crates/ratatui-layout/use-cases/0011-nested-event-routing-and-focus-scopes.md
@@ -1,0 +1,185 @@
+# 0011 Nested Event Routing And Focus Scopes
+
+## User Story
+
+An app author is building a screen with meaningful local relationships: a form inside a details
+pane, inline buttons inside table rows, a command strip inside a dialog, or a popup over an editor.
+The app can identify the rectangle under the pointer and the currently focused id, but it also
+needs to know how nearby and nested controls relate to each other.
+
+The author needs a way to answer:
+
+- Which target is the leaf that should see this input first?
+- Which parent groups should see the input after the leaf declines or handles it?
+- Which focus scope owns Tab, Shift-Tab, arrow movement, and Escape?
+- Which pointer target captures a drag or release after the press starts?
+- Which page-level shortcuts should still run when a child field, menu, or dialog has focus?
+
+This is the relationship and routing-order question behind richer apps. It is adjacent to
+`FrameSnapshot`, but it is not the same problem as storing rectangles or hit targets.
+
+## Scenarios
+
+### Form Group Inside A Pane
+
+A details pane contains editable fields, a Save/Cancel row, and pane-level shortcuts. A text field
+should handle character input, Backspace, Delete, Home, End, and local cursor movement. The form
+group should handle Tab and Shift-Tab across fields and buttons. The pane may handle Escape or help,
+and the page may handle global commands.
+
+The app needs a clear route from focused field to form group to pane to page. A single flat
+`FocusState<Target>` can name the focused field, but it does not describe the parent chain.
+
+### Inline Controls Inside Rows
+
+A list row may contain a checkbox, row title, status pill, and action button. A click on the button
+should activate the button first. A click on row background should select the row. Keyboard focus
+may move between rows, while local arrow keys or Space may act on the inline control.
+
+The app needs both hit testing and containment. The target under the pointer is a leaf, but the row
+is also meaningful context.
+
+### Modal Or Popup Above A Page
+
+A modal dialog or popup sits above page content. Pointer routing should prefer the topmost child.
+Clicking outside may dismiss the popup, while clicking through to the page may be blocked. Keyboard
+focus may be trapped inside the modal until it closes.
+
+The app needs topmost hit testing, negative hit behavior, and focus-scope policy. Z-order alone
+does not say whether the page behind can receive the input.
+
+### Nested Roving Focus
+
+A command strip, menu, segmented control, tab bar, and radio group can all use local roving focus.
+The page may use Tab to enter or leave the group, while Left/Right or Up/Down moves within the
+group. The selected item may be different from the locally focused item.
+
+The app needs local focus scopes that can be entered, exited, and repaired when children are
+disabled or removed.
+
+### Captured Pointer Interaction
+
+A slider, drag handle, scrollbar thumb, or text selection gesture should keep receiving pointer
+updates after the pointer leaves its original rectangle. A release should route to the captured
+target, not just the target currently under the pointer.
+
+The current `PointerState` tracks pressed id enough for simple press/release activation. Drag and
+capture need stronger route ownership.
+
+## Background Reading
+
+This use case was informed by broader Rust GUI architecture writing, but those projects are
+brainstorm material rather than direct requirements. They solve different problems with different
+constraints, often using retained widget trees, pass systems, accessibility trees, and platform
+rendering concerns that are outside this crate's current scope.
+
+The useful ideas to keep in mind are narrower:
+
+1. Events often need a target path, not just a target id. A route from root to leaf gives each local
+   layer a chance to adapt state or policy.
+1. Event systems often separate pointer, keyboard/text, accessibility, layout, paint, and update
+   work. Even when Ratatui stays immediate-mode, it is useful to name which previous-frame data an
+   input event is allowed to use.
+1. Full GUI toolkits need strong answers for text input, keyboard layouts, IME, accessibility,
+   pointer capture, and focus updates. This crate should leave room for those concerns without
+   pretending to solve them.
+
+`ratatui-layout` does not have a retained widget tree, and it should not copy those architectures
+directly. The useful lesson is narrower: once an app has nested surfaces, flat ids are not enough to
+explain input ownership. The app needs an explicit route or scope model if the crate wants to help
+with nested focus and event propagation.
+
+## Current Crate Coverage
+
+The crate already covers the frame-local data needed to build routes:
+
+- `Regions` records visible regions and z-order.
+- `PointerTargets` records pointer targets, disabled state, local coordinates, and z-order.
+- `FocusTargets` records enabled focus targets in traversal order.
+- `FrameSnapshot` can map, translate, clip, and merge child data across component boundaries.
+- `FrameTargets` can derive aligned layout, mouse, and focus target data from one region list.
+
+The crate also has examples that approach this from different sides:
+
+- `component_frames` shows app-owned parent and child ids moving through an aggregate frame.
+- `modal_prompt` shows a raised surface with backdrop routing and local button focus.
+- `profile_editor` shows field focus, a command row, and validation-disabled Save.
+- `pointer_targets` shows z-order, disabled pointer targets, hover, press, and release.
+- `toolbar_targets` shows action-surface ids shared across layout, focus, and pointer data.
+
+Those examples prove the low-level data are useful, but they still encode route relationships by
+hand in application enums and event handlers.
+
+## Coordination Data Analysis
+
+Nested routing usually combines several value types, but the central missing value is relationship.
+
+| Shape                | Layout | Mouse | Focus | Selection | Cursor | Route |
+| -------------------- | ------ | ----- | ----- | --------- | ------ | ----- |
+| Form inside pane     | yes    | maybe | yes   | maybe     | yes    | yes   |
+| Inline row controls  | yes    | yes   | maybe | yes       | no     | yes   |
+| Modal over page      | yes    | yes   | yes   | no        | maybe  | yes   |
+| Roving focus group   | yes    | maybe | yes   | maybe     | no     | yes   |
+| Drag/capture target  | yes    | yes   | no    | maybe     | no     | yes   |
+
+`Route` here means parent/child relationship and propagation order. It is different from
+`PointerTargets::hit_test`, which returns the topmost leaf target, and different from
+`FocusTargets`, which returns the next enabled focus target in a flat traversal order.
+
+## Possible API Direction
+
+Do not add this yet. The shape needs at least one strong example first.
+
+The likely primitives are small and explicit:
+
+- `TargetPath<Id>` or `RoutePath<Id>`: a root-to-leaf path such as page, pane, form, field.
+- `RouteMap<Id>`: frame-local parent/child relationships plus optional areas for routing.
+- `FocusScope<Id>`: a named group with ordered children, entry target, fallback target, and trap
+  policy.
+- `EventRoute<Id>`: the result of routing one event, including leaf target and ancestor chain.
+- `PointerCapture<Id>`: persistent state saying pointer updates belong to the pressed/captured id.
+
+The most Ratatui-compatible version would keep these as optional data. Widgets would still render
+into `Rect` and `Buffer`. Apps would still own domain state and decide what each routed event means.
+
+## Proof Example
+
+A future proof example should combine:
+
+- a page with two panes;
+- a details pane containing a form group;
+- a row list where each row has an inline action;
+- a modal or popup above both panes;
+- keyboard routing that lets fields handle text first, then form-level traversal, then page-level
+  shortcuts;
+- mouse routing that can report both leaf target and parent row or modal shell;
+- one captured pointer interaction, such as dragging a splitter or scrollbar thumb.
+
+The example starts with app-owned route code. Only extract API after the repeated mechanics are
+visible and boring.
+
+## What This Validates
+
+This use case explains a limitation of the current flat values:
+
+- topmost hit testing is not the same as route propagation;
+- focus traversal is not the same as focus scoping;
+- z-order is not the same as outside-click or capture policy;
+- enum ids can encode hierarchy, but the app still has to write the route mechanics;
+- `FrameSnapshot` can carry data across component boundaries, but it does not define who handles an
+  event first.
+
+The current crate should document this as future pressure. Adding route paths or focus scopes too
+early would likely create a framework-shaped API before the example pressure is clear.
+
+## Related Use Cases
+
+- [`0001 Ordered Action Surfaces`](0001-command-toolbar-routing.md) covers roving action surfaces.
+- [`0002 Modal Dialog Coordination`](0002-modal-dialog-coordination.md) covers raised surfaces and
+  outside-click policy.
+- [`0007 Component Frame Composition`](0007-component-frame-composition.md) covers child frame
+  mapping and merging.
+- [`0008 Mouse Overlays And Disabled Targets`](0008-mouse-overlays-and-disabled-targets.md) covers
+  pointer z-order, disabled targets, hover, and press/release.
+- [`0010 Frame Snapshots`](0010-frame-snapshots.md) covers choosing which data a surface
+  should produce.

--- a/crates/ratatui-layout/use-cases/README.md
+++ b/crates/ratatui-layout/use-cases/README.md
@@ -1,0 +1,43 @@
+# ratatui-layout Use Cases
+
+These notes ground `ratatui-layout` in application needs rather than implementation inventory.
+Each use case describes a real TUI shape, the coordination problem it creates, what the crate
+currently offers, and which API gaps still need sharper names or stronger primitives.
+
+Rustdoc remains the main API guide. These use cases are a design validation catalog for deciding
+whether a helper reduces real application complexity or only hides code.
+
+## Catalog
+
+- [0001-command-toolbar-routing](0001-command-toolbar-routing.md): command strips where disabled,
+  focused, clicked, and selected controls share the same ids.
+- [0002-modal-dialog-coordination](0002-modal-dialog-coordination.md): raised surfaces, z-order,
+  local focus, and routing while the page behind remains visible.
+- [0003-filtered-record-selection](0003-filtered-record-selection.md): durable selection for
+  filtered or sorted application records.
+- [0004-multi-pane-scroll-routing](0004-multi-pane-scroll-routing.md): mouse wheel routing to the
+  pane under the pointer without changing selection.
+- [0005-virtual-list-row-rendering](0005-virtual-list-row-rendering.md): large or variable-height
+  lists where the app owns row data and row rendering.
+- [0006-virtual-table-inspection](0006-virtual-table-inspection.md): two-axis tables with pinned
+  headers, selected cells, hit testing, and scroll metrics.
+- [0007-component-frame-composition](0007-component-frame-composition.md): componentized apps that
+  return frame-local data without adopting a retained widget tree.
+- [0008-mouse-overlays-and-disabled-targets](0008-mouse-overlays-and-disabled-targets.md):
+  overlapping pointer targets, disabled controls, hover, press/release, and local coordinates.
+- [0009-form-editing](0009-form-editing.md): editable fields, temporary edit buffers, focus
+  traversal, cursor placement, validation pressure, and form command rows.
+- [0010-frame-snapshots](0010-frame-snapshots.md): choosing which frame-local data, persistent
+  state, derived layouts, metrics, and contexts each surface actually needs.
+- [0011-nested-event-routing-and-focus-scopes](0011-nested-event-routing-and-focus-scopes.md):
+  parent/child route paths, local focus scopes, event order, and pointer capture pressure.
+
+## Review Questions
+
+Use these questions when adding or changing APIs:
+
+1. Does the helper make one of these use cases read more like the user's intent?
+1. Does it preserve Ratatui's immediate-mode rendering model?
+1. Does the application still own domain data, widget state, and event policy?
+1. Does it reduce repeated coordination machinery rather than only shortening example code?
+1. Can a focused example show the helper without becoming a framework tutorial?

--- a/typos.toml
+++ b/typos.toml
@@ -6,3 +6,4 @@ extend-exclude = [
 
 [default.extend-words]
 ratatui = "ratatui"
+WRK = "WRK"


### PR DESCRIPTION
## Summary

- import the experimental `ratatui-layout` crate into the `ratatui-labs` workspace
- adapt its manifest from Ratatui monorepo workspace dependencies to published dependencies
- re-export the crate as `ratatui_labs::layout` and document the new workspace entry points

## Validation

- `cargo +nightly fmt --all`
- `cargo check --workspace --all-targets --all-features`
- `cargo test --workspace --all-targets --all-features`
- `cargo test --workspace --doc --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `markdownlint-cli2 README.md AGENTS.md 'docs/**/*.md' 'crates/**/*.md'`
- `cargo doc --workspace --all-features --no-deps`
