### PR TITLE
Add experimental ratatui-derive crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +675,16 @@ name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "indoc"
@@ -1230,12 +1252,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui-derive"
+version = "0.1.0-beta.0"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "ratatui",
+ "ratatui-core",
+ "syn 2.0.118",
+ "trybuild",
+]
+
+[[package]]
 name = "ratatui-labs"
 version = "0.1.0"
 dependencies = [
  "ratatui-action",
  "ratatui-command-palette",
  "ratatui-core",
+ "ratatui-derive",
  "ratatui-layout",
 ]
 
@@ -1424,6 +1460,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1603,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1694,6 +1767,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1844,22 @@ dependencies = [
  "sharded-slab",
  "thread_local",
  "tracing-core",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0710d4dfbeae4f9c390baa784c49858a7468fa433f3fe5d0ec5ebef651cf59f9"
+dependencies = [
+ "dissimilar",
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -1963,6 +2091,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,3 +2137,9 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ grow into real experiments when there is a concrete design to test.
   invocation requests.
 - `crates/ratatui-command-palette` - experimental command palette state, rendering, preview, and
   invocation behavior.
+- `crates/ratatui-derive` - experimental derive macros and code generation helpers for Ratatui
+  APIs.
 - `crates/ratatui-layout` - experimental frame-local UI coordination primitives for visible
   regions, focus targets, pointer targets, cursor requests, and scroll metadata.
 - `crates/ratatui-labs` - umbrella crate for labs-style experiments and prototype Ratatui work.

--- a/crates/ratatui-derive/Cargo.toml
+++ b/crates/ratatui-derive/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "ratatui-derive"
+version = "0.1.0-beta.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Experimental derive macros and code generation helpers for Ratatui APIs."
+documentation = "https://docs.rs/ratatui-derive"
+readme = "README.md"
+include = [
+    "Cargo.toml",
+    "README.md",
+    "src/**/*.rs",
+    "tests/**/*.rs",
+    "tests/**/*.stderr",
+]
+
+[package.metadata.ratatui-reservation]
+area = "Experimental APIs"
+future_scope = "derive macros and code generation helpers for Ratatui APIs"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+darling = "0.23"
+proc-macro2 = "1.0.106"
+quote = "1.0.45"
+syn = { version = "2.0.118", features = ["full"] }
+
+[dev-dependencies]
+ratatui = "0.30.2"
+ratatui-core = "0.1.2"
+trybuild = { version = "1", features = ["diff"] }
+
+[lints]
+workspace = true

--- a/crates/ratatui-derive/README.md
+++ b/crates/ratatui-derive/README.md
@@ -1,0 +1,91 @@
+# ratatui-derive
+
+Derive macros and code generation helpers for Ratatui APIs.
+
+This crate is experimental and lives in
+[`ratatui/ratatui-labs`](https://github.com/ratatui/ratatui-labs). It is published with a beta
+version while the macro names, attribute grammar, and generated public contracts are evaluated in
+real Ratatui applications.
+
+The crate currently provides `FromRect`, a derive macro for named layout-area structs. It
+generates `impl From<Rect> for YourStruct`, so application code can split a `Rect` into ordinary
+named fields without a local layout macro.
+
+```rust
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal, spacing = 2)]
+struct ButtonDemoAreas {
+    #[length(46)]
+    gallery: Rect,
+
+    #[min(34)]
+    debug: Rect,
+}
+
+let area = Rect::new(0, 0, 100, 20);
+let areas = ButtonDemoAreas::from(area);
+```
+
+This keeps the layout result as regular Rust:
+
+- `ButtonDemoAreas` is a named type.
+- `gallery` and `debug` are ordinary fields.
+- `From<Rect>` works with `ButtonDemoAreas::from(area)` and `area.into()`.
+- The generated split can be tested through normal Rust tests.
+
+## Supported Shape
+
+`FromRect` supports structs with named fields. Each field must have one layout constraint
+attribute:
+
+```rust
+#[length(10)]
+#[min(20)]
+#[max(30)]
+#[percentage(50)]
+#[ratio(1, 3)]
+#[fill(1)]
+```
+
+The struct must choose one direction with `#[layout(horizontal)]` or `#[layout(vertical)]`.
+Layout options include spacing, margin, axis-specific margins, flex, and crate path override:
+
+```rust
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(vertical, margin = 1, horizontal_margin = 2, flex = Center)]
+struct Areas {
+    #[fill(1)]
+    main: Rect,
+}
+```
+
+By default, generated code uses `::ratatui::layout`. Lower-level crates that depend on
+`ratatui-core` directly can use `#[layout(crate = ratatui_core)]`. Renamed dependencies work the
+same way:
+
+```rust
+use ratatui as tui;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal, crate = tui)]
+struct Areas {
+    #[fill(1)]
+    main: tui::layout::Rect,
+}
+```
+
+See the [`FromRect` docs](https://docs.rs/ratatui-derive/latest/ratatui_derive/derive.FromRect.html)
+for the complete generated code shape, supported attributes, and compile-time error behavior.
+
+## Status
+
+`ratatui-derive` is separate from the main `ratatui` crate and is not re-exported by `ratatui`.
+Add it as a direct dependency when using the derive macros. The API may change before a stable
+release.

--- a/crates/ratatui-derive/src/from_rect.rs
+++ b/crates/ratatui-derive/src/from_rect.rs
@@ -1,0 +1,379 @@
+use darling::util::{Flag, Ignored};
+use darling::{FromDeriveInput, ast};
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::punctuated::Punctuated;
+use syn::{Attribute, DeriveInput, Error, Expr, Field, Generics, Ident, Path, Result, Token};
+
+pub(crate) fn expand(input: &DeriveInput) -> TokenStream2 {
+    let input = match FromRectInput::from_derive_input(input) {
+        Ok(input) => input,
+        Err(error) => return error.write_errors(),
+    };
+
+    match expand_validated_from_rect(&input) {
+        Ok(tokens) => tokens,
+        Err(error) => error.to_compile_error(),
+    }
+}
+
+fn expand_validated_from_rect(input: &FromRectInput) -> Result<TokenStream2> {
+    let direction = input.direction()?;
+    let layout_path = input.layout_path();
+    let direction_method = direction.method_ident();
+    let fields = input.fields()?;
+    let flex = input.flex_variant()?;
+
+    let field_idents = fields
+        .iter()
+        .map(|field| field.ident.clone())
+        .collect::<Vec<_>>();
+    let constraints = fields
+        .iter()
+        .map(|field| field.constraint.to_tokens(&layout_path))
+        .collect::<Vec<_>>();
+    let layout_options = input.layout_option_tokens(&layout_path, flex.as_ref());
+    let ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    Ok(quote! {
+        impl #impl_generics ::core::convert::From<#layout_path::Rect> for #ident #ty_generics
+        #where_clause
+        {
+            fn from(area: #layout_path::Rect) -> Self {
+                let constraints = [
+                    #(#constraints),*
+                ];
+                let [#(#field_idents),*] =
+                    #layout_path::Layout::#direction_method(constraints)
+                        #(#layout_options)*
+                        .areas(area);
+                Self {
+                    #(#field_idents),*
+                }
+            }
+        }
+    })
+}
+
+#[derive(FromDeriveInput)]
+#[darling(attributes(layout), supports(struct_named))]
+struct FromRectInput {
+    ident: Ident,
+    generics: Generics,
+    data: ast::Data<Ignored, Field>,
+    #[darling(default)]
+    horizontal: Flag,
+    #[darling(default)]
+    vertical: Flag,
+    spacing: Option<Expr>,
+    margin: Option<Expr>,
+    horizontal_margin: Option<Expr>,
+    vertical_margin: Option<Expr>,
+    flex: Option<Path>,
+    #[darling(default, rename = "crate")]
+    crate_path: Option<Path>,
+}
+
+impl FromRectInput {
+    fn direction(&self) -> Result<Direction> {
+        match (self.horizontal.is_present(), self.vertical.is_present()) {
+            (true, false) => Ok(Direction::Horizontal),
+            (false, true) => Ok(Direction::Vertical),
+            (false, false) => Err(Error::new_spanned(
+                &self.ident,
+                "missing layout direction: add #[layout(horizontal)] or #[layout(vertical)]",
+            )),
+            (true, true) => Err(Error::new(
+                self.vertical.span(),
+                "layout direction can only be specified once",
+            )),
+        }
+    }
+
+    fn fields(&self) -> Result<Vec<LayoutField>> {
+        let ast::Data::Struct(fields) = &self.data else {
+            return Err(Error::new_spanned(
+                &self.ident,
+                "FromRect can only be derived for structs with named fields",
+            ));
+        };
+
+        if fields.is_empty() {
+            return Err(Error::new_spanned(
+                &self.ident,
+                "FromRect requires at least one named field",
+            ));
+        }
+
+        let mut parsed_fields = Vec::with_capacity(fields.len());
+        let mut errors = None;
+
+        for field in &fields.fields {
+            match LayoutField::from_field(field) {
+                Ok(field) => parsed_fields.push(field),
+                Err(error) => push_error(&mut errors, error),
+            }
+        }
+
+        if let Some(error) = errors {
+            return Err(error);
+        }
+
+        Ok(parsed_fields)
+    }
+
+    fn layout_path(&self) -> TokenStream2 {
+        if let Some(crate_path) = &self.crate_path {
+            quote!(#crate_path::layout)
+        } else {
+            quote!(::ratatui::layout)
+        }
+    }
+
+    fn flex_variant(&self) -> Result<Option<Ident>> {
+        let Some(flex) = &self.flex else {
+            return Ok(None);
+        };
+
+        parse_flex_variant(flex).map(Some)
+    }
+
+    fn layout_option_tokens(
+        &self,
+        layout_path: &TokenStream2,
+        flex: Option<&Ident>,
+    ) -> Vec<TokenStream2> {
+        let mut options = Vec::new();
+
+        if let Some(margin) = &self.margin {
+            options.push(quote!(.margin(#margin)));
+        }
+        if let Some(horizontal_margin) = &self.horizontal_margin {
+            options.push(quote!(.horizontal_margin(#horizontal_margin)));
+        }
+        if let Some(vertical_margin) = &self.vertical_margin {
+            options.push(quote!(.vertical_margin(#vertical_margin)));
+        }
+        if let Some(flex) = flex {
+            options.push(quote!(.flex(#layout_path::Flex::#flex)));
+        }
+        if let Some(spacing) = &self.spacing {
+            options.push(quote!(.spacing(#spacing)));
+        }
+
+        options
+    }
+}
+
+fn parse_flex_variant(path: &Path) -> Result<Ident> {
+    let Some(ident) = path.get_ident().cloned() else {
+        return Err(Error::new_spanned(
+            path,
+            "expected a Flex variant: Start, End, Center, SpaceBetween, SpaceAround, \
+             SpaceEvenly, or Legacy",
+        ));
+    };
+
+    match ident.to_string().as_str() {
+        "Start" | "End" | "Center" | "SpaceBetween" | "SpaceAround" | "SpaceEvenly" | "Legacy" => {
+            Ok(ident)
+        }
+        _ => Err(Error::new_spanned(
+            ident,
+            "expected a Flex variant: Start, End, Center, SpaceBetween, SpaceAround, \
+             SpaceEvenly, or Legacy",
+        )),
+    }
+}
+
+struct LayoutField {
+    ident: Ident,
+    constraint: Constraint,
+}
+
+impl LayoutField {
+    fn from_field(field: &Field) -> Result<Self> {
+        let Some(ident) = field.ident.clone() else {
+            return Err(Error::new_spanned(
+                field,
+                "FromRect only supports named fields",
+            ));
+        };
+        let constraint = parse_constraint(field)?;
+
+        Ok(Self { ident, constraint })
+    }
+}
+
+enum Direction {
+    Horizontal,
+    Vertical,
+}
+
+impl Direction {
+    fn method_ident(&self) -> Ident {
+        match self {
+            Self::Horizontal => format_ident!("horizontal"),
+            Self::Vertical => format_ident!("vertical"),
+        }
+    }
+}
+
+enum Constraint {
+    Length(Expr),
+    Min(Expr),
+    Max(Expr),
+    Percentage(Expr),
+    Ratio { numerator: Expr, denominator: Expr },
+    Fill(Expr),
+}
+
+impl Constraint {
+    fn to_tokens(&self, layout_path: &TokenStream2) -> TokenStream2 {
+        match self {
+            Self::Length(expr) => quote!(#layout_path::Constraint::Length(#expr)),
+            Self::Min(expr) => quote!(#layout_path::Constraint::Min(#expr)),
+            Self::Max(expr) => quote!(#layout_path::Constraint::Max(#expr)),
+            Self::Percentage(expr) => quote!(#layout_path::Constraint::Percentage(#expr)),
+            Self::Ratio {
+                numerator,
+                denominator,
+            } => {
+                quote!(#layout_path::Constraint::Ratio(#numerator, #denominator))
+            }
+            Self::Fill(expr) => quote!(#layout_path::Constraint::Fill(#expr)),
+        }
+    }
+}
+
+fn parse_constraint(field: &Field) -> Result<Constraint> {
+    let mut constraint = None;
+    let mut saw_constraint_attr = false;
+    let mut errors = None;
+
+    for attr in &field.attrs {
+        let Some(kind) = ConstraintKind::from_attr(attr) else {
+            continue;
+        };
+        saw_constraint_attr = true;
+
+        if constraint.is_some() {
+            push_error(
+                &mut errors,
+                Error::new_spanned(attr, "field can only have one layout constraint attribute"),
+            );
+            continue;
+        }
+
+        match kind.parse(attr) {
+            Ok(parsed_constraint) => constraint = Some(parsed_constraint),
+            Err(error) => push_error(&mut errors, error),
+        }
+    }
+
+    if !saw_constraint_attr {
+        push_error(
+            &mut errors,
+            Error::new_spanned(
+                field,
+                "missing layout constraint attribute: add one of #[length(expr)], #[min(expr)], \
+                 #[max(expr)], #[percentage(expr)], #[ratio(numerator, denominator)], or \
+                 #[fill(expr)]",
+            ),
+        );
+    }
+
+    if let Some(error) = errors {
+        return Err(error);
+    }
+
+    constraint.ok_or_else(|| Error::new_spanned(field, "missing layout constraint attribute"))
+}
+
+enum ConstraintKind {
+    Length,
+    Min,
+    Max,
+    Percentage,
+    Ratio,
+    Fill,
+}
+
+impl ConstraintKind {
+    fn from_attr(attr: &Attribute) -> Option<Self> {
+        let ident = attr.path().get_ident()?;
+
+        match ident.to_string().as_str() {
+            "length" => Some(Self::Length),
+            "min" => Some(Self::Min),
+            "max" => Some(Self::Max),
+            "percentage" => Some(Self::Percentage),
+            "ratio" => Some(Self::Ratio),
+            "fill" => Some(Self::Fill),
+            _ => None,
+        }
+    }
+
+    fn parse(&self, attr: &Attribute) -> Result<Constraint> {
+        match self {
+            Self::Length => single_expr_constraint(attr, "length", Constraint::Length),
+            Self::Min => single_expr_constraint(attr, "min", Constraint::Min),
+            Self::Max => single_expr_constraint(attr, "max", Constraint::Max),
+            Self::Percentage => single_expr_constraint(attr, "percentage", Constraint::Percentage),
+            Self::Fill => single_expr_constraint(attr, "fill", Constraint::Fill),
+            Self::Ratio => ratio_constraint(attr),
+        }
+    }
+}
+
+fn single_expr_constraint(
+    attr: &Attribute,
+    attr_name: &'static str,
+    build: impl FnOnce(Expr) -> Constraint,
+) -> Result<Constraint> {
+    let expr = attr.parse_args::<Expr>().map_err(|error| {
+        let mut new_error = Error::new_spanned(attr, format!("expected #[{attr_name}(expr)]"));
+        new_error.combine(error);
+        new_error
+    })?;
+
+    Ok(build(expr))
+}
+
+fn ratio_constraint(attr: &Attribute) -> Result<Constraint> {
+    let args = attr.parse_args_with(Punctuated::<Expr, Token![,]>::parse_terminated)?;
+    if args.len() != 2 {
+        return Err(Error::new_spanned(
+            attr,
+            "expected #[ratio(numerator, denominator)]",
+        ));
+    }
+
+    let mut args = args.into_iter();
+    let Some(numerator) = args.next() else {
+        return Err(Error::new_spanned(
+            attr,
+            "expected #[ratio(numerator, denominator)]",
+        ));
+    };
+    let Some(denominator) = args.next() else {
+        return Err(Error::new_spanned(
+            attr,
+            "expected #[ratio(numerator, denominator)]",
+        ));
+    };
+
+    Ok(Constraint::Ratio {
+        numerator,
+        denominator,
+    })
+}
+
+fn push_error(errors: &mut Option<Error>, error: Error) {
+    if let Some(errors) = errors {
+        errors.combine(error);
+    } else {
+        *errors = Some(error);
+    }
+}

--- a/crates/ratatui-derive/src/lib.rs
+++ b/crates/ratatui-derive/src/lib.rs
@@ -1,0 +1,227 @@
+//! Derive macros for Ratatui.
+//!
+//! See [`FromRect`] for the full derive documentation, including supported attributes,
+//! generated code shape, and examples.
+
+#![allow(clippy::needless_continue)]
+
+mod from_rect;
+
+use proc_macro::TokenStream;
+use syn::DeriveInput;
+
+/// `FromRect` derives `From<Rect>` for structs that name the [`Rect`]s produced by a Ratatui
+/// [`Layout`]. It is intended for app code that repeatedly splits the same area into named
+/// regions.
+///
+/// ```rust
+/// use ratatui::layout::Rect;
+/// use ratatui_derive::FromRect;
+///
+/// #[derive(FromRect)]
+/// #[layout(horizontal, spacing = 2)]
+/// struct ButtonDemoAreas {
+///     #[length(46)]
+///     gallery: Rect,
+///
+///     #[min(34)]
+///     debug: Rect,
+/// }
+///
+/// let area = Rect::new(0, 0, 100, 20);
+/// let areas = ButtonDemoAreas::from(area);
+/// assert_eq!(areas.gallery.width, 46);
+/// ```
+///
+/// The generated implementation is equivalent to writing the layout split by hand:
+///
+/// ```rust
+/// # use ratatui::layout::Rect;
+/// # struct ButtonDemoAreas {
+/// #     gallery: Rect,
+/// #     debug: Rect,
+/// # }
+/// impl From<Rect> for ButtonDemoAreas {
+///     fn from(area: Rect) -> Self {
+///         let constraints = [
+///             ratatui::layout::Constraint::Length(46),
+///             ratatui::layout::Constraint::Min(34),
+///         ];
+///         let [gallery, debug] = ratatui::layout::Layout::horizontal(constraints)
+///             .spacing(2)
+///             .areas(area);
+///         Self { gallery, debug }
+///     }
+/// }
+/// ```
+///
+/// # Supported input
+///
+/// `FromRect` supports structs with named fields. Tuple structs, unit structs, enums, and unions
+/// are rejected. The derive does not check that each field is typed as [`Rect`]; Rust type
+/// checking rejects incompatible field types when the generated `Self { field }` expression is
+/// compiled.
+///
+/// Each struct needs exactly one layout direction:
+///
+/// ```rust
+/// # use ratatui::layout::Rect;
+/// # use ratatui_derive::FromRect;
+/// #[derive(FromRect)]
+/// #[layout(horizontal)]
+/// struct HorizontalAreas {
+///     #[fill(1)]
+///     main: Rect,
+/// }
+///
+/// #[derive(FromRect)]
+/// #[layout(vertical)]
+/// struct VerticalAreas {
+///     #[fill(1)]
+///     main: Rect,
+/// }
+/// ```
+///
+/// # Layout options
+///
+/// The `#[layout(...)]` attribute accepts these options:
+///
+/// - `horizontal` or `vertical`: required direction flag.
+/// - `spacing = expr`: calls [`Layout::spacing`].
+/// - `margin = expr`: calls [`Layout::margin`].
+/// - `horizontal_margin = expr`: calls [`Layout::horizontal_margin`].
+/// - `vertical_margin = expr`: calls [`Layout::vertical_margin`].
+/// - `flex = Variant`: calls [`Layout::flex`] with a [`Flex`] variant.
+/// - `crate = path`: uses `path::layout` instead of the default `::ratatui::layout`.
+///
+/// When `margin` is combined with `horizontal_margin` or `vertical_margin`, the generated code
+/// applies `margin` first and then the axis-specific margins. This makes `margin` the default for
+/// both axes and lets axis-specific options override one side.
+///
+/// The default path is `::ratatui::layout`, which is the right path for applications that depend
+/// on the main `ratatui` crate. Crates that depend on `ratatui-core` directly can use
+/// `#[layout(crate = ratatui_core)]`. Renamed dependencies work the same way because the value is
+/// a Rust path:
+///
+/// ```rust
+/// use ratatui as tui;
+/// use ratatui_derive::FromRect;
+///
+/// #[derive(FromRect)]
+/// #[layout(horizontal, crate = tui)]
+/// struct Areas {
+///     #[fill(1)]
+///     main: tui::layout::Rect,
+/// }
+/// ```
+///
+/// Layout options can be combined:
+///
+/// ```rust
+/// # use ratatui::layout::Rect;
+/// # use ratatui_derive::FromRect;
+/// #[derive(FromRect)]
+/// #[layout(vertical, margin = 1, horizontal_margin = 2, spacing = 1)]
+/// struct BodyAreas {
+///     #[fill(1)]
+///     main: Rect,
+/// }
+/// ```
+///
+/// # Flex variants
+///
+/// `flex = Variant` accepts Ratatui [`Flex`] variants by their variant name: `Start`, `End`,
+/// `Center`, `SpaceBetween`, `SpaceAround`, `SpaceEvenly`, and `Legacy`.
+///
+/// ```rust
+/// # use ratatui::layout::Rect;
+/// # use ratatui_derive::FromRect;
+/// #[derive(FromRect)]
+/// #[layout(horizontal, flex = Center)]
+/// struct CenterAreas {
+///     #[length(1)]
+///     main: Rect,
+/// }
+/// ```
+///
+/// # Field constraints
+///
+/// Each field needs exactly one constraint attribute. The field order is the layout order, and the
+/// field names become the names of the generated [`Rect`]s.
+///
+/// ```rust
+/// # use ratatui::layout::Rect;
+/// # use ratatui_derive::FromRect;
+/// #[derive(FromRect)]
+/// #[layout(vertical)]
+/// struct EveryConstraint {
+///     #[length(1)]
+///     length: Rect,
+///
+///     #[min(2)]
+///     min: Rect,
+///
+///     #[max(3)]
+///     max: Rect,
+///
+///     #[percentage(25)]
+///     percentage: Rect,
+///
+///     #[ratio(1, 2)]
+///     ratio: Rect,
+///
+///     #[fill(1)]
+///     fill: Rect,
+/// }
+/// ```
+///
+/// The constraint values are Rust expressions passed to the matching [`Constraint`] variant. The
+/// derive does not evaluate them:
+///
+/// ```rust
+/// # use ratatui::layout::Rect;
+/// # use ratatui_derive::FromRect;
+/// const SIDEBAR_WIDTH: u16 = 30;
+/// const NUMERATOR: u32 = 1;
+/// const DENOMINATOR: u32 = 3;
+///
+/// #[derive(FromRect)]
+/// #[layout(
+///     horizontal,
+///     spacing = SIDEBAR_WIDTH / 30,
+///     margin = 1 + 1,
+///     horizontal_margin = SIDEBAR_WIDTH / 10,
+///     vertical_margin = 2,
+/// )]
+/// struct ExpressionAreas {
+///     #[length(SIDEBAR_WIDTH + 2)]
+///     sidebar: Rect,
+///
+///     #[ratio(NUMERATOR, DENOMINATOR)]
+///     content: Rect,
+///
+///     #[fill(1 + 1)]
+///     extra: Rect,
+/// }
+/// ```
+///
+/// `FromRect` intentionally supports only the six field attributes shown above. It does not
+/// support wrapper attributes or raw constraint expressions.
+///
+/// [`Constraint`]: https://docs.rs/ratatui/latest/ratatui/layout/enum.Constraint.html
+/// [`Flex`]: https://docs.rs/ratatui/latest/ratatui/layout/enum.Flex.html
+/// [`Layout`]: https://docs.rs/ratatui/latest/ratatui/layout/struct.Layout.html
+/// [`Layout::flex`]: https://docs.rs/ratatui/latest/ratatui/layout/struct.Layout.html#method.flex
+/// [`Layout::horizontal_margin`]: https://docs.rs/ratatui/latest/ratatui/layout/struct.Layout.html#method.horizontal_margin
+/// [`Layout::margin`]: https://docs.rs/ratatui/latest/ratatui/layout/struct.Layout.html#method.margin
+/// [`Layout::spacing`]: https://docs.rs/ratatui/latest/ratatui/layout/struct.Layout.html#method.spacing
+/// [`Layout::vertical_margin`]: https://docs.rs/ratatui/latest/ratatui/layout/struct.Layout.html#method.vertical_margin
+/// [`Rect`]: https://docs.rs/ratatui/latest/ratatui/layout/struct.Rect.html
+#[proc_macro_derive(
+    FromRect,
+    attributes(layout, length, min, max, percentage, ratio, fill)
+)]
+pub fn derive_from_rect(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as DeriveInput);
+    from_rect::expand(&input).into()
+}

--- a/crates/ratatui-derive/tests/from_rect.rs
+++ b/crates/ratatui-derive/tests/from_rect.rs
@@ -1,0 +1,105 @@
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui_derive::FromRect;
+
+#[derive(Debug, Eq, PartialEq, FromRect)]
+#[layout(horizontal, spacing = 2)]
+struct ButtonDemoAreas {
+    #[length(46)]
+    gallery: Rect,
+
+    #[min(34)]
+    debug: Rect,
+}
+
+#[derive(Debug, Eq, PartialEq, FromRect)]
+#[layout(vertical, margin = 1, flex = Center)]
+struct VerticalAreas {
+    #[length(1)]
+    header: Rect,
+
+    #[fill(1)]
+    body: Rect,
+}
+
+#[derive(Debug, Eq, PartialEq, FromRect)]
+#[layout(vertical, margin = 1, horizontal_margin = 2, vertical_margin = 3)]
+struct AxisMarginAreas {
+    #[fill(1)]
+    main: Rect,
+}
+
+#[derive(Debug, Eq, PartialEq, FromRect)]
+#[layout(horizontal)]
+struct InherentFromAreas {
+    #[fill(1)]
+    main: Rect,
+}
+
+impl InherentFromAreas {
+    const fn from(_area: Rect) -> Self {
+        Self {
+            main: Rect::new(9, 9, 9, 9),
+        }
+    }
+}
+
+#[test]
+fn from_rect_matches_direct_horizontal_layout() {
+    let area = Rect::new(0, 0, 100, 20);
+    let areas = ButtonDemoAreas::from(area);
+    let [gallery, debug] = Layout::horizontal([Constraint::Length(46), Constraint::Min(34)])
+        .spacing(2)
+        .areas(area);
+
+    assert_eq!(areas, ButtonDemoAreas { gallery, debug });
+}
+
+#[test]
+fn from_rect_matches_direct_vertical_layout() {
+    let area = Rect::new(0, 0, 100, 20);
+    let areas = VerticalAreas::from(area);
+    let [header, body] = Layout::vertical([Constraint::Length(1), Constraint::Fill(1)])
+        .margin(1)
+        .flex(Flex::Center)
+        .areas(area);
+
+    assert_eq!(areas, VerticalAreas { header, body });
+}
+
+#[test]
+fn from_rect_matches_direct_layout_with_axis_margins() {
+    let area = Rect::new(0, 0, 100, 20);
+    let areas = AxisMarginAreas::from(area);
+    let [main] = Layout::vertical([Constraint::Fill(1)])
+        .margin(1)
+        .horizontal_margin(2)
+        .vertical_margin(3)
+        .areas(area);
+
+    assert_eq!(areas, AxisMarginAreas { main });
+}
+
+#[test]
+fn inherent_from_can_coexist_with_generated_from_impl() {
+    let area = Rect::new(0, 0, 100, 20);
+    let inherent = InherentFromAreas::from(area);
+    let trait_from = <InherentFromAreas as From<Rect>>::from(area);
+    let into: InherentFromAreas = area.into();
+    let [main] = Layout::horizontal([Constraint::Fill(1)]).areas(area);
+
+    assert_eq!(inherent.main, Rect::new(9, 9, 9, 9));
+    assert_eq!(trait_from, InherentFromAreas { main });
+    assert_eq!(into, InherentFromAreas { main });
+}
+
+#[test]
+fn trybuild_passes() {
+    let test_cases = trybuild::TestCases::new();
+    test_cases.pass("tests/ui/pass/*.rs");
+}
+
+#[test]
+fn trybuild_failures() {
+    let test_cases = trybuild::TestCases::new();
+    test_cases.compile_fail("tests/ui/fail/*.rs");
+}

--- a/crates/ratatui-derive/tests/ui/fail/bad_flex.rs
+++ b/crates/ratatui-derive/tests/ui/fail/bad_flex.rs
@@ -1,0 +1,11 @@
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal, flex = Stretch)]
+struct Areas {
+    #[fill(1)]
+    main: Rect,
+}
+
+fn main() {}

--- a/crates/ratatui-derive/tests/ui/fail/bad_flex.stderr
+++ b/crates/ratatui-derive/tests/ui/fail/bad_flex.stderr
@@ -1,0 +1,5 @@
+error: expected a Flex variant: Start, End, Center, SpaceBetween, SpaceAround, SpaceEvenly, or Legacy
+ --> tests/ui/fail/bad_flex.rs:5:29
+  |
+5 | #[layout(horizontal, flex = Stretch)]
+  |                             ^^^^^^^

--- a/crates/ratatui-derive/tests/ui/fail/bad_ratio.rs
+++ b/crates/ratatui-derive/tests/ui/fail/bad_ratio.rs
@@ -1,0 +1,11 @@
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal)]
+struct Areas {
+    #[ratio(1)]
+    main: Rect,
+}
+
+fn main() {}

--- a/crates/ratatui-derive/tests/ui/fail/bad_ratio.stderr
+++ b/crates/ratatui-derive/tests/ui/fail/bad_ratio.stderr
@@ -1,0 +1,5 @@
+error: expected #[ratio(numerator, denominator)]
+ --> tests/ui/fail/bad_ratio.rs:7:5
+  |
+7 |     #[ratio(1)]
+  |     ^^^^^^^^^^^

--- a/crates/ratatui-derive/tests/ui/fail/duplicate_constraints.rs
+++ b/crates/ratatui-derive/tests/ui/fail/duplicate_constraints.rs
@@ -1,0 +1,12 @@
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal)]
+struct Areas {
+    #[length(1)]
+    #[min(1)]
+    main: Rect,
+}
+
+fn main() {}

--- a/crates/ratatui-derive/tests/ui/fail/duplicate_constraints.stderr
+++ b/crates/ratatui-derive/tests/ui/fail/duplicate_constraints.stderr
@@ -1,0 +1,5 @@
+error: field can only have one layout constraint attribute
+ --> tests/ui/fail/duplicate_constraints.rs:8:5
+  |
+8 |     #[min(1)]
+  |     ^^^^^^^^^

--- a/crates/ratatui-derive/tests/ui/fail/duplicate_directions.rs
+++ b/crates/ratatui-derive/tests/ui/fail/duplicate_directions.rs
@@ -1,0 +1,11 @@
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal, vertical)]
+struct Areas {
+    #[fill(1)]
+    main: Rect,
+}
+
+fn main() {}

--- a/crates/ratatui-derive/tests/ui/fail/duplicate_directions.stderr
+++ b/crates/ratatui-derive/tests/ui/fail/duplicate_directions.stderr
@@ -1,0 +1,5 @@
+error: layout direction can only be specified once
+ --> tests/ui/fail/duplicate_directions.rs:5:22
+  |
+5 | #[layout(horizontal, vertical)]
+  |                      ^^^^^^^^

--- a/crates/ratatui-derive/tests/ui/fail/missing_constraint.rs
+++ b/crates/ratatui-derive/tests/ui/fail/missing_constraint.rs
@@ -1,0 +1,10 @@
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal)]
+struct Areas {
+    main: Rect,
+}
+
+fn main() {}

--- a/crates/ratatui-derive/tests/ui/fail/missing_constraint.stderr
+++ b/crates/ratatui-derive/tests/ui/fail/missing_constraint.stderr
@@ -1,0 +1,5 @@
+error: missing layout constraint attribute: add one of #[length(expr)], #[min(expr)], #[max(expr)], #[percentage(expr)], #[ratio(numerator, denominator)], or #[fill(expr)]
+ --> tests/ui/fail/missing_constraint.rs:7:5
+  |
+7 |     main: Rect,
+  |     ^^^^^^^^^^

--- a/crates/ratatui-derive/tests/ui/fail/missing_direction.rs
+++ b/crates/ratatui-derive/tests/ui/fail/missing_direction.rs
@@ -1,0 +1,10 @@
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+struct Areas {
+    #[fill(1)]
+    main: Rect,
+}
+
+fn main() {}

--- a/crates/ratatui-derive/tests/ui/fail/missing_direction.stderr
+++ b/crates/ratatui-derive/tests/ui/fail/missing_direction.stderr
@@ -1,0 +1,5 @@
+error: missing layout direction: add #[layout(horizontal)] or #[layout(vertical)]
+ --> tests/ui/fail/missing_direction.rs:5:8
+  |
+5 | struct Areas {
+  |        ^^^^^

--- a/crates/ratatui-derive/tests/ui/fail/unsupported_shapes.rs
+++ b/crates/ratatui-derive/tests/ui/fail/unsupported_shapes.rs
@@ -1,0 +1,24 @@
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal)]
+struct Tuple(#[fill(1)] Rect);
+
+#[derive(FromRect)]
+#[layout(horizontal)]
+struct Unit;
+
+#[derive(FromRect)]
+#[layout(horizontal)]
+enum Enum {
+    Area,
+}
+
+#[derive(FromRect)]
+#[layout(horizontal)]
+union Union {
+    area: Rect,
+}
+
+fn main() {}

--- a/crates/ratatui-derive/tests/ui/fail/unsupported_shapes.stderr
+++ b/crates/ratatui-derive/tests/ui/fail/unsupported_shapes.stderr
@@ -1,0 +1,31 @@
+error: Unsupported shape `one unnamed field`. Expected named fields.
+ --> tests/ui/fail/unsupported_shapes.rs:4:10
+  |
+4 | #[derive(FromRect)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `FromRect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Unsupported shape `no fields`. Expected named fields.
+ --> tests/ui/fail/unsupported_shapes.rs:8:10
+  |
+8 | #[derive(FromRect)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `FromRect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Unsupported shape `enum`. Expected struct with named fields.
+  --> tests/ui/fail/unsupported_shapes.rs:12:10
+   |
+12 | #[derive(FromRect)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `FromRect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Unsupported shape `union`. Expected struct with named fields.
+  --> tests/ui/fail/unsupported_shapes.rs:18:10
+   |
+18 | #[derive(FromRect)]
+   |          ^^^^^^^^
+   |
+   = note: this error originates in the derive macro `FromRect` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/ratatui-derive/tests/ui/pass/crate_alias.rs
+++ b/crates/ratatui-derive/tests/ui/pass/crate_alias.rs
@@ -1,0 +1,14 @@
+use ratatui as tui;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal, crate = tui)]
+struct AliasAreas {
+    #[fill(1)]
+    main: tui::layout::Rect,
+}
+
+fn main() {
+    let areas = AliasAreas::from(tui::layout::Rect::new(0, 0, 10, 10));
+    let _ = areas.main;
+}

--- a/crates/ratatui-derive/tests/ui/pass/crate_override.rs
+++ b/crates/ratatui-derive/tests/ui/pass/crate_override.rs
@@ -1,0 +1,17 @@
+use ratatui_core::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(vertical, crate = ratatui_core)]
+struct CoreAreas {
+    #[length(1)]
+    header: Rect,
+
+    #[fill(1)]
+    body: Rect,
+}
+
+fn main() {
+    let areas = CoreAreas::from(Rect::new(0, 0, 10, 10));
+    let _ = (areas.header, areas.body);
+}

--- a/crates/ratatui-derive/tests/ui/pass/default_path.rs
+++ b/crates/ratatui-derive/tests/ui/pass/default_path.rs
@@ -1,0 +1,17 @@
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal, spacing = 2)]
+struct ButtonDemoAreas {
+    #[length(46)]
+    gallery: Rect,
+
+    #[min(34)]
+    debug: Rect,
+}
+
+fn main() {
+    let areas = ButtonDemoAreas::from(Rect::new(0, 0, 100, 20));
+    let _ = (areas.gallery, areas.debug);
+}

--- a/crates/ratatui-derive/tests/ui/pass/expression_values.rs
+++ b/crates/ratatui-derive/tests/ui/pass/expression_values.rs
@@ -1,0 +1,51 @@
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+const WIDTH: u16 = 10;
+const GAP: i32 = 2;
+const NUMERATOR: u32 = 1;
+const DENOMINATOR: u32 = 3;
+
+fn fill_weight() -> u16 {
+    2
+}
+
+#[derive(FromRect)]
+#[layout(
+    horizontal,
+    spacing = GAP,
+    margin = WIDTH / 10,
+    horizontal_margin = WIDTH / 5,
+    vertical_margin = WIDTH / 2
+)]
+struct ExpressionValues {
+    #[length(WIDTH + 1)]
+    length: Rect,
+
+    #[min(WIDTH - 2)]
+    min: Rect,
+
+    #[max(WIDTH + 10)]
+    max: Rect,
+
+    #[percentage(WIDTH * 5)]
+    percentage: Rect,
+
+    #[ratio(NUMERATOR, DENOMINATOR)]
+    ratio: Rect,
+
+    #[fill(fill_weight())]
+    fill: Rect,
+}
+
+fn main() {
+    let areas = ExpressionValues::from(Rect::new(0, 0, 100, 20));
+    let _ = (
+        areas.length,
+        areas.min,
+        areas.max,
+        areas.percentage,
+        areas.ratio,
+        areas.fill,
+    );
+}

--- a/crates/ratatui-derive/tests/ui/pass/flex_variants.rs
+++ b/crates/ratatui-derive/tests/ui/pass/flex_variants.rs
@@ -1,0 +1,74 @@
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal, flex = Start)]
+struct StartAreas {
+    #[length(1)]
+    main: Rect,
+}
+
+#[derive(FromRect)]
+#[layout(horizontal, flex = End)]
+struct EndAreas {
+    #[length(1)]
+    main: Rect,
+}
+
+#[derive(FromRect)]
+#[layout(horizontal, flex = Center)]
+struct CenterAreas {
+    #[length(1)]
+    main: Rect,
+}
+
+#[derive(FromRect)]
+#[layout(horizontal, flex = SpaceBetween)]
+struct SpaceBetweenAreas {
+    #[length(1)]
+    first: Rect,
+
+    #[length(1)]
+    second: Rect,
+}
+
+#[derive(FromRect)]
+#[layout(horizontal, flex = SpaceAround)]
+struct SpaceAroundAreas {
+    #[length(1)]
+    first: Rect,
+
+    #[length(1)]
+    second: Rect,
+}
+
+#[derive(FromRect)]
+#[layout(horizontal, flex = SpaceEvenly)]
+struct SpaceEvenlyAreas {
+    #[length(1)]
+    first: Rect,
+
+    #[length(1)]
+    second: Rect,
+}
+
+#[derive(FromRect)]
+#[layout(horizontal, flex = Legacy)]
+struct LegacyAreas {
+    #[length(1)]
+    main: Rect,
+}
+
+fn main() {
+    let area = Rect::new(0, 0, 10, 10);
+    let _ = StartAreas::from(area).main;
+    let _ = EndAreas::from(area).main;
+    let _ = CenterAreas::from(area).main;
+    let space_between = SpaceBetweenAreas::from(area);
+    let _ = (space_between.first, space_between.second);
+    let space_around = SpaceAroundAreas::from(area);
+    let _ = (space_around.first, space_around.second);
+    let space_evenly = SpaceEvenlyAreas::from(area);
+    let _ = (space_evenly.first, space_evenly.second);
+    let _ = LegacyAreas::from(area).main;
+}

--- a/crates/ratatui-derive/tests/ui/pass/options_and_constraints.rs
+++ b/crates/ratatui-derive/tests/ui/pass/options_and_constraints.rs
@@ -1,0 +1,43 @@
+use ratatui::layout::Rect;
+use ratatui_derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(
+    vertical,
+    margin = 1,
+    horizontal_margin = 2,
+    vertical_margin = 3,
+    flex = SpaceEvenly,
+    spacing = 1
+)]
+struct AllConstraints {
+    #[length(1)]
+    length: Rect,
+
+    #[min(2)]
+    min: Rect,
+
+    #[max(3)]
+    max: Rect,
+
+    #[percentage(25)]
+    percentage: Rect,
+
+    #[ratio(1, 2)]
+    ratio: Rect,
+
+    #[fill(1)]
+    fill: Rect,
+}
+
+fn main() {
+    let areas = AllConstraints::from(Rect::new(0, 0, 100, 20));
+    let _ = (
+        areas.length,
+        areas.min,
+        areas.max,
+        areas.percentage,
+        areas.ratio,
+        areas.fill,
+    );
+}

--- a/crates/ratatui-labs/Cargo.toml
+++ b/crates/ratatui-labs/Cargo.toml
@@ -21,6 +21,7 @@ future_scope = "labs-style experiments and prototype Ratatui work"
 ratatui-core = "0.1.2"
 ratatui-action = { path = "../ratatui-action", version = "0.1.0" }
 ratatui-command-palette = { path = "../ratatui-command-palette", version = "0.1.0" }
+ratatui-derive = { path = "../ratatui-derive", version = "0.1.0-beta.0" }
 ratatui-layout = { path = "../ratatui-layout", version = "0.0.1-alpha.0" }
 
 [lints]

--- a/crates/ratatui-labs/README.md
+++ b/crates/ratatui-labs/README.md
@@ -86,6 +86,35 @@ Documentation for this reservation crate is published at:
 
 - <https://docs.rs/ratatui-labs>
 
+## Derive Macro Experiment
+
+The derive macro experiment lives in `ratatui-derive`. It currently provides
+`FromRect`, a proc macro for named layout-area structs that generates
+`impl From<Rect> for YourStruct`.
+
+The API is experimental and published with a beta version while the name,
+attribute grammar, and generated public contract are evaluated in real
+applications.
+
+```rust
+use ratatui_core::layout::Rect;
+use ratatui_labs::derive::FromRect;
+
+#[derive(FromRect)]
+#[layout(horizontal, spacing = 2, crate = ratatui_core)]
+struct ButtonDemoAreas {
+    #[length(46)]
+    gallery: Rect,
+
+    #[min(34)]
+    debug: Rect,
+}
+
+let area = Rect::new(0, 0, 100, 20);
+let areas = ButtonDemoAreas::from(area);
+assert_eq!(areas.gallery.width, 46);
+```
+
 ## Related Crates And Overlap
 
 This reservation may overlap with:

--- a/crates/ratatui-labs/src/lib.rs
+++ b/crates/ratatui-labs/src/lib.rs
@@ -5,5 +5,7 @@
 pub use ratatui_action as action;
 /// Command palette state, view data, and rendering.
 pub use ratatui_command_palette as command_palette;
+/// Derive macros and code generation helpers.
+pub use ratatui_derive as derive;
 /// Frame-local UI coordination primitives.
 pub use ratatui_layout as layout;


### PR DESCRIPTION
## Summary

- add experimental `ratatui-derive` as a beta-versioned labs crate
- port the `FromRect` derive, docs, README, runtime tests, and trybuild coverage
- expose the crate through the `ratatui-labs` umbrella namespace and document its experimental status

## Validation

- `cargo +nightly fmt --all`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p ratatui-derive --all-targets --all-features`
- `cargo test --workspace --all-targets --all-features`
- `cargo test --workspace --doc --all-features`
- `cargo doc -p ratatui-derive --all-features --no-deps`
- `markdownlint-cli2 README.md AGENTS.md 'crates/**/*.md'`
- `cargo package -p ratatui-derive --allow-dirty`
