### PR TITLE
Adjust Betamax tape frame sizes

### DIFF
--- a/tapes/command-palette.tape
+++ b/tapes/command-palette.tape
@@ -6,7 +6,7 @@ Require cargo
 
 Set Shell "bash"
 Set Width 1200
-Set Height 620
+Set Height 650
 Set WindowBar Colorful
 Set BorderRadius 8
 Set TypingSpeed 35ms

--- a/tapes/renderers/flat.tape
+++ b/tapes/renderers/flat.tape
@@ -6,7 +6,7 @@ Require cargo
 
 Set Shell "bash"
 Set Width 1200
-Set Height 620
+Set Height 650
 Set WindowBar Colorful
 Set BorderRadius 8
 Set TypingSpeed 35ms

--- a/tapes/renderers/fullscreen.tape
+++ b/tapes/renderers/fullscreen.tape
@@ -6,7 +6,7 @@ Require cargo
 
 Set Shell "bash"
 Set Width 1200
-Set Height 620
+Set Height 650
 Set WindowBar Colorful
 Set BorderRadius 8
 Set TypingSpeed 35ms

--- a/tapes/renderers/inline.tape
+++ b/tapes/renderers/inline.tape
@@ -6,7 +6,7 @@ Require cargo
 
 Set Shell "bash"
 Set Width 1200
-Set Height 620
+Set Height 650
 Set WindowBar Colorful
 Set BorderRadius 8
 Set TypingSpeed 35ms

--- a/tapes/renderers/modal.tape
+++ b/tapes/renderers/modal.tape
@@ -6,7 +6,7 @@ Require cargo
 
 Set Shell "bash"
 Set Width 1200
-Set Height 620
+Set Height 650
 Set WindowBar Colorful
 Set BorderRadius 8
 Set TypingSpeed 35ms

--- a/tapes/renderers/split.tape
+++ b/tapes/renderers/split.tape
@@ -6,7 +6,7 @@ Require cargo
 
 Set Shell "bash"
 Set Width 1200
-Set Height 620
+Set Height 650
 Set WindowBar Colorful
 Set BorderRadius 8
 Set TypingSpeed 35ms


### PR DESCRIPTION
## Summary

- Adjust repo-owned Betamax tapes for Betamax's VHS-compatible final-frame sizing semantics
- Preserve the existing 1200x650 rendered output size for tapes that use the default 30px window bar
- Leave generated Betamax media untracked under `target/betamax/`

## Validation

- `cargo build -p betamax` in `/Users/joshka/local/betamax-vhs-sizing`
- `BETAMAX_BIN=/Users/joshka/local/betamax-vhs-sizing/target/debug/betamax BETAMAX_JOBS=1 just betamax`
- pre/post `file` dimension capture and diff for generated PNG/GIF artifacts
- visual spot-check of `target/betamax/command-palette-open.png` and `target/betamax/renderers/split-open.png`
