### PR TITLE
feat(textwrap): add styled text wrapping experiment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,10 +568,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -580,6 +597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -1143,6 +1161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1300,7 @@ dependencies = [
  "ratatui-core",
  "ratatui-derive",
  "ratatui-layout",
+ "ratatui-textwrap",
 ]
 
 [[package]]
@@ -1317,6 +1345,17 @@ checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
+]
+
+[[package]]
+name = "ratatui-textwrap"
+version = "0.0.1-alpha.0"
+dependencies = [
+ "pretty_assertions",
+ "ratatui",
+ "ratatui-core",
+ "rstest",
+ "textwrap",
 ]
 
 [[package]]
@@ -1376,6 +1415,41 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.118",
+ "unicode-ident",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -1551,6 +1625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "smawk"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +1777,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,6 +1877,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -2125,6 +2226,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ grow into real experiments when there is a concrete design to test.
   APIs.
 - `crates/ratatui-layout` - experimental frame-local UI coordination primitives for visible
   regions, focus targets, pointer targets, cursor requests, and scroll metadata.
+- `crates/ratatui-textwrap` - experimental materialization of wrapped, styled Ratatui text.
 - `crates/ratatui-labs` - umbrella crate for labs-style experiments and prototype Ratatui work.
+
+## Text wrapping
+
+`ratatui-textwrap` precomputes styled `Text` at a requested terminal width. It compares textwrap's
+first-fit and optimal-fit algorithms with an explicit Paragraph-compatible legacy algorithm; the
+[same algorithms are also available at the `Line` level](crates/ratatui-textwrap/README.md#algorithm-choice)
+for custom widgets. The crate README is the canonical usage guide.
 
 ## Examples
 

--- a/crates/ratatui-labs/Cargo.toml
+++ b/crates/ratatui-labs/Cargo.toml
@@ -23,6 +23,7 @@ ratatui-action = { path = "../ratatui-action", version = "0.1.0" }
 ratatui-command-palette = { path = "../ratatui-command-palette", version = "0.1.0" }
 ratatui-derive = { path = "../ratatui-derive", version = "0.1.0-beta.0" }
 ratatui-layout = { path = "../ratatui-layout", version = "0.0.1-alpha.0" }
+ratatui-textwrap = { path = "../ratatui-textwrap", version = "0.0.1-alpha.0" }
 
 [lints]
 workspace = true

--- a/crates/ratatui-labs/README.md
+++ b/crates/ratatui-labs/README.md
@@ -76,6 +76,24 @@ let frame = FrameSnapshot::new(Rect::new(0, 0, 20, 1))
 assert_eq!(frame.route_position((2, 0)).unwrap().id, "save");
 ```
 
+## Text Wrapping Experiment
+
+The `ratatui-textwrap` experiment materializes styled `Span`, `Line`, and `Text` inputs as owned,
+wrapped text. The umbrella crate exposes it as `ratatui_labs::textwrap`; the focused
+[`ratatui-textwrap` README](../ratatui-textwrap/README.md) is the canonical usage guide.
+
+```rust
+use ratatui_core::text::Line;
+use ratatui_labs::textwrap::{TextWrapper, WrapAlgorithm};
+
+let wrapping = TextWrapper::new().algorithm(WrapAlgorithm::OptimalFit);
+let wrapped = wrapping.wrap(Line::from("alpha beta"), 8);
+assert_eq!(wrapped.lines.len(), 2);
+```
+
+Custom widgets can call `textwrap::algorithms::paragraph::wrap_line` or the line-level first-fit and
+optimal-fit functions without constructing a complete `Text`.
+
 The crate points at the main Ratatui project rather than a separate
 implementation repository:
 
@@ -122,6 +140,7 @@ This reservation may overlap with:
 - `ratatui-unstable`, `ratatui-experimental`, and future unstable API policy.
 - the experimental `ratatui-action` and `ratatui-command-palette` crates in this workspace.
 - the experimental `ratatui-layout` crate in this workspace.
+- the experimental `ratatui-textwrap` crate in this workspace.
 
 Any future implementation should coordinate with those crates or clearly explain
 the difference before publishing a non-reservation release.

--- a/crates/ratatui-labs/src/lib.rs
+++ b/crates/ratatui-labs/src/lib.rs
@@ -9,3 +9,5 @@ pub use ratatui_command_palette as command_palette;
 pub use ratatui_derive as derive;
 /// Frame-local UI coordination primitives.
 pub use ratatui_layout as layout;
+/// Owned styled-text wrapping.
+pub use ratatui_textwrap as textwrap;

--- a/crates/ratatui-textwrap/Cargo.toml
+++ b/crates/ratatui-textwrap/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ratatui-textwrap"
+version = "0.0.1-alpha.0"
+publish = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Experimental owned wrapping for styled Ratatui text."
+readme = "README.md"
+include = ["Cargo.toml", "README.md", "src/**/*.rs"]
+
+[dependencies]
+# Keep this aligned with the umbrella crate so the workspace's direct-minimal dependency check can
+# resolve one `ratatui-core` version.
+ratatui-core = "0.1.2"
+textwrap = { version = "0.16", default-features = false, features = ["smawk"] }
+
+[dev-dependencies]
+pretty_assertions = "1"
+ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
+rstest = "0.26"
+
+[lints]
+workspace = true

--- a/crates/ratatui-textwrap/README.md
+++ b/crates/ratatui-textwrap/README.md
@@ -1,0 +1,95 @@
+# Ratatui Textwrap
+
+`ratatui-textwrap` precomputes wrapped, styled Ratatui text. It accepts strings, spans, lines, and
+other values that convert into `Text`, then returns an owned `Text<'static>` that can be cached or
+passed to another widget.
+
+## Usage
+
+```rust
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::widgets::Paragraph;
+use ratatui_textwrap::{TextWrapper, WrapAlgorithm};
+
+let line = Line::from(vec!["Styled ".blue(), "text can wrap across spans".bold()]);
+let wrapping = TextWrapper::new().algorithm(WrapAlgorithm::OptimalFit);
+let wrapped = wrapping.wrap(line, 20);
+let paragraph = Paragraph::new(wrapped);
+```
+
+Wrapping allocates the owned `wrapped` value. Keep it while the source, algorithm, and width remain
+unchanged. Width is supplied to each call, so one `TextWrapper` configuration can serve a resizable
+view.
+
+## Algorithm choice
+
+| Algorithm         | Behavior                                                       | Use when                                                    |
+| ----------------- | -------------------------------------------------------------- | ----------------------------------------------------------- |
+| `FirstFit`        | Greedily fills lines; this is the default.                     | Predictable textwrap behavior is sufficient.                |
+| `OptimalFit`      | Scores every break point with textwrap's default penalties.    | Line balance matters more than greedy placement.            |
+| `ParagraphCompat` | Runs a copy of Ratatui Paragraph's reflow algorithm.           | Ratatui 0.30.2 behavior must be reproduced.                 |
+
+First-fit and optimal-fit model each word together with its following whitespace, following
+textwrap's [fragment contract]. A source `Span` boundary does not create a break inside a word.
+Overlong words are split at Ratatui grapheme boundaries before textwrap chooses lines. Separator
+whitespace after the final fragment on a generated line is omitted.
+
+`ParagraphCompat` also accepts Paragraph's `trim` policy:
+
+```rust
+use ratatui_textwrap::{TextWrapper, WrapAlgorithm};
+
+let wrapping = TextWrapper::new()
+    .algorithm(WrapAlgorithm::ParagraphCompat { trim: true });
+let wrapped = wrapping.wrap("alpha beta", 8);
+```
+
+Custom widgets can use the same implementations one line at a time:
+
+```rust
+use ratatui::text::Line;
+use ratatui_textwrap::algorithms::paragraph;
+
+let source = Line::from("alpha beta");
+let wrapped = paragraph::wrap_line(&source, 8, true);
+```
+
+The `algorithms::paragraph` module exposes the copied compatibility behavior;
+`algorithms::textwrap` exposes first-fit and optimal-fit. These functions return owned lines but do
+not retain state between calls. Use `TextWrapper` when wrapping a complete `Text` so its top-level
+style and alignment are carried into the result.
+
+The copied implementation uses Ratatui 0.30.2 as its source baseline. Compatibility tests render it
+against the compatible Ratatui release selected for development. The same tests record where
+first-fit differs from Paragraph and where optimal-fit differs from first-fit. Current Paragraph
+differences center on leading, trailing, repeated, whitespace-only, and styled whitespace.
+
+## Text behavior
+
+Each entry in `Text::lines` is an independent wrapping boundary. Generated lines preserve the
+source text, line, and span styles and alignment. Adjacent output spans with equal styles may be
+coalesced, so callers should rely on rendered cells rather than the original span partition.
+
+A width of zero returns no lines while retaining top-level text style and alignment. Control
+characters embedded directly in a manually constructed `Span` are filtered by Ratatui's
+styled-grapheme iterator; use separate `Line` values for hard boundaries.
+
+First-fit and optimal-fit preserve a grapheme wider than the requested width as an indivisible,
+overflowing line. `ParagraphCompat` omits that grapheme, matching Paragraph's historical behavior.
+
+## Scope
+
+`ratatui-textwrap` is an experiment, and its API may change while the configuration and
+compatibility surface are evaluated. It does not replace `Paragraph::wrap`, expose textwrap types,
+or provide stateful incremental wrapping, lazy layout, source-position mapping, cursor mapping,
+indentation, hyphenation, or custom optimal-fit penalties.
+
+The implementation follows textwrap's [fragment contract], [first-fit source], and [optimal-fit
+source]. `ParagraphCompat` follows Ratatui's [WordWrapper source] and [Paragraph integration].
+
+[first-fit source]: https://github.com/mgeisler/textwrap/blob/4770e55af425a0cffb9ad8496599d2a1a4f5ed14/src/wrap_algorithms.rs#L336-L367
+[fragment contract]: https://docs.rs/textwrap/0.16/textwrap/core/trait.Fragment.html
+[optimal-fit source]: https://github.com/mgeisler/textwrap/blob/4770e55af425a0cffb9ad8496599d2a1a4f5ed14/src/wrap_algorithms/optimal_fit.rs#L302-L381
+[Paragraph integration]: https://github.com/ratatui/ratatui/blob/ratatui-v0.30.2/ratatui-widgets/src/paragraph.rs#L329-L355
+[WordWrapper source]: https://github.com/ratatui/ratatui/blob/ratatui-v0.30.2/ratatui-widgets/src/reflow.rs#L29-L273

