### PR TITLE
docs(textwrap): clarify textwrap integration

### DIFF
--- a/crates/ratatui-textwrap/Cargo.toml
+++ b/crates/ratatui-textwrap/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "Experimental owned wrapping for styled Ratatui text."
+description = "Styled Ratatui text wrapping with textwrap algorithms and Paragraph compatibility."
 readme = "README.md"
 include = ["Cargo.toml", "CHANGELOG.md", "README.md", "docs/**/*.md", "src/**/*.rs"]
 

--- a/crates/ratatui-textwrap/README.md
+++ b/crates/ratatui-textwrap/README.md
@@ -1,8 +1,12 @@
 # Ratatui Textwrap
 
-`ratatui-textwrap` precomputes wrapped, styled Ratatui text. It accepts strings, spans, lines, and
-other values that convert into `Text`, then returns an owned `Text<'static>` that can be cached or
-passed to another widget.
+`ratatui-textwrap` adapts the [`textwrap`][textwrap] crate's first-fit and optimal-fit line-breaking
+algorithms to styled Ratatui text. It prepares textwrap fragments from Ratatui graphemes, then
+rebuilds owned Ratatui lines while preserving their styles. A separate `ParagraphCompat` mode
+reproduces Ratatui Paragraph's reflow behavior.
+
+The crate accepts strings, spans, lines, and other values that convert into `Text`, then returns an
+owned `Text<'static>` that can be cached or passed to another widget.
 
 ## Usage
 
@@ -96,4 +100,5 @@ source]. `ParagraphCompat` follows Ratatui's [WordWrapper source] and [Paragraph
 [fragment contract]: https://docs.rs/textwrap/0.16/textwrap/core/trait.Fragment.html
 [optimal-fit source]: https://github.com/mgeisler/textwrap/blob/4770e55af425a0cffb9ad8496599d2a1a4f5ed14/src/wrap_algorithms/optimal_fit.rs#L302-L381
 [Paragraph integration]: https://github.com/ratatui/ratatui/blob/ratatui-v0.30.2/ratatui-widgets/src/paragraph.rs#L329-L355
+[textwrap]: https://docs.rs/textwrap/0.16/textwrap/
 [WordWrapper source]: https://github.com/ratatui/ratatui/blob/ratatui-v0.30.2/ratatui-widgets/src/reflow.rs#L29-L273

--- a/crates/ratatui-textwrap/src/lib.rs
+++ b/crates/ratatui-textwrap/src/lib.rs
@@ -1,5 +1,9 @@
 //! Wraps styled Ratatui text before it is rendered.
 //!
+//! [`WrapAlgorithm::FirstFit`] and [`WrapAlgorithm::OptimalFit`] adapt textwrap's low-level
+//! line-breaking algorithms to styled Ratatui graphemes. [`WrapAlgorithm::ParagraphCompat`] is a
+//! separate implementation that reproduces Ratatui Paragraph's reflow behavior.
+//!
 //! [`TextWrapper`] converts strings, spans, lines, and other values accepted by [`Text`] into an
 //! owned `Text<'static>` at a requested terminal width. The owned result can be cached until its
 //! source, width, or [`WrapAlgorithm`] changes, then rendered by an ordinary [`Paragraph`].


### PR DESCRIPTION
## Summary

- state up front that `FirstFit` and `OptimalFit` adapt textwrap's low-level algorithms
- distinguish the separate Ratatui `ParagraphCompat` implementation
- align the crate description, README, and crate-level Rustdoc

## Validation

- `markdownlint-cli2 crates/ratatui-textwrap/README.md`
- `cargo test -p ratatui-textwrap`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p ratatui-textwrap --no-deps`