--- a/crates/ratatui-textwrap/src/algorithms.rs
+++ b/crates/ratatui-textwrap/src/algorithms.rs
@@ -1,0 +1,127 @@
+//! Wraps individual styled lines with the crate's line-breaking algorithms.
+//!
+//! [`WrapAlgorithm`] is the public choice stored by [`TextWrapper`](crate::TextWrapper).
+//! `wrap_line` applies that choice to one source line. First-fit and optimal-fit share the same
+//! styled fragments; Paragraph compatibility uses a separate grapheme-stream state machine.
+//!
+//! # Entry points
+//!
+//! - [`crate::algorithms::wrap_line`] dispatches a [`WrapAlgorithm`] selected at runtime.
+//! - [`crate::algorithms::paragraph::wrap_line`] reproduces Paragraph's historical wrapping
+//!   behavior.
+//! - [`crate::algorithms::textwrap::wrap_first_fit`] and
+//!   [`crate::algorithms::textwrap::wrap_optimal_fit`] invoke one textwrap-backed algorithm
+//!   directly.
+//!
+//! These functions suit custom widgets and processing pipelines that already divide input into
+//! independent line boundaries. Calls do not share wrapping state. All entry points allocate owned
+//! span strings and return lines that can outlive `source`; use [`crate::TextWrapper`] when
+//! top-level [`Text`](ratatui_core::text::Text) metadata must also be preserved.
+//!
+//! # Example
+//!
+//! ```
+//! use ratatui::text::Line;
+//! use ratatui_textwrap::algorithms::paragraph;
+//!
+//! let source = Line::from("alpha beta");
+//! let wrapped = paragraph::wrap_line(&source, 8, true);
+//!
+//! assert_eq!(wrapped[0].to_string(), "alpha");
+//! assert_eq!(wrapped[1].to_string(), "beta");
+//! ```
+//!
+//! textwrap's [line-breaking overview] describes the generic first-fit and optimal-fit algorithms.
+//! Ratatui supplies the grapheme segmentation, whitespace classification, and terminal-cell widths
+//! used by this adapter.
+//!
+//! [line-breaking overview]: https://docs.rs/textwrap/0.16/textwrap/wrap_algorithms/index.html
+
+use ratatui_core::text::Line;
+
+/// Styled word fragments consumed by textwrap.
+mod fragment;
+/// Ratatui Paragraph's copied legacy line-wrapping algorithm.
+pub mod paragraph;
+/// Owned styled runs shared by line-breaking strategies.
+mod piece;
+/// Integration with textwrap's low-level line-breaking algorithms.
+pub mod textwrap;
+
+/// Chooses the line-breaking behavior used by [`TextWrapper`](crate::TextWrapper).
+///
+/// [`Self::FirstFit`] and [`Self::OptimalFit`] use textwrap with Ratatui graphemes and cell widths.
+/// They split overlong words at grapheme boundaries and omit separator whitespace at the end of a
+/// generated line. An indivisible grapheme wider than the requested width remains on an
+/// overflowing line. [`Self::ParagraphCompat`] preserves Ratatui Paragraph's different streaming
+/// behavior, including omitting such a grapheme.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum WrapAlgorithm {
+    /// Fills each line greedily with the next fragment that fits.
+    ///
+    /// This is the default strategy. See [`crate::algorithms::textwrap::wrap_first_fit`] for its
+    /// line-level contract.
+    #[default]
+    FirstFit,
+
+    /// Scores every break point in a source line and chooses the lowest-cost layout.
+    ///
+    /// This can prefer a small overflow to a poorly balanced break. See
+    /// [`crate::algorithms::textwrap::wrap_optimal_fit`] for its cost and fallback contract.
+    OptimalFit,
+
+    /// Reproduces Ratatui 0.30.2 Paragraph word reflow.
+    ///
+    /// This uses the maintained compatibility implementation documented by
+    /// [`crate::algorithms::paragraph::wrap_line`], rather than textwrap.
+    ParagraphCompat {
+        /// Controls leading separator whitespace on continuation lines.
+        ///
+        /// `true` discards it and `false` preserves it, matching
+        /// `ratatui::widgets::Wrap::trim`.
+        trim: bool,
+    },
+}
+
+/// Wraps one source line with `algorithm`.
+///
+/// Every returned line copies `source` style and alignment and owns its span strings. A positive
+/// width produces at least one output line, including for an empty source line. A zero width
+/// produces no lines, matching [`TextWrapper::wrap`](crate::TextWrapper::wrap).
+///
+/// This function allocates temporary wrapping state and the returned line and span collections.
+/// Calls are independent and do not continue a partially wrapped source line from an earlier call.
+#[must_use]
+pub fn wrap_line(algorithm: WrapAlgorithm, source: &Line<'_>, width: u16) -> Vec<Line<'static>> {
+    match algorithm {
+        WrapAlgorithm::FirstFit => textwrap::wrap_first_fit(source, width),
+        WrapAlgorithm::OptimalFit => textwrap::wrap_optimal_fit(source, width),
+        WrapAlgorithm::ParagraphCompat { trim } => paragraph::wrap_line(source, width, trim),
+    }
+}
+
+/// Unit tests for strategy dispatch.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Checks that each public variant reaches its corresponding implementation.
+    #[test]
+    fn variants_dispatch_to_their_implementation() {
+        let source = Line::from("alpha  beta gamma");
+
+        assert_eq!(
+            wrap_line(WrapAlgorithm::FirstFit, &source, 8),
+            textwrap::wrap_first_fit(&source, 8)
+        );
+        assert_eq!(
+            wrap_line(WrapAlgorithm::OptimalFit, &source, 8),
+            textwrap::wrap_optimal_fit(&source, 8)
+        );
+        assert_eq!(
+            wrap_line(WrapAlgorithm::ParagraphCompat { trim: true }, &source, 8),
+            paragraph::wrap_line(&source, 8, true)
+        );
+    }
+}

--- a/crates/ratatui-textwrap/src/algorithms/fragment.rs
+++ b/crates/ratatui-textwrap/src/algorithms/fragment.rs
@@ -1,0 +1,214 @@
+//! Styled implementation of textwrap's fragment contract.
+//!
+//! `StyledFragment` stores one word and its following whitespace as separate styled runs. The
+//! separation lets textwrap count whitespace between words without rendering it at the end of a
+//! generated line. Words may cross source span boundaries, so a style change does not introduce a
+//! break point.
+//!
+//! `from_line` groups Ratatui graphemes into fragments and splits words wider than the requested
+//! width. A single grapheme wider than that width remains an indivisible overflowing fragment. The
+//! line-breaking algorithms can then treat every fragment as atomic. Reconstruction reads the word
+//! and whitespace portions separately to preserve their source styles.
+//!
+//! Ratatui remains authoritative for grapheme segmentation, whitespace classification, and cell
+//! width. The upstream [fragment documentation] and [source] define the low-level textwrap
+//! contract.
+//!
+//! [fragment documentation]: https://docs.rs/textwrap/0.16/textwrap/core/trait.Fragment.html
+//! [source]: https://github.com/mgeisler/textwrap/blob/4770e55af425a0cffb9ad8496599d2a1a4f5ed14/src/core.rs#L217-L230
+
+use ratatui_core::style::Style;
+use ratatui_core::text::{Line, Span};
+use textwrap::core::Fragment;
+
+use super::piece::{self, StyledPiece};
+
+/// Stores a styled word and its following whitespace as one textwrap fragment.
+///
+/// textwrap's [`Fragment`] contract measures trailing whitespace only when another fragment fits
+/// on the same output line. Separate styled collections preserve the source styles while exposing
+/// that measurement model. One word may contain pieces from several source spans.
+#[derive(Debug, Default, Clone)]
+pub struct StyledFragment {
+    /// Word content that remains indivisible after overlong-word splitting.
+    word: Vec<StyledPiece>,
+
+    /// Whitespace immediately following [`Self::word`] in the source line.
+    whitespace: Vec<StyledPiece>,
+
+    /// Sum of word widths exposed through [`Fragment::width`].
+    ///
+    /// The cached sum avoids rescanning owned strings during line-breaking passes.
+    word_width: u32,
+
+    /// Sum of whitespace widths exposed through [`Fragment::whitespace_width`].
+    ///
+    /// A separate sum is necessary because textwrap excludes it when the fragment ends a line.
+    whitespace_width: u32,
+}
+
+/// Builds width-bounded textwrap fragments from one Ratatui line.
+///
+/// Segmentation crosses source span boundaries so differently styled pieces of one lexical word
+/// remain one wrapping unit. `piece::collect_graphemes` filters control characters and measures
+/// cell widths. Overlong words are split before reaching textwrap, but a grapheme wider than
+/// `width` remains whole and may produce an overflowing line. `width` is positive because
+/// [`crate::TextWrapper`] handles zero before dispatching source lines.
+pub fn from_line(line: &Line<'_>, width: u16) -> Vec<StyledFragment> {
+    let mut fragments = Vec::new();
+    let mut current = StyledFragment::default();
+
+    for piece in piece::collect_graphemes(line) {
+        if piece.whitespace {
+            current.push_whitespace(piece);
+            continue;
+        }
+        if !current.whitespace.is_empty() {
+            fragments.push(current);
+            current = StyledFragment::default();
+        }
+        current.push_word(piece);
+    }
+    if current.has_word() || !current.whitespace.is_empty() {
+        fragments.push(current);
+    }
+
+    fragments
+        .into_iter()
+        .flat_map(|fragment| fragment.split_word(width))
+        .collect()
+}
+
+impl StyledFragment {
+    /// Splits this fragment's word at Ratatui grapheme boundaries when it exceeds `width`.
+    ///
+    /// textwrap's algorithms do not divide a [`Fragment`], so words must be bounded first. Only
+    /// the final fragment inherits the source fragment's trailing whitespace; assigning it to an
+    /// earlier fragment would create a false separator inside the original word. Zero-width
+    /// graphemes remain with the current fragment to avoid producing empty fragments. `width` is
+    /// positive because zero-width text is handled before fragment construction.
+    pub fn split_word(self, width: u16) -> Vec<Self> {
+        if self.word_width <= u32::from(width) {
+            return vec![self];
+        }
+
+        let mut split = Vec::new();
+        let mut current = Self::default();
+        for piece in self.word {
+            let span = Span::styled(piece.content, piece.style);
+            let graphemes = span.styled_graphemes(Style::new());
+            for grapheme in graphemes {
+                let piece =
+                    StyledPiece::new(grapheme.symbol, grapheme.style, grapheme.is_whitespace());
+                let would_overflow = current.word_width + piece.width > u32::from(width);
+                if piece.width > 0 && current.has_word() && would_overflow {
+                    split.push(current);
+                    current = Self::default();
+                }
+                current.push_word(piece);
+            }
+        }
+        current.whitespace = self.whitespace;
+        current.whitespace_width = self.whitespace_width;
+        split.push(current);
+        split
+    }
+
+    /// Appends the word portion to an output span list, coalescing equal adjacent styles.
+    pub fn append_word_to(&self, spans: &mut Vec<Span<'static>>) {
+        piece::append(spans, &self.word);
+    }
+
+    /// Appends trailing whitespace when reconstruction decides that it remains visible.
+    pub fn append_whitespace_to(&self, spans: &mut Vec<Span<'static>>) {
+        piece::append(spans, &self.whitespace);
+    }
+
+    /// Adds word content and updates its cached width.
+    fn push_word(&mut self, piece: StyledPiece) {
+        self.word_width += piece.width;
+        piece::push(&mut self.word, piece);
+    }
+
+    /// Adds following whitespace and updates its cached width.
+    fn push_whitespace(&mut self, piece: StyledPiece) {
+        self.whitespace_width += piece.width;
+        piece::push(&mut self.whitespace, piece);
+    }
+
+    /// Returns whether the fragment contains word content.
+    ///
+    /// Leading whitespace remains a whitespace-only fragment because it participates in overflow
+    /// behavior even though no word precedes it.
+    const fn has_word(&self) -> bool {
+        !self.word.is_empty()
+    }
+}
+
+impl Fragment for StyledFragment {
+    /// Returns the word width used by textwrap's line-breaking algorithms.
+    ///
+    /// textwrap expresses widths as `f64`; the stored value remains an integer terminal-cell count
+    /// until this trait boundary.
+    fn width(&self) -> f64 {
+        f64::from(self.word_width)
+    }
+
+    /// Returns the following whitespace width included only between same-line fragments.
+    fn whitespace_width(&self) -> f64 {
+        f64::from(self.whitespace_width)
+    }
+
+    /// Returns zero because this adapter inserts neither hyphens nor replacement glyphs.
+    fn penalty_width(&self) -> f64 {
+        0.0
+    }
+}
+
+/// Unit tests for styled fragment construction.
+#[cfg(test)]
+mod tests {
+    use ratatui_core::style::{Color, Style};
+
+    use super::*;
+
+    /// Checks that style changes inside a word do not introduce break points.
+    #[test]
+    fn style_boundaries_remain_inside_one_word_fragment() {
+        let line = Line::from(vec![
+            Span::styled("al", Style::new().fg(Color::Red)),
+            Span::styled("pha", Style::new().fg(Color::Blue)),
+            Span::raw(" beta"),
+        ]);
+
+        let fragments = from_line(&line, 20);
+
+        assert_eq!(fragments.len(), 2);
+        assert_eq!(fragments[0].word_width, 5);
+        assert_eq!(fragments[0].word.len(), 2);
+        assert_eq!(fragments[0].whitespace_width, 1);
+    }
+
+    /// Checks that only the final slice of an overlong word keeps following whitespace.
+    #[test]
+    fn overlong_word_keeps_whitespace_on_its_final_fragment() {
+        let fragments = from_line(&Line::from("abcdef  "), 3);
+
+        assert_eq!(fragments.len(), 2);
+        assert_eq!(fragments[0].word_width, 3);
+        assert_eq!(fragments[0].whitespace_width, 0);
+        assert_eq!(fragments[1].word_width, 3);
+        assert_eq!(fragments[1].whitespace_width, 2);
+    }
+
+    /// Checks that an indivisible grapheme becomes one overflowing fragment instead of
+    /// disappearing.
+    #[test]
+    fn grapheme_wider_than_line_remains_an_overflowing_fragment() {
+        let fragments = from_line(&Line::from("界"), 1);
+
+        assert_eq!(fragments.len(), 1);
+        assert_eq!(fragments[0].word_width, 2);
+        assert_eq!(fragments[0].word[0].content, "界");
+    }
+}

--- a/crates/ratatui-textwrap/src/algorithms/paragraph.rs
+++ b/crates/ratatui-textwrap/src/algorithms/paragraph.rs
@@ -1,0 +1,182 @@
+//! Preserves Ratatui Paragraph's historical word-reflow behavior for one styled line.
+//!
+//! textwrap's fragment model assigns whitespace to the preceding word and assumes an atomic
+//! fragment has one fixed width. Paragraph instead processes graphemes as a stream. Its observable
+//! behavior can consume one whitespace grapheme at a wrap boundary, carry excess whitespace to the
+//! next line, and admit a multi-cell grapheme after the pending word has crossed the limit. Those
+//! cases affect line count, styles, and rendered cells.
+//!
+//! [`wrap_line`] is the public line-level compatibility entry point. It maintains Paragraph's
+//! pending line, word, and whitespace queues over the uncoalesced styled-grapheme stream. The
+//! output uses the same owned pieces as the textwrap path, but no textwrap fragment or
+//! line-breaking API participates. Prefer [`crate::TextWrapper`] when the input is a complete
+//! [`Text`](ratatui_core::text::Text) and its top-level metadata must also be preserved.
+//!
+//! The state machine is maintained against Ratatui 0.30.2's [`WordWrapper` implementation]. The
+//! surrounding [`Paragraph integration`] shows how the widget constructs and consumes that wrapper;
+//! compatibility tests render both paths and compare buffers and line counts.
+//!
+//! [`Paragraph integration`]: https://github.com/ratatui/ratatui/blob/ratatui-v0.30.2/ratatui-widgets/src/paragraph.rs#L329-L355
+//! [`WordWrapper` implementation]: https://github.com/ratatui/ratatui/blob/ratatui-v0.30.2/ratatui-widgets/src/reflow.rs#L29-L273
+
+use std::collections::VecDeque;
+use std::mem;
+
+use ratatui_core::text::Line;
+
+use super::piece::{self, StyledPiece};
+
+/// Wraps one source line with Paragraph's pending-word and pending-whitespace rules.
+///
+/// The copied behavior includes consuming one separator grapheme when whitespace crosses a
+/// boundary. `pending_line` contains committed pieces; `pending_word` and `pending_whitespace`
+/// remain movable until the next grapheme determines whether they fit. Every returned line copies
+/// `source` style and alignment and owns its span strings. A positive width produces at least one
+/// line; a zero width produces no lines.
+///
+/// Graphemes containing controls and graphemes wider than `width` are omitted to reproduce
+/// Paragraph's rendered behavior. The function allocates its pending queues and returned lines.
+/// Calls are independent and do not preserve wrapping state between source chunks.
+///
+/// When `trim` is `true`, leading separator whitespace is discarded on continuation lines. When it
+/// is `false`, that whitespace is preserved, matching `ratatui::widgets::Wrap::trim`.
+#[must_use]
+pub fn wrap_line(source: &Line<'_>, width: u16, trim: bool) -> Vec<Line<'static>> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    let mut output = VecDeque::new();
+    let mut pending_line = Vec::new();
+    let mut pending_word = Vec::new();
+    let mut pending_whitespace: VecDeque<StyledPiece> = VecDeque::new();
+    let mut line_width = 0_u32;
+    let mut word_width = 0_u32;
+    let mut whitespace_width = 0_u32;
+    let mut has_pending_word = false;
+
+    for piece in piece::collect_graphemes(source) {
+        // Paragraph's WordWrapper silently skips a grapheme that cannot fit in an empty line. Keep
+        // that compatibility policy here rather than deleting content during shared conversion.
+        if piece.width > u32::from(width) {
+            continue;
+        }
+
+        let piece_width = piece.width;
+        let word_ended = has_pending_word && piece.whitespace;
+        let trimmed_overflow =
+            pending_line.is_empty() && trim && word_width + piece_width > u32::from(width);
+        let whitespace_overflow =
+            pending_line.is_empty() && trim && whitespace_width + piece_width > u32::from(width);
+        let untrimmed_overflow = pending_line.is_empty()
+            && !trim
+            && word_width + whitespace_width + piece_width > u32::from(width);
+
+        if word_ended || trimmed_overflow || whitespace_overflow || untrimmed_overflow {
+            if !pending_line.is_empty() || !trim {
+                pending_line.extend(pending_whitespace.drain(..));
+                line_width += whitespace_width;
+            }
+            pending_line.append(&mut pending_word);
+            line_width += word_width;
+            pending_whitespace.clear();
+            whitespace_width = 0;
+            word_width = 0;
+        }
+
+        let line_full = line_width >= u32::from(width);
+        let pending_word_overflow =
+            piece_width > 0 && line_width + whitespace_width + word_width >= u32::from(width);
+        if line_full || pending_word_overflow {
+            let mut remaining = u32::from(width).saturating_sub(line_width);
+            output.push_back(mem::take(&mut pending_line));
+            line_width = 0;
+
+            while let Some(front) = pending_whitespace.front() {
+                if front.width > remaining {
+                    break;
+                }
+                whitespace_width -= front.width;
+                remaining -= front.width;
+                pending_whitespace.pop_front();
+            }
+            if piece.whitespace && pending_whitespace.is_empty() {
+                continue;
+            }
+        }
+
+        if piece.whitespace {
+            whitespace_width += piece_width;
+            pending_whitespace.push_back(piece);
+        } else {
+            word_width += piece_width;
+            pending_word.push(piece);
+        }
+        has_pending_word = !pending_word.is_empty();
+    }
+
+    if pending_line.is_empty() && pending_word.is_empty() && !pending_whitespace.is_empty() && trim
+    {
+        output.push_back(Vec::new());
+    }
+    if !pending_line.is_empty() || !trim {
+        pending_line.extend(pending_whitespace);
+    }
+    pending_line.append(&mut pending_word);
+    if !pending_line.is_empty() {
+        output.push_back(pending_line);
+    }
+    if output.is_empty() {
+        output.push_back(Vec::new());
+    }
+
+    output
+        .into_iter()
+        .map(|pieces| piece::line_from(source, &pieces))
+        .collect()
+}
+
+/// Unit tests for the copied Paragraph state machine.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Checks Paragraph's distinct whitespace-only behavior for both trim policies.
+    #[test]
+    fn whitespace_only_line_follows_trim_policy() {
+        let source = Line::from("   ");
+
+        let preserved = wrap_line(&source, 2, false);
+        let trimmed = wrap_line(&source, 2, true);
+
+        assert_eq!(
+            preserved
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            ["  "]
+        );
+        assert_eq!(
+            trimmed.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            [""]
+        );
+    }
+
+    /// Checks the mixed-width overflow behavior retained from Paragraph.
+    #[test]
+    fn mixed_width_word_keeps_paragraph_overflow_behavior() {
+        let lines = wrap_line(&Line::from("a界b"), 2, false);
+        let content = lines.iter().map(ToString::to_string).collect::<Vec<_>>();
+
+        assert_eq!(content, ["a", "界b"]);
+    }
+
+    /// Checks Paragraph's policy of omitting a grapheme wider than an otherwise empty line.
+    #[test]
+    fn grapheme_wider_than_line_is_omitted() {
+        let lines = wrap_line(&Line::from("界"), 1, false);
+
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].to_string(), "");
+    }
+}

--- a/crates/ratatui-textwrap/src/algorithms/piece.rs
+++ b/crates/ratatui-textwrap/src/algorithms/piece.rs
@@ -1,0 +1,168 @@
+//! Conversion between Ratatui graphemes and owned styled runs.
+//!
+//! `StyledPiece` is the owned unit shared by both wrapping implementations. A piece records text,
+//! source span style, Ratatui cell width, and Ratatui whitespace classification. It does not apply
+//! the containing line or text style; those remain on the reconstructed [`Line`].
+//!
+//! `collect_graphemes` creates one piece per styled grapheme without applying a wrapping policy.
+//! The textwrap path coalesces pieces after assigning them to a word or whitespace, while Paragraph
+//! compatibility keeps the stream at grapheme granularity. `append` coalesces equal adjacent styles
+//! when it creates output spans.
+//!
+//! Ratatui's [`StyledGrapheme`] and [`CellWidth`] APIs define the classification and measurement
+//! semantics retained here. The tagged [`Ratatui text source`] shows the implementation used by the
+//! 0.30.2 source baseline.
+//!
+//! [`CellWidth`]: ratatui_core::buffer::CellWidth
+//! [`Ratatui text source`]: https://github.com/ratatui/ratatui/blob/ratatui-v0.30.2/ratatui-core/src/text.rs
+//! [`StyledGrapheme`]: ratatui_core::text::StyledGrapheme
+
+use ratatui_core::buffer::CellWidth;
+use ratatui_core::style::Style;
+use ratatui_core::text::{Line, Span};
+
+/// Stores an owned, uniformly styled run with one word-or-whitespace role.
+///
+/// A piece begins as one Ratatui [`StyledGrapheme`](ratatui_core::text::StyledGrapheme), then may
+/// absorb adjacent graphemes with the same style and classification. The intermediate form avoids
+/// one output [`Span`] allocation per grapheme while retaining every boundary that affects layout
+/// or rendering.
+#[derive(Debug, Clone)]
+pub struct StyledPiece {
+    /// Owned grapheme content used to build the final `Text<'static>`.
+    ///
+    /// Ownership removes any output lifetime dependency on the source text.
+    pub content: String,
+
+    /// The source span style before text and line styles are applied.
+    ///
+    /// Keeping the unpatched style prevents reset colors and modifiers from being applied twice
+    /// when the output line restores its original metadata.
+    pub style: Style,
+
+    /// Cached terminal-cell width calculated with Ratatui's [`CellWidth`].
+    ///
+    /// The cache keeps layout independent of textwrap's optional Unicode-width feature and makes
+    /// Ratatui's terminal-specific width corrections authoritative.
+    pub width: u32,
+
+    /// Ratatui's word-separation classification for every grapheme in [`Self::content`].
+    ///
+    /// Ratatui treats a zero-width space as whitespace and a non-breaking space as word content,
+    /// which differs from recomputing the value with `char::is_whitespace`.
+    pub whitespace: bool,
+}
+
+impl StyledPiece {
+    /// Copies one classified content run and records its Ratatui cell width.
+    ///
+    /// `whitespace` comes from `StyledGrapheme::is_whitespace`, keeping segmentation aligned with
+    /// Ratatui's treatment of non-breaking and zero-width spaces.
+    pub fn new(content: &str, style: Style, whitespace: bool) -> Self {
+        Self {
+            content: content.to_owned(),
+            style,
+            width: u32::from(content.cell_width()),
+            whitespace,
+        }
+    }
+}
+
+/// Collects one owned piece for each Ratatui grapheme in `line`.
+///
+/// `Line::styled_graphemes` filters graphemes containing control characters. Every remaining
+/// grapheme is retained regardless of width so each wrapping algorithm can apply its own overflow
+/// policy. Keeping one piece per grapheme lets Paragraph compatibility make its width and
+/// whitespace decisions as a stream; word fragments coalesce pieces later.
+pub fn collect_graphemes(line: &Line<'_>) -> Vec<StyledPiece> {
+    line.spans
+        .iter()
+        .flat_map(|span| span.styled_graphemes(Style::new()))
+        .map(|grapheme| StyledPiece::new(grapheme.symbol, grapheme.style, grapheme.is_whitespace()))
+        .collect()
+}
+
+/// Builds an owned line from `pieces` and copies the source line metadata.
+///
+/// Keeping style and alignment on the [`Line`] preserves Ratatui's text-to-line-to-span style
+/// patch order and makes every physical line generated from one source line align identically.
+pub fn line_from(source: &Line<'_>, pieces: &[StyledPiece]) -> Line<'static> {
+    let mut spans = Vec::new();
+    append(&mut spans, pieces);
+    Line {
+        style: source.style,
+        alignment: source.alignment,
+        spans,
+    }
+}
+
+/// Adds `piece`, coalescing it with an adjacent piece of the same style and role.
+///
+/// Requiring the same whitespace role prevents coalescing from erasing the semantic boundary
+/// between a word and its following separator.
+pub fn push(pieces: &mut Vec<StyledPiece>, piece: StyledPiece) {
+    if let Some(last) = pieces.last_mut()
+        && last.style == piece.style
+        && last.whitespace == piece.whitespace
+    {
+        last.content.push_str(&piece.content);
+        last.width += piece.width;
+    } else {
+        pieces.push(piece);
+    }
+}
+
+/// Appends owned spans and coalesces equal adjacent source styles.
+///
+/// Reconstruction no longer needs the word-or-whitespace classification, so equal styles may
+/// cross that boundary. Rendered cells are unchanged and the output avoids redundant spans.
+pub fn append(spans: &mut Vec<Span<'static>>, pieces: &[StyledPiece]) {
+    for piece in pieces {
+        if let Some(last) = spans.last_mut()
+            && last.style == piece.style
+        {
+            last.content.to_mut().push_str(&piece.content);
+        } else {
+            spans.push(Span::styled(piece.content.clone(), piece.style));
+        }
+    }
+}
+
+/// Unit tests for grapheme conversion and run coalescing.
+#[cfg(test)]
+mod tests {
+    use ratatui_core::style::Color;
+
+    use super::*;
+
+    /// Checks Ratatui whitespace classification without applying an area-width policy.
+    #[test]
+    fn collection_keeps_ratatui_classification_and_wide_graphemes() {
+        let pieces = collect_graphemes(&Line::from("\u{200b}\u{a0}界"));
+
+        assert_eq!(pieces.len(), 3);
+        assert_eq!(pieces[0].content, "\u{200b}");
+        assert!(pieces[0].whitespace);
+        assert_eq!(pieces[1].content, "\u{a0}");
+        assert!(!pieces[1].whitespace);
+        assert_eq!(pieces[2].content, "界");
+        assert_eq!(pieces[2].width, 2);
+    }
+
+    /// Checks that semantic roles constrain piece coalescing but not final span coalescing.
+    #[test]
+    fn coalescing_keeps_piece_roles_and_merges_final_styles() {
+        let style = Style::new().fg(Color::Green);
+        let mut pieces = Vec::new();
+        push(&mut pieces, StyledPiece::new("a", style, false));
+        push(&mut pieces, StyledPiece::new("b", style, false));
+        push(&mut pieces, StyledPiece::new(" ", style, true));
+
+        assert_eq!(pieces.len(), 2);
+        assert_eq!(pieces[0].content, "ab");
+
+        let mut spans = Vec::new();
+        append(&mut spans, &pieces);
+        assert_eq!(spans, [Span::styled("ab ", style)]);
+    }
+}

--- a/crates/ratatui-textwrap/src/algorithms/textwrap.rs
+++ b/crates/ratatui-textwrap/src/algorithms/textwrap.rs
@@ -1,0 +1,146 @@
+//! Runs textwrap's line-breaking algorithms on one styled Ratatui line.
+//!
+//! [`crate::algorithms::textwrap::wrap_first_fit`] and
+//! [`crate::algorithms::textwrap::wrap_optimal_fit`] are public line-level entry points. They
+//! receive a Ratatui line, prepare fragments whose widths and break points come from Ratatui
+//! graphemes, and rebuild the selected slices as owned lines. Prefer [`crate::TextWrapper`] when
+//! the input is a complete [`Text`](ratatui_core::text::Text) and its top-level metadata must also
+//! be preserved. Reconstruction keeps whitespace between fragments on the same line and drops
+//! whitespace after the final fragment, as required by textwrap's [`Fragment`] contract.
+//! A grapheme wider than the requested width remains intact as an overflowing fragment because no
+//! valid grapheme boundary exists at which to split it.
+//!
+//! Fragment construction lives in the sibling `fragment` module. Paragraph compatibility has its
+//! own streaming algorithm because it does not follow textwrap's fragment model.
+//!
+//! [line-breaking overview]: https://docs.rs/textwrap/0.16/textwrap/wrap_algorithms/index.html
+//! [`Fragment`]: https://docs.rs/textwrap/0.16/textwrap/core/trait.Fragment.html
+
+use ::textwrap::wrap_algorithms::{
+    Penalties, wrap_first_fit as textwrap_first_fit, wrap_optimal_fit as textwrap_optimal_fit,
+};
+use ratatui_core::text::{Line, Span};
+
+use super::fragment::{self, StyledFragment};
+
+/// Wraps one source line with textwrap's greedy first-fit algorithm.
+///
+/// A fragment is one word plus its following whitespace. First-fit greedily adds the next fragment
+/// while it fits. Whitespace contributes to the fit between words but is omitted when its fragment
+/// ends an output line. The upstream [documentation] and [source] define the generic algorithm;
+/// this adapter supplies Ratatui graphemes and cell widths.
+///
+/// Every returned line copies `source` style and alignment and owns its span strings. A positive
+/// width produces at least one line; a zero width produces no lines. The function allocates styled
+/// fragments and returned line and span collections. Calls are independent.
+///
+/// [documentation]: https://docs.rs/textwrap/0.16/textwrap/wrap_algorithms/fn.wrap_first_fit.html
+/// [source]: https://github.com/mgeisler/textwrap/blob/4770e55af425a0cffb9ad8496599d2a1a4f5ed14/src/wrap_algorithms.rs#L336-L367
+#[must_use]
+pub fn wrap_first_fit(source: &Line<'_>, width: u16) -> Vec<Line<'static>> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    let fragments = fragment::from_line(source, width);
+    let line_widths = [f64::from(width)];
+    let wrapped = textwrap_first_fit(&fragments, &line_widths);
+    reconstruct_lines(source, wrapped)
+}
+
+/// Wraps one source line with textwrap's penalty-based optimal-fit algorithm.
+///
+/// This uses the same fragments and reconstruction rules as [`wrap_first_fit`] and passes
+/// textwrap's unchanged `Penalties::new()` value. The cost accounts for line count, squared unused
+/// width, overflow width, and a short final single-word line. The optimizer can therefore prefer a
+/// small overflow to a poorly balanced break. Hyphen penalties have no effect because this adapter
+/// does not hyphenate or report a penalty width. The upstream [documentation], [penalties], and
+/// [source] define the complete generic cost calculation.
+///
+/// Every returned line copies `source` style and alignment and owns its span strings. A positive
+/// width produces at least one line; a zero width produces no lines. The function allocates styled
+/// fragments, optimization state, and returned line and span collections. Calls are independent.
+/// If textwrap reports an infinite cost, this function uses first-fit so the public wrapping API
+/// remains infallible and deterministic.
+///
+/// [documentation]: https://docs.rs/textwrap/0.16/textwrap/wrap_algorithms/fn.wrap_optimal_fit.html
+/// [penalties]: https://docs.rs/textwrap/0.16/textwrap/wrap_algorithms/struct.Penalties.html
+/// [source]: https://github.com/mgeisler/textwrap/blob/4770e55af425a0cffb9ad8496599d2a1a4f5ed14/src/wrap_algorithms/optimal_fit.rs#L302-L381
+#[must_use]
+pub fn wrap_optimal_fit(source: &Line<'_>, width: u16) -> Vec<Line<'static>> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    let fragments = fragment::from_line(source, width);
+    let line_widths = [f64::from(width)];
+
+    // `wrap_optimal_fit` reports `OverflowError` when its accumulated cost becomes infinite. The
+    // fragments remain valid input to first-fit, and `TextWrapper::wrap` has no error channel, so
+    // falling back preserves useful deterministic output if future penalties or inputs reach that
+    // limit.
+    let wrapped = textwrap_optimal_fit(&fragments, &line_widths, &Penalties::new())
+        .unwrap_or_else(|_| textwrap_first_fit(&fragments, &line_widths));
+    reconstruct_lines(source, wrapped)
+}
+
+/// Rebuilds all fragment slices selected for one source line.
+fn reconstruct_lines(source: &Line<'_>, wrapped: Vec<&[StyledFragment]>) -> Vec<Line<'static>> {
+    wrapped
+        .into_iter()
+        .map(|fragments| reconstruct_line(source, fragments))
+        .collect()
+}
+
+/// Reconstructs one textwrap-selected fragment slice as an owned Ratatui line.
+///
+/// Keeps separator whitespace between fragments and drops it after the final fragment.
+fn reconstruct_line(source: &Line<'_>, fragments: &[StyledFragment]) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    for (index, fragment) in fragments.iter().enumerate() {
+        fragment.append_word_to(&mut spans);
+        if index + 1 != fragments.len() {
+            fragment.append_whitespace_to(&mut spans);
+        }
+    }
+    Line {
+        style: source.style,
+        alignment: source.alignment,
+        spans,
+    }
+}
+
+/// Unit tests for textwrap invocation and reconstruction.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Checks the fragment contract's end-of-line whitespace rule during reconstruction.
+    #[test]
+    fn reconstruction_drops_only_the_final_fragment_whitespace() {
+        let source = Line::from("alpha  beta  ");
+        let fragments = fragment::from_line(&source, 20);
+
+        let line = reconstruct_line(&source, &fragments);
+
+        assert_eq!(line.to_string(), "alpha  beta");
+    }
+
+    /// Checks the common first-fit word boundary without Paragraph wrapping.
+    #[test]
+    fn first_fit_returns_owned_physical_lines() {
+        let lines = wrap_first_fit(&Line::from("alpha beta"), 5);
+        let content = lines.iter().map(ToString::to_string).collect::<Vec<_>>();
+
+        assert_eq!(content, ["alpha", "beta"]);
+    }
+
+    /// Checks that both algorithms preserve an indivisible grapheme wider than the line.
+    #[test]
+    fn algorithms_preserve_grapheme_wider_than_line() {
+        let source = Line::from("界");
+
+        assert_eq!(wrap_first_fit(&source, 1)[0].to_string(), "界");
+        assert_eq!(wrap_optimal_fit(&source, 1)[0].to_string(), "界");
+    }
+}

--- a/crates/ratatui-textwrap/src/lib.rs
+++ b/crates/ratatui-textwrap/src/lib.rs
@@ -1,0 +1,110 @@
+//! Wraps styled Ratatui text before it is rendered.
+//!
+//! [`TextWrapper`] converts strings, spans, lines, and other values accepted by [`Text`] into an
+//! owned `Text<'static>` at a requested terminal width. The owned result can be cached until its
+//! source, width, or [`WrapAlgorithm`] changes, then rendered by an ordinary [`Paragraph`].
+//!
+//! # Quick start
+//!
+//! ```
+//! use ratatui::style::Stylize;
+//! use ratatui::text::Line;
+//! use ratatui::widgets::Paragraph;
+//! use ratatui_textwrap::{TextWrapper, WrapAlgorithm};
+//!
+//! let line = Line::from(vec!["Styled ".blue(), "text can wrap across spans".bold()]);
+//! let wrapping = TextWrapper::new().algorithm(WrapAlgorithm::OptimalFit);
+//! let wrapped = wrapping.wrap(line, 20);
+//! let paragraph = Paragraph::new(wrapped);
+//! ```
+//!
+//! `wrapped` exists as a separate value because wrapping allocates owned strings and line
+//! collections. Passing the width to [`TextWrapper::wrap`] lets the same configuration serve a
+//! resizable view.
+//!
+//! Custom widgets and text-processing pipelines can wrap one [`Line`] at a time through the
+//! [`algorithms`] module. Its functions expose owned line output without exposing textwrap
+//! fragments or Paragraph's internal queues.
+//!
+//! # Choosing an algorithm
+//!
+//! - [`WrapAlgorithm::FirstFit`] is the default. It greedily fills each line.
+//! - [`WrapAlgorithm::OptimalFit`] considers the complete source line and minimizes textwrap's
+//!   default monospace penalty cost. It may choose a small overflow when that costs less than an
+//!   unbalanced break.
+//! - [`WrapAlgorithm::ParagraphCompat`] runs the copied Ratatui Paragraph reflow state machine.
+//!   Choose it when matching that historical whitespace and long-word behavior matters more than
+//!   using textwrap's fragment model.
+//!
+//! First-fit and optimal-fit omit separator whitespace after the final fragment on a generated
+//! line. `ParagraphCompat` accepts the same `trim` policy as `ratatui::widgets::Wrap` and preserves
+//! Paragraph's distinct decisions at whitespace boundaries.
+//!
+//! # Text contract
+//!
+//! Wrapping preserves [`Text`] style and alignment. Each generated line copies the style and
+//! alignment of its source [`Line`]. Span styles survive word splitting, including a word composed
+//! from differently styled spans. Adjacent output spans with equal styles may be coalesced;
+//! rendered cells are preserved, but the original span partition is not.
+//!
+//! Each entry in [`Text::lines`] is a hard boundary. Newline and tab control characters embedded
+//! directly in a [`Span`] are filtered by Ratatui's styled-grapheme iterator; they do not create
+//! more lines. With first-fit or optimal-fit, a single grapheme wider than the requested width
+//! remains intact on an overflowing line; Paragraph compatibility omits it to match Paragraph. A
+//! width of zero returns no lines and retains the top-level style and alignment.
+//!
+//! # textwrap integration
+//!
+//! The textwrap algorithms receive fragments prepared from Ratatui's styled graphemes:
+//!
+//! 1. [`CellWidth`] measures terminal cells, and Ratatui classifies each grapheme as word content
+//!    or whitespace.
+//! 1. Graphemes are grouped into [`Fragment`] values containing a word and its following
+//!    whitespace. A style boundary inside a word is not a break point.
+//! 1. Overlong words are split at Ratatui grapheme boundaries before line breaking because
+//!    textwrap's low-level algorithms arrange complete fragments.
+//! 1. The selected fragment slices are rebuilt as owned Ratatui lines.
+//!
+//! The adapter calls textwrap's low-level [`wrap_first_fit`] and [`wrap_optimal_fit`] functions. It
+//! does not use textwrap's high-level wrapping, width calculation, word separator, or word
+//! splitter. See the [`Fragment` source], [first-fit source], and [optimal-fit source] for the
+//! upstream contracts used here.
+//!
+//! # Experimental status
+//!
+//! `ratatui-textwrap` is an experiment, and its public API may change while the configuration and
+//! compatibility surface are evaluated. The owned output and algorithm behavior described above
+//! are the current contract. The crate does not replace [`Paragraph::wrap`] or provide lazy layout,
+//! source-position mapping, cursor mapping, indentation, hyphenation, or configurable optimal-fit
+//! penalties.
+//!
+//! [`CellWidth`]: ratatui_core::buffer::CellWidth
+//! [`Fragment`]: https://docs.rs/textwrap/0.16/textwrap/core/trait.Fragment.html
+//! [`Fragment` source]: https://github.com/mgeisler/textwrap/blob/4770e55af425a0cffb9ad8496599d2a1a4f5ed14/src/core.rs#L217-L230
+//! [`Line`]: ratatui_core::text::Line
+//! [`Paragraph`]: https://docs.rs/ratatui/0.30.2/ratatui/widgets/struct.Paragraph.html
+//! [`Paragraph::wrap`]: https://docs.rs/ratatui/0.30.2/ratatui/widgets/struct.Paragraph.html#method.wrap
+//! [`Span`]: ratatui_core::text::Span
+//! [`Text`]: ratatui_core::text::Text
+//! [`Text::lines`]: ratatui_core::text::Text::lines
+//! [`wrap_first_fit`]: https://docs.rs/textwrap/0.16/textwrap/wrap_algorithms/fn.wrap_first_fit.html
+//! [`wrap_optimal_fit`]: https://docs.rs/textwrap/0.16/textwrap/wrap_algorithms/fn.wrap_optimal_fit.html
+//! [first-fit source]: https://github.com/mgeisler/textwrap/blob/4770e55af425a0cffb9ad8496599d2a1a4f5ed14/src/wrap_algorithms.rs#L336-L367
+//! [optimal-fit source]: https://github.com/mgeisler/textwrap/blob/4770e55af425a0cffb9ad8496599d2a1a4f5ed14/src/wrap_algorithms/optimal_fit.rs#L302-L381
+#![warn(missing_docs)]
+#![warn(clippy::missing_docs_in_private_items)]
+#![warn(rustdoc::bare_urls)]
+#![warn(rustdoc::broken_intra_doc_links)]
+#![warn(rustdoc::redundant_explicit_links)]
+
+/// Line-level wrapping algorithms for custom widgets and text-processing pipelines.
+pub mod algorithms;
+/// Public wrapping configuration and orchestration.
+mod wrapper;
+
+/// Selects the line-breaking strategy.
+#[doc(inline)]
+pub use algorithms::WrapAlgorithm;
+/// Configures owned styled-text wrapping.
+#[doc(inline)]
+pub use wrapper::TextWrapper;

--- a/crates/ratatui-textwrap/src/wrapper.rs
+++ b/crates/ratatui-textwrap/src/wrapper.rs
@@ -1,0 +1,135 @@
+//! Whole-text configuration and wrapping.
+//!
+//! [`TextWrapper`] accepts values that convert into [`Text`](ratatui_core::text::Text), preserves
+//! their top-level metadata, and sends each source line to the selected [`WrapAlgorithm`]. A
+//! zero-width request stops before line breaking and returns the same text style and alignment with
+//! no lines.
+
+use ratatui_core::text::Text;
+
+use crate::{WrapAlgorithm, algorithms};
+
+/// Configures how Ratatui text is wrapped into an owned value.
+///
+/// The wrapper stores a [`WrapAlgorithm`]; [`Self::wrap`] receives the terminal width for each
+/// call. Reuse the same wrapper when a view changes size, and recompute the text when its source,
+/// width, or algorithm changes. [`Self::new`] and [`Self::default`] select
+/// [`WrapAlgorithm::FirstFit`].
+///
+/// The returned [`Text<'static>`](Text) owns every span string and can outlive borrowed input.
+///
+/// # Examples
+///
+/// ```
+/// use ratatui::text::Line;
+/// use ratatui::widgets::Paragraph;
+/// use ratatui_textwrap::{TextWrapper, WrapAlgorithm};
+///
+/// let wrapping = TextWrapper::new().algorithm(WrapAlgorithm::OptimalFit);
+/// let wrapped = wrapping.wrap(Line::from("alpha beta gamma"), 10);
+/// let paragraph = Paragraph::new(wrapped);
+/// ```
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct TextWrapper {
+    /// Strategy applied independently to every entry in [`Text::lines`].
+    algorithm: WrapAlgorithm,
+}
+
+impl TextWrapper {
+    /// Creates a wrapper that uses textwrap's first-fit algorithm.
+    ///
+    /// This is equivalent to [`Self::default`].
+    pub const fn new() -> Self {
+        Self {
+            algorithm: WrapAlgorithm::FirstFit,
+        }
+    }
+
+    /// Returns this wrapper configured to use `algorithm`.
+    ///
+    /// Existing configuration is replaced. The same algorithm applies independently to every
+    /// entry in [`Text::lines`].
+    #[must_use]
+    pub const fn algorithm(mut self, algorithm: WrapAlgorithm) -> Self {
+        self.algorithm = algorithm;
+        self
+    }
+
+    /// Wraps `input` into owned text for `width` terminal cells.
+    ///
+    /// Strings, spans, lines, and text values use this same entry point through `Into<Text>`. Each
+    /// entry in [`Text::lines`] is an independent wrapping boundary and produces at least one
+    /// output line when `width` is positive. The output preserves [`Text::style`],
+    /// [`Text::alignment`], and the style and alignment of each source
+    /// [`Line`](ratatui_core::text::Line). Span styles remain attached across splits; adjacent
+    /// spans with equal styles may be coalesced.
+    ///
+    /// A zero width returns no lines while retaining top-level text style and alignment. Ratatui's
+    /// styled-grapheme iterator filters embedded control characters. A newline inside a manually
+    /// constructed [`Span`](ratatui_core::text::Span) therefore does not create a source line;
+    /// convert a string containing newlines or construct separate lines when that boundary matters.
+    /// First-fit and optimal-fit retain a grapheme wider than `width` on an overflowing line;
+    /// Paragraph compatibility omits it to reproduce Paragraph's behavior.
+    ///
+    /// # Allocation
+    ///
+    /// The returned `Text<'static>` owns its span strings and line collections. Wrapping also
+    /// allocates temporary owned fragments. Caching the result avoids those allocations while the
+    /// source, width, and algorithm remain unchanged.
+    ///
+    /// # Examples
+    ///
+    /// The output does not borrow from the input:
+    ///
+    /// ```
+    /// use ratatui_textwrap::TextWrapper;
+    ///
+    /// let wrapped = {
+    ///     let source = String::from("owned after wrapping");
+    ///     TextWrapper::new().wrap(source.as_str(), 8)
+    /// };
+    ///
+    /// assert_eq!(wrapped.lines.len(), 3);
+    /// ```
+    #[must_use]
+    pub fn wrap<'a>(&self, input: impl Into<Text<'a>>, width: u16) -> Text<'static> {
+        let input = input.into();
+        if width == 0 {
+            return Text {
+                alignment: input.alignment,
+                style: input.style,
+                lines: Vec::new(),
+            };
+        }
+
+        let lines = input
+            .lines
+            .iter()
+            .flat_map(|line| algorithms::wrap_line(self.algorithm, line, width))
+            .collect();
+        Text {
+            alignment: input.alignment,
+            style: input.style,
+            lines,
+        }
+    }
+}
+
+/// Unit tests for whole-text configuration.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Checks that a later algorithm selection replaces the stored strategy.
+    #[test]
+    fn algorithm_replaces_the_previous_selection() {
+        let wrapper = TextWrapper::new()
+            .algorithm(WrapAlgorithm::OptimalFit)
+            .algorithm(WrapAlgorithm::ParagraphCompat { trim: true });
+
+        assert_eq!(
+            wrapper.algorithm,
+            WrapAlgorithm::ParagraphCompat { trim: true }
+        );
+    }
+}

--- a/crates/ratatui-textwrap/tests/compatibility.rs
+++ b/crates/ratatui-textwrap/tests/compatibility.rs
@@ -1,0 +1,234 @@
+//! Rendered comparisons between the available algorithms and Ratatui Paragraph.
+//!
+//! The copied compatibility path must match Paragraph for every case, width, and trim policy in the
+//! corpus. The textwrap paths are allowed to differ; stable inventories make each known difference
+//! visible in review.
+//!
+//! The development requirement accepts compatible Ratatui 0.30 releases. A lockfile update can
+//! therefore reveal drift from the 0.30.2 source baseline instead of silently preserving an older
+//! oracle.
+
+use std::fmt::Write;
+
+use pretty_assertions::assert_eq;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Alignment, Rect};
+use ratatui::style::{Color, Modifier, Style, Stylize};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Paragraph, Widget, Wrap};
+use ratatui_textwrap::{TextWrapper, WrapAlgorithm};
+use rstest::rstest;
+
+/// Compares the copied compatibility algorithm with both Paragraph trim policies.
+#[rstest]
+#[case::preserve_whitespace(false)]
+#[case::trim_whitespace(true)]
+fn paragraph_compat_matches_the_resolved_paragraph_oracle(#[case] trim: bool) {
+    for (case, source) in cases() {
+        let max_width = source.width().min(40) as u16 + 3;
+        for width in 0..=max_width {
+            let algorithm = WrapAlgorithm::ParagraphCompat { trim };
+            let expected = render_paragraph(source.clone(), trim, width);
+            let actual = render_wrapped(source.clone(), algorithm, width);
+            assert_eq!(
+                actual, expected,
+                "Paragraph compatibility mismatch: case={case:?}, trim={trim}, width={width}"
+            );
+        }
+    }
+}
+
+/// Checks the reviewed widths where first-fit differs from Paragraph.
+#[test]
+fn first_fit_paragraph_differences_are_reviewed() {
+    let differences = paragraph_differences(WrapAlgorithm::FirstFit);
+    assert_eq!(differences, FIRST_FIT_PARAGRAPH_DIFFERENCES);
+}
+
+/// Checks the reviewed widths where optimal-fit differs from first-fit.
+#[test]
+fn optimal_fit_first_fit_differences_are_reviewed() {
+    let differences = algorithm_differences(WrapAlgorithm::OptimalFit, WrapAlgorithm::FirstFit);
+    assert_eq!(differences, OPTIMAL_FIT_FIRST_FIT_DIFFERENCES);
+}
+
+/// Reviewed first-fit differences, grouped by input and Paragraph trim policy.
+const FIRST_FIT_PARAGRAPH_DIFFERENCES: &str = concat!(
+    "leading spaces | trim=false | widths=[1, 2, 3, 6, 7, 8, 9]\n",
+    "leading spaces | trim=true | widths=[1, 5, 10, 11, 12, 13, 14, 15, 16, 17, 18]\n",
+    "trailing spaces | trim=false | widths=[1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13]\n",
+    "trailing spaces | trim=true | widths=[1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13]\n",
+    "repeated spaces | trim=false | widths=[1, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 18, 19]\n",
+    "repeated spaces | trim=true | widths=[2, 3, 4, 5, 6]\n",
+    "whitespace only | trim=false | widths=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]\n",
+    "styled whitespace | trim=false | widths=[1, 2, 3, 4, 5, 6, 7, 8, 9]\n",
+    "styled whitespace | trim=true | widths=[3, 4, 6]\n",
+);
+
+/// Reviewed optimal-fit differences from first-fit, grouped by input.
+const OPTIMAL_FIT_FIRST_FIT_DIFFERENCES: &str = concat!(
+    "lookahead balance | widths=[9, 15, 16, 17, 43]\n",
+    "punctuation | widths=[18]\n",
+);
+
+/// Formats Paragraph mismatches as a stable inventory of case names and widths.
+fn paragraph_differences(algorithm: WrapAlgorithm) -> String {
+    let mut output = String::new();
+    for (case, source) in cases() {
+        let max_width = source.width().min(40) as u16 + 3;
+        for trim in [false, true] {
+            let widths = (0..=max_width)
+                .filter(|&width| {
+                    render_wrapped(source.clone(), algorithm, width)
+                        != render_paragraph(source.clone(), trim, width)
+                })
+                .collect::<Vec<_>>();
+            if !widths.is_empty() {
+                writeln!(output, "{case} | trim={trim} | widths={widths:?}")
+                    .expect("writing to a String cannot fail");
+            }
+        }
+    }
+    output
+}
+
+/// Formats pairwise algorithm mismatches as a stable inventory of case names and widths.
+fn algorithm_differences(left: WrapAlgorithm, right: WrapAlgorithm) -> String {
+    let mut output = String::new();
+    for (case, source) in cases() {
+        let max_width = source.width().min(40) as u16 + 3;
+        let widths = (0..=max_width)
+            .filter(|&width| {
+                render_wrapped(source.clone(), left, width)
+                    != render_wrapped(source.clone(), right, width)
+            })
+            .collect::<Vec<_>>();
+        if !widths.is_empty() {
+            writeln!(output, "{case} | widths={widths:?}")
+                .expect("writing to a String cannot fail");
+        }
+    }
+    output
+}
+
+/// Renders Paragraph and returns its buffer and reported physical line count.
+fn render_paragraph(source: Text<'static>, trim: bool, width: u16) -> (Buffer, usize) {
+    let area = Rect::new(0, 0, width, 80);
+    let paragraph = Paragraph::new(source).wrap(Wrap { trim });
+    let line_count = paragraph.line_count(width);
+    let mut buffer = Buffer::empty(area);
+    paragraph.render(area, &mut buffer);
+    (buffer, line_count)
+}
+
+/// Wraps with `algorithm`, then renders the owned text without Paragraph wrapping.
+fn render_wrapped(source: Text<'static>, algorithm: WrapAlgorithm, width: u16) -> (Buffer, usize) {
+    let area = Rect::new(0, 0, width, 80);
+    let wrapped = TextWrapper::new().algorithm(algorithm).wrap(source, width);
+    let line_count = wrapped.lines.len();
+    let mut buffer = Buffer::empty(area);
+    Paragraph::new(wrapped).render(area, &mut buffer);
+    (buffer, line_count)
+}
+
+/// Returns the styled, whitespace, metadata, and Unicode comparison corpus.
+fn cases() -> Vec<(&'static str, Text<'static>)> {
+    let red = Style::new().fg(Color::Red);
+    let blue = Style::new().fg(Color::Blue);
+    let green = Style::new().fg(Color::Green);
+    vec![
+        ("empty input", Text::from("")),
+        ("no text lines", Text::default()),
+        (
+            "blank and trailing source lines",
+            Text::from(vec![Line::from(""), Line::from("tail"), Line::from("")]),
+        ),
+        (
+            "multiple explicit lines",
+            Text::from(vec![Line::from("alpha beta"), Line::from("gamma delta")]),
+        ),
+        (
+            "embedded span newline",
+            Text::from(Line::from(Span::raw("alpha\nbeta"))),
+        ),
+        (
+            "embedded tab",
+            Text::from(Line::from(Span::raw("alpha\tbeta"))),
+        ),
+        ("leading spaces", Text::from("     alpha beta")),
+        ("trailing spaces", Text::from("alpha beta     ")),
+        ("repeated spaces", Text::from("alpha      beta      gamma")),
+        ("whitespace only", Text::from("               ")),
+        (
+            "long unbreakable word",
+            Text::from("supercalifragilisticexpialidocious"),
+        ),
+        (
+            "lookahead balance",
+            Text::from("These few words will unfortunately not wrap nicely."),
+        ),
+        (
+            "exact fit word and following space",
+            Text::from("12345 6789"),
+        ),
+        ("punctuation", Text::from("Wait... what? yes; no!")),
+        ("non-breaking space", Text::from("alpha\u{a0}beta gamma")),
+        ("CJK double width", Text::from("你")),
+        ("combining marks", Text::from("Cafe\u{301} au lait")),
+        ("emoji ZWJ", Text::from("👨‍👩‍👧‍👦")),
+        (
+            "zero width spaces",
+            Text::from("alpha\u{200b}beta\u{200b}gamma"),
+        ),
+        ("wide grapheme", Text::from("界")),
+        ("zero width combining grapheme", Text::from("\u{301}")),
+        (
+            "styles around wrap points",
+            Text::from(Line::from(vec![
+                Span::styled("alpha", red),
+                Span::styled(" ", green),
+                Span::styled("beta", blue),
+                Span::styled(" gamma", red),
+            ])),
+        ),
+        (
+            "one word across styles",
+            Text::from(Line::from(vec![
+                Span::styled("super", red),
+                Span::styled("cali", blue),
+                Span::styled("fragilistic", green),
+            ])),
+        ),
+        (
+            "styled whitespace",
+            Text::from(Line::from(vec![
+                Span::styled("alpha", red),
+                Span::styled("      ", blue),
+                Span::styled("beta", green),
+            ])),
+        ),
+        (
+            "text and line styles",
+            Text::from(
+                Line::from(vec![Span::raw("alpha "), Span::styled("beta gamma", red)]).on_blue(),
+            )
+            .style(Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        ),
+        (
+            "left alignment",
+            Text::from(Line::from("alpha beta gamma").left_aligned()),
+        ),
+        (
+            "center alignment",
+            Text::from(Line::from("alpha beta gamma").centered()),
+        ),
+        (
+            "right alignment",
+            Text::from(Line::from("alpha beta gamma").right_aligned()),
+        ),
+        (
+            "top level alignment",
+            Text::from("alpha beta gamma").alignment(Alignment::Center),
+        ),
+    ]
+}

--- a/crates/ratatui-textwrap/tests/structure.rs
+++ b/crates/ratatui-textwrap/tests/structure.rs
@@ -1,0 +1,208 @@
+//! Structural contracts that rendered buffers cannot show.
+//!
+//! These tests inspect ownership, `Into<Text>` conversions, metadata, span coalescing, defaults,
+//! and line structure in the returned `Text`. Each setup stays beside its assertions because the
+//! inputs are small and do not share policy.
+
+use pretty_assertions::assert_eq;
+use ratatui::layout::Alignment;
+use ratatui::style::{Color, Style, Stylize};
+use ratatui::text::{Line, Span, Text};
+use ratatui_textwrap::algorithms::{self, paragraph, textwrap};
+use ratatui_textwrap::{TextWrapper, WrapAlgorithm};
+use rstest::rstest;
+
+/// Drops borrowed input before inspecting the owned output spans.
+#[test]
+fn output_owns_borrowed_input() {
+    let wrapped = {
+        let input = String::from("owned after wrapping");
+        TextWrapper::new().wrap(input.as_str(), 8)
+    };
+
+    assert_eq!(wrapped.lines.len(), 3);
+    assert!(wrapped.lines.iter().all(|line| {
+        line.spans
+            .iter()
+            .all(|span| matches!(span.content, std::borrow::Cow::Owned(_)))
+    }));
+}
+
+/// Exercises string, span, line, and text conversions through the same wrap method.
+#[test]
+fn common_text_conversions_share_the_wrap_method() {
+    let wrapper = TextWrapper::new();
+    let expected = wrapper.wrap("alpha beta", 5);
+
+    assert_eq!(wrapper.wrap(String::from("alpha beta"), 5), expected);
+    assert_eq!(wrapper.wrap(Span::raw("alpha beta"), 5), expected);
+    assert_eq!(wrapper.wrap(Line::from("alpha beta"), 5), expected);
+    assert_eq!(wrapper.wrap(Text::from("alpha beta"), 5), expected);
+}
+
+/// Checks text and source-line metadata on every generated line.
+#[rstest]
+#[case::first_fit(WrapAlgorithm::FirstFit)]
+#[case::optimal_fit(WrapAlgorithm::OptimalFit)]
+#[case::paragraph_preserve_whitespace(WrapAlgorithm::ParagraphCompat { trim: false })]
+#[case::paragraph_trim_whitespace(WrapAlgorithm::ParagraphCompat { trim: true })]
+fn text_and_line_metadata_survive_every_generated_line(#[case] algorithm: WrapAlgorithm) {
+    let line_style = Style::new().fg(Color::Red);
+    let text_style = Style::new().bg(Color::Blue);
+    let source = Text::from(
+        Line::from("alpha beta gamma")
+            .style(line_style)
+            .right_aligned(),
+    )
+    .style(text_style)
+    .alignment(Alignment::Center);
+
+    let wrapped = TextWrapper::new().algorithm(algorithm).wrap(source, 5);
+
+    assert_eq!(wrapped.style, text_style);
+    assert_eq!(wrapped.alignment, Some(Alignment::Center));
+    assert_eq!(wrapped.lines.len(), 3);
+    for line in wrapped.lines {
+        assert_eq!(line.style, line_style);
+        assert_eq!(line.alignment, Some(Alignment::Right));
+    }
+}
+
+/// Checks that equal adjacent source styles produce one output span.
+#[test]
+fn adjacent_equal_styles_coalesce() {
+    let style = Style::new().fg(Color::Green);
+    let source = Line::from(vec![
+        Span::styled("al", style),
+        Span::styled("pha", style),
+        Span::styled(" ", style),
+        Span::styled("beta", style),
+    ]);
+
+    let wrapped = TextWrapper::new().wrap(source, 20);
+
+    assert_eq!(
+        wrapped.lines[0].spans,
+        vec![Span::styled("alpha beta", style)]
+    );
+}
+
+/// Checks the line shape and retained metadata at width zero.
+#[test]
+fn zero_width_preserves_text_metadata_without_lines() {
+    let source = Text::from("alpha").yellow().alignment(Alignment::Right);
+    let wrapped = TextWrapper::new().wrap(source, 0);
+
+    assert_eq!(wrapped.style, Style::new().fg(Color::Yellow));
+    assert_eq!(wrapped.alignment, Some(Alignment::Right));
+    assert!(wrapped.lines.is_empty());
+}
+
+/// Checks that empty source lines remain hard boundaries at positive widths.
+#[test]
+fn positive_width_preserves_empty_source_line_boundaries() {
+    let source = Text::from(vec![Line::from(""), Line::from("alpha"), Line::from("")]);
+
+    let algorithm = WrapAlgorithm::ParagraphCompat { trim: true };
+    let wrapped = TextWrapper::new().algorithm(algorithm).wrap(source, 20);
+
+    assert_eq!(wrapped.lines.len(), 3);
+    assert!(wrapped.lines[0].spans.is_empty());
+    assert!(wrapped.lines[2].spans.is_empty());
+}
+
+/// Checks that the constructor and derived defaults both select first-fit.
+#[test]
+fn new_matches_default_and_first_fit() {
+    assert_eq!(TextWrapper::new(), TextWrapper::default());
+    assert_eq!(WrapAlgorithm::default(), WrapAlgorithm::FirstFit);
+    assert_eq!(
+        TextWrapper::new().wrap("  alpha", 20),
+        TextWrapper::default()
+            .algorithm(WrapAlgorithm::FirstFit)
+            .wrap("  alpha", 20)
+    );
+}
+
+/// Records the different mixed-width word behavior of textwrap and Paragraph compatibility.
+#[test]
+fn mixed_width_words_characterize_algorithm_boundaries() {
+    let first_fit = TextWrapper::new().wrap("a界b", 2);
+    let paragraph = TextWrapper::new()
+        .algorithm(WrapAlgorithm::ParagraphCompat { trim: false })
+        .wrap("a界b", 2);
+
+    let first_fit_lines = first_fit
+        .lines
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    let paragraph_lines = paragraph
+        .lines
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    assert_eq!(first_fit_lines, ["a", "界", "b"]);
+    assert_eq!(paragraph_lines, ["a", "界b"]);
+}
+
+/// Checks the algorithm-specific policy for a grapheme that cannot fit on an empty line.
+#[rstest]
+#[case::first_fit(WrapAlgorithm::FirstFit)]
+#[case::optimal_fit(WrapAlgorithm::OptimalFit)]
+fn textwrap_algorithms_preserve_graphemes_wider_than_the_line(#[case] algorithm: WrapAlgorithm) {
+    let red = Style::new().fg(Color::Red);
+    let blue = Style::new().fg(Color::Blue);
+    let source = Line::from(vec![Span::styled("界", red), Span::styled("界", blue)]);
+
+    let wrapped = TextWrapper::new().algorithm(algorithm).wrap(source, 1);
+
+    assert_eq!(wrapped.lines.len(), 2);
+    assert_eq!(wrapped.lines[0].spans, [Span::styled("界", red)]);
+    assert_eq!(wrapped.lines[1].spans, [Span::styled("界", blue)]);
+}
+
+/// Checks that Paragraph compatibility retains Paragraph's lossy too-wide policy.
+#[test]
+fn paragraph_compat_omits_graphemes_wider_than_the_line() {
+    let wrapped = TextWrapper::new()
+        .algorithm(WrapAlgorithm::ParagraphCompat { trim: false })
+        .wrap("界", 1);
+
+    assert_eq!(wrapped.lines.len(), 1);
+    assert_eq!(wrapped.lines[0].to_string(), "");
+}
+
+/// Exercises every public line-level entry point without the whole-text wrapper.
+#[test]
+fn public_algorithms_wrap_owned_lines_and_handle_zero_width() {
+    let paragraph_lines = {
+        let source = Line::from("alpha beta").right_aligned();
+        algorithms::wrap_line(WrapAlgorithm::ParagraphCompat { trim: true }, &source, 8)
+    };
+
+    let paragraph_source = Line::from("alpha beta").right_aligned();
+    assert_eq!(
+        paragraph_lines,
+        paragraph::wrap_line(&paragraph_source, 8, true)
+    );
+    assert_eq!(paragraph_lines[0].alignment, Some(Alignment::Right));
+    assert!(paragraph_lines.iter().all(|line| {
+        line.spans
+            .iter()
+            .all(|span| matches!(span.content, std::borrow::Cow::Owned(_)))
+    }));
+
+    let source = Line::from("alpha beta");
+    assert_eq!(
+        algorithms::wrap_line(WrapAlgorithm::FirstFit, &source, 8),
+        textwrap::wrap_first_fit(&source, 8)
+    );
+    assert_eq!(
+        algorithms::wrap_line(WrapAlgorithm::OptimalFit, &source, 8),
+        textwrap::wrap_optimal_fit(&source, 8)
+    );
+    assert!(paragraph::wrap_line(&source, 0, true).is_empty());
+    assert!(textwrap::wrap_first_fit(&source, 0).is_empty());
+    assert!(textwrap::wrap_optimal_fit(&source, 0).is_empty());
+}


### PR DESCRIPTION
## Summary

- add `ratatui-textwrap`, an opt-in styled-text wrapping experiment
- expose first-fit, optimal-fit, and Paragraph-compatible wrapping policies
- preserve Ratatui text styling and metadata while materializing owned wrapped text
- re-export the crate from `ratatui-labs` for discovery

The crate name has been reserved on crates.io with a `0.0.0` placeholder, and trusted publishing
is configured for this repository's `release-plz.yml` workflow and `release` environment. Merging
this PR lets release-plz prepare the first API-bearing prerelease.

## Validation

- `just validate`
- `cargo package -p ratatui-textwrap --allow-dirty`
